### PR TITLE
Only set nothing here choice if explicitly configured

### DIFF
--- a/app/models/extractors/survey_extractor.rb
+++ b/app/models/extractors/survey_extractor.rb
@@ -11,13 +11,13 @@ module Extractors
     end
 
     def nothing_here_choice
-      config["nothing_here_choice"] || "NTHNGHR"
+      config["nothing_here_choice"]
     end
 
     def choices(classification)
       values = classification.annotations.fetch(task_key)
       choices = values.flat_map { |value| value.fetch("value", []).map { |val| val["choice"] } }
-      choices << nothing_here_choice if choices.empty?
+      choices << nothing_here_choice if choices.empty? && nothing_here_choice
       choices
     end
   end

--- a/spec/models/extractors/survey_extractor_spec.rb
+++ b/spec/models/extractors/survey_extractor_spec.rb
@@ -19,7 +19,8 @@ describe Extractors::SurveyExtractor do
   subject(:extractor) { described_class.new("s") }
 
   describe '#process' do
-    it 'converts empty value lists to nothing_here' do
+    it 'converts empty value lists to nothing_here if configured' do
+      extractor.config["nothing_here_choice"] = "NTHNGHR"
       annotations[0]["value"] = []
       expect(extractor.process(classification)).to eq("choices" => ["NTHNGHR"])
     end


### PR DESCRIPTION
Given that we were just bitten by Nero assuming certain survey option keys, it's probably safer to have Caesar not assume them. Most surveys will be required anyways.