### PR TITLE
safer lookups

### DIFF
--- a/app/models/conditions/from_config.rb
+++ b/app/models/conditions/from_config.rb
@@ -15,7 +15,7 @@ module Conditions
       when 'const'
         Constant.new(config[1])
       when 'lookup'
-        Lookup.new(config[1])
+        Lookup.new(config[1], config[2])
       else
         raise InvalidConfig, "Unknown rule type: #{config[0]} (in #{config.inspect})"
       end

--- a/app/models/conditions/lookup.rb
+++ b/app/models/conditions/lookup.rb
@@ -1,11 +1,12 @@
 module Conditions
   class Lookup
-    def initialize(key)
+    def initialize(key, absent_val=nil)
       @key = key
+      @absent_val = absent_val
     end
 
     def apply(bindings)
-      bindings.fetch(@key)
+      bindings.fetch(@key, @absent_val)
     end
   end
 end

--- a/app/models/rule_bindings.rb
+++ b/app/models/rule_bindings.rb
@@ -5,9 +5,9 @@ class RuleBindings
     @reductions = reductions.index_by(&:reducer_id)
   end
 
-  def fetch(key)
+  def fetch(key, defaultVal=nil)
     reducer_id, data_key = key.split(".")
-    @reductions.fetch(reducer_id).data.fetch(data_key)
+    @reductions.fetch(reducer_id).data.fetch(data_key, defaultVal)
   end
 
   def keys

--- a/spec/models/conditions/lookup_spec.rb
+++ b/spec/models/conditions/lookup_spec.rb
@@ -5,4 +5,15 @@ describe Conditions::Lookup do
     expected = double
     expect(described_class.new("a").apply("a" => expected)).to eq(expected)
   end
+
+  it 'returns nil if the stored value is not present' do
+    expected = double
+    expect(described_class.new("b").apply("a" => expected)).to be(nil)
+  end
+
+  it 'returns default if the stored value is not present' do
+    expected = double
+    unexpected = double
+    expect(described_class.new("b",unexpected).apply("a" => expected)).to eq(unexpected)
+  end
 end

--- a/spec/models/rule_bindings_spec.rb
+++ b/spec/models/rule_bindings_spec.rb
@@ -10,6 +10,20 @@ describe RuleBindings do
     expect(rule_bindings.fetch("other.b")).to eq(2)
   end
 
+  it 'handles absent keys' do
+    reductions = [
+      Reduction.new(reducer_id: 'count', data: {"a" => 1}),
+      Reduction.new(reducer_id: 'other', data: {"b" => 2})
+    ]
+
+    unexpected = double
+
+    rule_bindings = described_class.new(reductions)
+    expect(rule_bindings.fetch("count.a")).to eq(1)
+    expect(rule_bindings.fetch("count.b")).to be(nil)
+    expect(rule_bindings.fetch("count.b",unexpected)).to eq(unexpected)
+  end
+
   it 'works with overlapping data keys' do
     reductions = [
       Reduction.new(reducer_id: 'count', data: {"a" => 1}),


### PR DESCRIPTION
Currently, if a rule looks for a key in the reduction set that is absent, it throws an error. however, this can happen if all of the classifications say "A" and the rule is looking for "B" and this is a use case we should probably support.

This change lets the lookup condition include an optional extra parameter for the "default" value of a lookup if the key is absent. If the key is present, the value of the key will be returned. If the key is absent and the default value is set, the default value will be returned. Otherwise nil will be returned if the key is absent.