### PR TITLE
send admin flag to panoptes-client gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     nio4r (1.2.1)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
-    panoptes-client (0.2.12)
+    panoptes-client (0.2.13)
       faraday
       faraday-panoptes (~> 0.2.0)
       jwt (~> 1.5.0)

--- a/app/models/effects.rb
+++ b/app/models/effects.rb
@@ -12,7 +12,8 @@ module Effects
     if ENV.key?("PANOPTES_CLIENT_ID") || Rails.env.staging? || Rails.env.production?
       @panoptes = Panoptes::Client.new(env: Rails.env.to_s,
                                        auth: {client_id: ENV.fetch("PANOPTES_CLIENT_ID"),
-                                              client_secret: ENV.fetch("PANOPTES_CLIENT_SECRET")})
+                                              client_secret: ENV.fetch("PANOPTES_CLIENT_SECRET")},
+                                              params: {:admin => true})
     else
       @panoptes = FakePanoptes.new
     end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       context: .
       args:
         RAILS_ENV: development
+
     
     volumes:
       - ./:/rails_app


### PR DESCRIPTION
everything caesar does should be done as admin, otherwise it may fail when we try to have it update workflows it doesn't have permissions on