### PR TITLE
don't spam the logs about duplicate subjects in subject set

### DIFF
--- a/app/models/effects/add_subject_to_set.rb
+++ b/app/models/effects/add_subject_to_set.rb
@@ -2,10 +2,18 @@ module Effects
   class AddSubjectToSet < Effect
     def perform(workflow_id, subject_id)
       Effects.panoptes.add_subjects_to_subject_set(subject_set_id, [subject_id])
+    rescue Panoptes::Client::ServerError => se
+      # don't blow up if the subject is already in the subject set;
+      # this can happen from time to time and is OK
+      raise unless self.class.was_duplicate(se)
     end
 
     def subject_set_id
       config.fetch("subject_set_id")
+    end
+
+    def self.was_duplicate(err)
+      err.message.include? "PG::UniqueViolation"
     end
   end
 end

--- a/spec/models/effects/add_subject_to_set_spec.rb
+++ b/spec/models/effects/add_subject_to_set_spec.rb
@@ -17,4 +17,12 @@ describe Effects::AddSubjectToSet do
       .with(1234, [20])
   end
 
+  it 'knows when an exception is safe to ignore' do
+    duplicate = { :errors => [{:message => "PG::UniqueViolation"}]}
+    unexpected = { :errors => [{:message => "ActiveRecord::Error"}]}
+
+    expect(described_class.was_duplicate(Panoptes::Client::ServerError.new(duplicate))).to be(true)
+    expect(described_class.was_duplicate(Panoptes::Client::ServerError.new(unexpected))).to be(false)
+  end
+
 end


### PR DESCRIPTION
Since the outcome is that the subject is in the right subject set, whether or not WE put it there, we don't really need to do anything but handle the error. This does that.

Closes #44 