### PR TITLE
Always require lookup to specify a default

### DIFF
--- a/app/models/conditions/from_config.rb
+++ b/app/models/conditions/from_config.rb
@@ -15,6 +15,7 @@ module Conditions
       when 'const'
         Constant.new(config[1])
       when 'lookup'
+        raise InvalidConfig, "Not enough arguments given to lookup" unless config[1..-1].size == 2
         Lookup.new(config[1], config[2])
       else
         raise InvalidConfig, "Unknown rule type: #{config[0]} (in #{config.inspect})"

--- a/app/models/conditions/lookup.rb
+++ b/app/models/conditions/lookup.rb
@@ -1,6 +1,6 @@
 module Conditions
   class Lookup
-    def initialize(key, absent_val=nil)
+    def initialize(key, absent_val)
       @key = key
       @absent_val = absent_val
     end

--- a/spec/fixtures/example_kinesis_payload.json
+++ b/spec/fixtures/example_kinesis_payload.json
@@ -67,7 +67,7 @@
                             "reducers": {"s": {"type": "stats"}},
                             "rules": [
                                 {
-                                    "if": ["gte", ["lookup", "s.VHCL"], ["const", 1]],
+                                    "if": ["gte", ["lookup", "s.VHCL", 0], ["const", 1]],
                                     "then": [{"action": "retire_subject", "reason": "flagged"}]
                                 }
                             ]

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -46,7 +46,7 @@ describe ClassificationPipeline do
 
   let(:rule) do
     {
-      if: [:gt, [:lookup, "s.LK"], [:const, 0]],
+      if: [:gt, [:lookup, "s.LK", 0], [:const, 0]],
       then: [{action: :retire_subject, reason: "consensus"}]
     }
   end

--- a/spec/models/conditions/from_config_spec.rb
+++ b/spec/models/conditions/from_config_spec.rb
@@ -12,10 +12,12 @@ describe Conditions::FromConfig do
     expect(condition.apply({})).to eq(123)
   end
 
-  it 'builds a comparison with a lookup' do
-    condition = described_class.build([:lt, [:const, 1], [:lookup, "num"], [:const, 3]])
-    expect(condition.apply({"num" => 2})).to eq(true)
-    expect(condition.apply({"num" => 4})).to eq(false)
+  describe 'lookups' do
+    it 'builds a comparison with a lookup' do
+      condition = described_class.build([:lt, [:const, 1], [:lookup, "num", 0], [:const, 3]])
+      expect(condition.apply({"num" => 2})).to eq(true)
+      expect(condition.apply({"num" => 4})).to eq(false)
+    end
   end
 
   it 'builds boolean algebra' do

--- a/spec/models/conditions/lookup_spec.rb
+++ b/spec/models/conditions/lookup_spec.rb
@@ -3,17 +3,12 @@ require 'spec_helper'
 describe Conditions::Lookup do
   it 'returns the stored value' do
     expected = double
-    expect(described_class.new("a").apply("a" => expected)).to eq(expected)
-  end
-
-  it 'returns nil if the stored value is not present' do
-    expected = double
-    expect(described_class.new("b").apply("a" => expected)).to be(nil)
+    expect(described_class.new("a", 0).apply("a" => expected)).to eq(expected)
   end
 
   it 'returns default if the stored value is not present' do
     expected = double
-    unexpected = double
-    expect(described_class.new("b",unexpected).apply("a" => expected)).to eq(unexpected)
+    default = double
+    expect(described_class.new("b", default).apply("a" => expected)).to eq(default)
   end
 end


### PR DESCRIPTION
Fixes #56 

All currently existing rules specify defaults, so this won't break anything.