### PR TITLE
Fix randomly  failing Kinesis spec

### DIFF
--- a/app/workers/check_rules_worker.rb
+++ b/app/workers/check_rules_worker.rb
@@ -1,6 +1,7 @@
 class CheckRulesWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 2, unique: :until_executing
+  sidekiq_options retry: 2
+  sidekiq_options unique: :until_executing unless Rails.env.test?
 
   def perform(workflow_id, subject_id)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/fetch_classifications_worker.rb
+++ b/app/workers/fetch_classifications_worker.rb
@@ -1,7 +1,7 @@
 class FetchClassificationsWorker
   include Sidekiq::Worker
 
-  sidekiq_options unique: :until_executing
+  sidekiq_options unique: :until_executing unless Rails.env.test?
 
   def perform(subject_id, workflow_id)
     classifications = Effects.panoptes.get_subject_classifications(subject_id, workflow_id)["classifications"]

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -1,6 +1,7 @@
 class ReduceWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 5, unique: :until_executing
+  sidekiq_options retry: 5
+  sidekiq_options unique: :until_executing unless Rails.env.test?
   sidekiq_retry_in do |count|
     (count ** 8) + 15 + (rand(30) * count + 1)
   end


### PR DESCRIPTION
This fixes that one weird spec. Turns out the unique jobs check doesn't play well with Sidekiq's testing integration (`sidekiq: :inline` in RSpec metadata).