### PR TITLE
handle blank values coming back from external APIs

### DIFF
--- a/app/models/extractors/external_extractor.rb
+++ b/app/models/extractors/external_extractor.rb
@@ -8,13 +8,15 @@ module Extractors
       if url
         response = RestClient.post(url.to_s, classification.to_json, {content_type: :json, accept: :json})
 
-        if response.body.present?
+        if response.code==204
+          Extractor.NoData
+        elsif ([200, 201, 202].include? response.code) and response.body.present?
           JSON.parse(response.body)
         else
-          {}
+          raise StandardError.new 'Remote extractor failed'
         end
       else
-        {}
+        raise StandardError.new "External extractor improperly configured: no URL"
       end
     end
 

--- a/app/models/extractors/extractor.rb
+++ b/app/models/extractors/extractor.rb
@@ -4,6 +4,11 @@ module Extractors
 
     attr_reader :key, :config
 
+    @@NoData = Object.new
+    def self.NoData
+      @@NoData
+    end
+
     def initialize(key, config = {})
       @key = key
       load_configuration(config)

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -8,13 +8,15 @@ module Reducers
       if url
         response = RestClient.post(url.to_s, extractions.to_json, {content_type: :json, accept: :json})
 
-        if response.body.present?
+        if response.code==204
+          Reducer.NoData
+        elsif ([200, 201, 202].include? response.code) and response.body.present?
           JSON.parse(response.body)
         else
-          {}
+          raise StandardError.new 'Remote reducer failed'
         end
       else
-        {}
+        raise StandardError.new "External extractor improperly configured: no URL"
       end
     end
 

--- a/app/models/reducers/reducer.rb
+++ b/app/models/reducers/reducer.rb
@@ -2,6 +2,11 @@ module Reducers
   class Reducer
     include Configurable
 
+    @@NoData = Object.new
+    def self.NoData
+      @@NoData
+    end
+
     attr_reader :key, :filters
 
     def initialize(key, config = {})

--- a/app/workers/extract_worker.rb
+++ b/app/workers/extract_worker.rb
@@ -10,8 +10,9 @@ class ExtractWorker
     classification = Classification.new(classification_data)
     extract = workflow.classification_pipeline.extract(classification)
 
-    ReduceWorker.perform_async(workflow_id, classification.subject_id)
+    return if extract == Extractors::Extractor.NoData
 
+    ReduceWorker.perform_async(workflow_id, classification.subject_id)
     workflow.webhooks.process(:new_extraction, extract.data) if workflow.subscribers?
   end
 end

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -10,8 +10,9 @@ class ReduceWorker
     workflow = Workflow.find(workflow_id)
     reduction = workflow.classification_pipeline.reduce(workflow_id, subject_id)
 
-    CheckRulesWorker.perform_async(workflow_id, subject_id)
+    return if reduction == Reducers::Reducer.NoData
 
+    CheckRulesWorker.perform_async(workflow_id, subject_id)
     workflow.webhooks.process(:new_reduction, reduction.data) if workflow.subscribers?
   end
 end

--- a/spec/models/extractors/external_extractor_spec.rb
+++ b/spec/models/extractors/external_extractor_spec.rb
@@ -44,15 +44,14 @@ describe Extractors::ExternalExtractor do
 
     extractor = described_class.new("ext", "url" => "http://example.org/post/classification/here")
     result = extractor.process(classification)
-    expect(result).to eq({})
+    expect(result).to eq(Extractors::Extractor.NoData)
   end
 
   it 'does not post if no url is configured' do
     extractor = described_class.new("ext")
-    extractor.process(classification)
 
-    expect(a_request(:post, "example.org/post/classification/here")
-             .with(body: classification.to_json))
-      .not_to have_been_made
+    expect do
+      extractor.process(classification)
+    end.to raise_error(StandardError)
   end
 end

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -40,17 +40,15 @@ describe Reducers::ExternalReducer do
 
     extractor = described_class.new("red", "url" => "http://example.org/post/extracts/here")
     result = extractor.process(extracts)
-    expect(result).to eq({})
+    expect(result).to eq(Reducers::Reducer.NoData)
   end
 
   it 'does not post if no url is configured' do
     reducer = described_class.new("red", url: nil)
-    result = reducer.process(extracts)
 
-    expect(result).to eq({})
-    expect(a_request(:post, "example.org/post/extracts/here")
-            .with(body: extracts.to_json))
-      .not_to have_been_made
+    expect do
+      reducer.process(classification)
+    end.to raise_error(StandardError)
   end
 
 end


### PR DESCRIPTION
resolves #86 and #101 

1. don't try to parse response body if other server says 204
2. don't run reducers if an extract is a NoData
3. don't run rules if a reduction is a NoData
4. don't notify webhooks of NoData