### PR TITLE
Do not check for presence of configs

### DIFF
--- a/app/models/stream_events/classification_event.rb
+++ b/app/models/stream_events/classification_event.rb
@@ -29,7 +29,7 @@ module StreamEvents
     private
 
     def enabled?
-      workflow.present? && workflow.enabled?
+      workflow.present?
     end
 
     def classification

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -10,23 +10,8 @@ class Workflow < ApplicationRecord
 
   has_many :data_requests
 
-  def enabled?
-    extractors_config.present? || reducers_config.present? || rules_config.present?
-  end
-
   def subscribers?
     webhooks&.size > 0
-  end
-
-  def update_cache(config)
-    if workflow.new_record? || workflow.updated_at < attributes[:updated_at]
-      workflow.extractors_config = config[:extractors] || {}
-      workflow.reducers_config = config[:reducers] || {}
-      workflow.rules_config = config[:rules] || []
-      workflow.updated_at = attributes[:updated_at] || Time.zone.now
-      workflow.webhooks_config = config[:webhooks] || []
-      workflow.save!
-    end
   end
 
   def classification_pipeline

--- a/spec/models/stream_events/classification_event_spec.rb
+++ b/spec/models/stream_events/classification_event_spec.rb
@@ -22,20 +22,4 @@ describe StreamEvents::ClassificationEvent do
     described_class.new(stream, hash).process
     expect(queue).not_to have_received(:add)
   end
-
-  it 'does not process when workflow has nothing configured' do
-    workflow.update! extractors_config: {}, reducers_config: {}, rules_config: []
-    described_class.new(stream, hash).process
-    expect(queue).not_to have_received(:add)
-  end
-
-  let(:data) { { "foo" => "bar" } }
-
-  let(:sample_event){
-    described_class.new(nil, {
-      "data" => data,
-      "linked" => {}
-    })
-  }
-
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -3,42 +3,6 @@ require 'rails_helper'
 RSpec.describe Workflow, type: :model do
   let(:workflow) { Workflow.new }
 
-  describe '#enabled?' do
-    it 'is false when the config is nil' do
-      workflow.extractors_config = nil
-      workflow.reducers_config = nil
-      workflow.rules_config = nil
-      expect(workflow.enabled?).to be_falsey
-    end
-
-    it 'is false when there are no pipelines' do
-      workflow.extractors_config = {}
-      workflow.reducers_config = {}
-      workflow.rules_config = {}
-      expect(workflow.enabled?).to be_falsey
-    end
-
-    it 'is true if extractors are configured' do
-      workflow.extractors_config = {"s" => {"type" => "survey", "task_key" => "T0"}}
-      expect(workflow.enabled?).to be_truthy
-    end
-
-    it 'is true if reducers are configured' do
-      workflow.reducers_config = {"s" => {"type" => "stats"}}
-      expect(workflow.enabled?).to be_truthy
-    end
-
-    it 'is true if rules are configured' do
-      workflow.rules_config = [
-        {
-          "if" => ["gte", ["lookup", "s-VHCL"], ["const", 1]],
-          "then" => [{"action" => "retire_subject", "reason" => "flagged"}]
-        }
-      ]
-      expect(workflow.enabled?).to be_truthy
-    end
-  end
-
   it 'returns a list of extractors' do
     workflow.extractors_config = {
       "s" => {type: "survey", task_key: "T0"}


### PR DESCRIPTION
Now that we don't auto-sync all workflows, the presence of a workflow suffices.