### PR TITLE
Rename extractor_id and reducer_id to *_key

### DIFF
--- a/app/controllers/extracts_controller.rb
+++ b/app/controllers/extracts_controller.rb
@@ -7,7 +7,7 @@ class ExtractsController < ApplicationController
 
   def update
     extract = Extract.find_or_initialize_by(workflow_id: workflow.id,
-                                            extractor_id: extractor.id,
+                                            extractor_key: extractor.id,
                                             classification_id: classification_id)
     extract.update! extract_params
 
@@ -29,7 +29,7 @@ class ExtractsController < ApplicationController
   end
 
   def extractor
-    workflow.extractors[params[:extractor_id]]
+    workflow.extractors[params[:extractor_key]]
   end
 
   def subject

--- a/app/controllers/extracts_controller.rb
+++ b/app/controllers/extracts_controller.rb
@@ -7,7 +7,7 @@ class ExtractsController < ApplicationController
 
   def update
     extract = Extract.find_or_initialize_by(workflow_id: workflow.id,
-                                            extractor_key: extractor.id,
+                                            extractor_key: extractor.key,
                                             classification_id: classification_id)
     extract.update! extract_params
 

--- a/app/controllers/reductions_controller.rb
+++ b/app/controllers/reductions_controller.rb
@@ -1,14 +1,14 @@
 class ReductionsController < ApplicationController
   def index
     reductions = Reduction.where(workflow_id: params[:workflow_id], subject_id: params[:subject_id])
-    reductions = reductions.where(reducer_id: params[:reducer_id]) if params.key?(:reducer_id)
+    reductions = reductions.where(reducer_key: params[:reducer_key]) if params.key?(:reducer_key)
 
     render json: reductions
   end
 
   def update
     reduction = Reduction.find_or_initialize_by(workflow_id: workflow.id,
-                                                reducer_id: reducer.id,
+                                                reducer_key: reducer.id,
                                                 subject_id: subject.id)
     reduction.update! reduction_params
 
@@ -34,7 +34,7 @@ class ReductionsController < ApplicationController
   end
 
   def reducer
-    workflow.reducers[params[:reducer_id]]
+    workflow.reducers[params[:reducer_key]]
   end
 
   def subject

--- a/app/controllers/reductions_controller.rb
+++ b/app/controllers/reductions_controller.rb
@@ -8,7 +8,7 @@ class ReductionsController < ApplicationController
 
   def update
     reduction = Reduction.find_or_initialize_by(workflow_id: workflow.id,
-                                                reducer_key: reducer.id,
+                                                reducer_key: reducer.key,
                                                 subject_id: subject.id)
     reduction.update! reduction_params
 

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -16,12 +16,12 @@ class ClassificationPipeline
   def extract(classification)
     tries ||= 2
 
-    extractors.each do |id, extractor|
+    extractors.each do |key, extractor|
       known_subject = Extract.exists?(subject_id: classification.subject_id, workflow_id: classification.workflow_id)
 
       data = extractor.process(classification)
 
-      extract = Extract.where(workflow_id: classification.workflow_id, subject_id: classification.subject_id, classification_id: classification.id, extractor_id: id).first_or_initialize
+      extract = Extract.where(workflow_id: classification.workflow_id, subject_id: classification.subject_id, classification_id: classification.id, extractor_key: key).first_or_initialize
       extract.user_id = classification.user_id
       extract.classification_at = classification.created_at
       extract.data = data
@@ -42,10 +42,10 @@ class ClassificationPipeline
   def reduce(workflow_id, subject_id)
     tries ||= 2
 
-    reducers.each do |id, reducer|
+    reducers.each do |key, reducer|
       data = reducer.process(extracts(workflow_id, subject_id))
 
-      reduction = Reduction.where(workflow_id: workflow_id, subject_id: subject_id, reducer_id: id).first_or_initialize
+      reduction = Reduction.where(workflow_id: workflow_id, subject_id: subject_id, reducer_key: key).first_or_initialize
       reduction.data = data
       reduction.save!
 

--- a/app/models/extract_filter.rb
+++ b/app/models/extract_filter.rb
@@ -31,7 +31,7 @@ class ExtractFilter
   end
 
   def to_a
-    filter_by_extractor_ids(filter_by_subrange(filter_by_repeatedness(extracts))).flat_map(&:extracts)
+    filter_by_extractor_keys(filter_by_subrange(filter_by_repeatedness(extracts))).flat_map(&:extracts)
   end
 
   private
@@ -51,12 +51,12 @@ class ExtractFilter
     extracts.sort_by(&:classification_at)[subrange]
   end
 
-  def filter_by_extractor_ids(extracts)
-    return extracts if extractor_ids.blank?
+  def filter_by_extractor_keys(extracts)
+    return extracts if extractor_keys.blank?
 
     extracts.map do |group|
       group.select do |extract|
-        extractor_ids.include?(extract.extractor_id)
+        extractor_keys.include?(extract.extractor_key)
       end
     end
   end
@@ -79,7 +79,7 @@ class ExtractFilter
     Range.new(from, to)
   end
 
-  def extractor_ids
-    filters["extractor_ids"] || []
+  def extractor_keys
+    filters["extractor_keys"] || []
   end
 end

--- a/app/models/extractors/extractor.rb
+++ b/app/models/extractors/extractor.rb
@@ -2,10 +2,10 @@ module Extractors
   class Extractor
     include Configurable
 
-    attr_reader :id, :config
+    attr_reader :key, :config
 
-    def initialize(id, config = {})
-      @id = id
+    def initialize(key, config = {})
+      @key = key
       load_configuration(config)
     end
   end

--- a/app/models/reducers/reducer.rb
+++ b/app/models/reducers/reducer.rb
@@ -2,10 +2,10 @@ module Reducers
   class Reducer
     include Configurable
 
-    attr_reader :id, :filters
+    attr_reader :key, :filters
 
-    def initialize(id, config = {})
-      @id = id
+    def initialize(key, config = {})
+      @key = key
       @filters = config["filters"] || {}
       load_configuration(config)
     end

--- a/app/models/rule_bindings.rb
+++ b/app/models/rule_bindings.rb
@@ -2,13 +2,13 @@ class RuleBindings
   class OverlappingKeys < StandardError; end
 
   def initialize(reductions)
-    @reductions = reductions.index_by(&:reducer_id)
+    @reductions = reductions.index_by(&:reducer_key)
   end
 
   def fetch(key, defaultVal=nil)
-    reducer_id, data_key = key.split(".")
-    return @reductions.fetch(reducer_id) if data_key.nil?
-    @reductions.fetch(reducer_id).data.fetch(data_key, defaultVal)
+    reducer_key, data_key = key.split(".")
+    return @reductions.fetch(reducer_key) if data_key.nil?
+    @reductions.fetch(reducer_key).data.fetch(data_key, defaultVal)
   end
 
   def keys

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -19,9 +19,9 @@
                     <td><%= extract.id %></td>
                     <td><%= extract.classification_id %></td>
                     <td><%= extract.user_id %></td>
-                    <td><%= extract.extractor_id %></td>
+                    <td><%= extract.extractor_key %></td>
                     <td><%= extract.updated_at %></td>
-                    
+
                     <% keys.each do |key| %>
                         <td><%= extract.data[key] %></td>
                     <% end %>
@@ -45,12 +45,12 @@
             </tr>
         </thead>
         <tbody>
-            <% reductions.sort_by(&:reducer_id).each do |reduction| %>
+            <% reductions.sort_by(&:reducer_key).each do |reduction| %>
                 <tr>
                     <td><%= reduction.id %></td>
-                    <td><%= reduction.reducer_id %></td>
+                    <td><%= reduction.reducer_key %></td>
                     <td><%= reduction.updated_at %></td>
-                    
+
                     <% keys.each do |key| %>
                         <td><%= reduction.data[key] %></td>
                     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,10 +19,10 @@ Rails.application.routes.draw do
     resources :data_requests
   end
 
-  get 'workflows/:workflow_id/extractors/:extractor_id/extracts', to: 'extracts#index'
-  put 'workflows/:workflow_id/extractors/:extractor_id/extracts', to: 'extracts#update', defaults: { format: :json }
+  get 'workflows/:workflow_id/extractors/:extractor_key/extracts', to: 'extracts#index'
+  put 'workflows/:workflow_id/extractors/:extractor_key/extracts', to: 'extracts#update', defaults: { format: :json }
 
-  get 'workflows/:workflow_id/reducers/:reducer_id/reductions', to: 'reductions#index'
+  get 'workflows/:workflow_id/reducers/:reducer_key/reductions', to: 'reductions#index'
   get 'workflows/:workflow_id/subjects/:subject_id/reductions', to: 'reductions#index'
-  put 'workflows/:workflow_id/reducers/:reducer_id/reductions', to: 'reductions#update'
+  put 'workflows/:workflow_id/reducers/:reducer_key/reductions', to: 'reductions#update'
 end

--- a/db/migrate/20170821150623_rename_extractor_and_reducer_id_to_key.rb
+++ b/db/migrate/20170821150623_rename_extractor_and_reducer_id_to_key.rb
@@ -1,0 +1,10 @@
+class RenameExtractorAndReducerIdToKey < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :extracts, :extractor_id, :extractor_key
+    rename_column :reductions, :reducer_id, :reducer_key
+
+    Workflow.find_each do |workflow|
+      workflow.extractors_config
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170816094055) do
+ActiveRecord::Schema.define(version: 20170821150623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,28 +56,28 @@ ActiveRecord::Schema.define(version: 20170816094055) do
   create_table "extracts", id: :serial, force: :cascade do |t|
     t.integer "classification_id", null: false
     t.datetime "classification_at", null: false
-    t.string "extractor_id", null: false
+    t.string "extractor_key", null: false
     t.integer "workflow_id", null: false
     t.integer "user_id"
     t.integer "subject_id", null: false
     t.jsonb "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["classification_id", "extractor_id"], name: "index_extracts_on_classification_id_and_extractor_id", unique: true
+    t.index ["classification_id", "extractor_key"], name: "index_extracts_on_classification_id_and_extractor_key", unique: true
     t.index ["subject_id"], name: "index_extracts_on_subject_id"
     t.index ["user_id"], name: "index_extracts_on_user_id"
     t.index ["workflow_id"], name: "index_extracts_on_workflow_id"
   end
 
   create_table "reductions", id: :serial, force: :cascade do |t|
-    t.string "reducer_id", null: false
+    t.string "reducer_key", null: false
     t.integer "workflow_id", null: false
     t.integer "subject_id", null: false
     t.jsonb "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["subject_id"], name: "index_reductions_on_subject_id"
-    t.index ["workflow_id", "subject_id", "reducer_id"], name: "index_reductions_on_workflow_id_and_subject_id_and_reducer_id", unique: true
+    t.index ["workflow_id", "subject_id", "reducer_key"], name: "index_reductions_on_workflow_id_and_subject_id_and_reducer_key", unique: true
     t.index ["workflow_id"], name: "index_reductions_on_workflow_id"
   end
 

--- a/docs/source/includes/_extracts.md
+++ b/docs/source/includes/_extracts.md
@@ -3,7 +3,7 @@
 ## Get extracts
 
 ```http
-GET /workflows/$WORKFLOW_ID/extractors/$EXTRACTOR_ID/extracts?subject_id=$SUBJECT_ID HTTP/1.1
+GET /workflows/$WORKFLOW_ID/extractors/$EXTRACTOR_KEY/extracts?subject_id=$SUBJECT_ID HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 Authorization: Bearer $TOKEN
@@ -18,7 +18,7 @@ Authorization: Bearer $TOKEN
         "classification_id": 54376560,
         "created_at": "2017-05-16T20:37:39.124Z",
         "data": null,
-        "extractor_id": "c",
+        "extractor_key": "c",
         "id": 411083,
         "subject_id": 458033,
         "updated_at": "2017-05-16T20:37:39.124Z",
@@ -32,11 +32,11 @@ Extracts are pieces of information relating to a specific classification (and th
 
 ### Query Parameters
 
-Parameter    | Default | Description
------------- | ------- | -----------
-WORKFLOW_ID  | null    | **Required** &middot; Specifies which workflow
-SUBJECT_ID   | null    | **Required** &middot; Specifies which subject
-EXTRACTOR_ID | null    | **Required** &middot; Specifies which extractor to fetch extracts from.
+Parameter     | Default | Description
+------------- | ------- | -----------
+WORKFLOW_ID   | null    | **Required** &middot; Specifies which workflow
+SUBJECT_ID    | null    | **Required** &middot; Specifies which subject
+EXTRACTOR_KEY | null    | **Required** &middot; Specifies which extractor to fetch extracts from.
 
 
 ## Create &amp; update extracts
@@ -44,7 +44,7 @@ EXTRACTOR_ID | null    | **Required** &middot; Specifies which extractor to fetc
 Inserting and updating extracts happens through one and the same API endpoint, which performs an "upsert".
 
 ```http
-POST /workflows/$WORKFLOW_ID/extractors/$EXTRACTOR_ID/extracts HTTP/1.1
+POST /workflows/$WORKFLOW_ID/extractors/$EXTRACTOR_KEY/extracts HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 Authorization: Bearer $TOKEN

--- a/docs/source/includes/_how_to_swap.md
+++ b/docs/source/includes/_how_to_swap.md
@@ -47,7 +47,7 @@ Accept: application/vnd.api+json; version=1
 > And store expert-seenness in Caesar so that you can use it in the rulse
 
 ```http
-POST /workflows/WORKFLOW_ID/reducers/REDUCER_ID/reductions HTTP/1.1
+POST /workflows/WORKFLOW_ID/reducers/REDUCER_KEY/reductions HTTP/1.1
 Host: caesar-staging.zooniverse.org
 Authorization: Bearer TOKEN
 Content-Type: application/json

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -84,7 +84,7 @@ describe ClassificationPipeline do
   it 'does not fetch classifications when extracts already present' do
     Extract.create(
       classification_id: classification.id,
-      extractor_id: "zzz",
+      extractor_key: "zzz",
       subject_id: classification.subject_id,
       workflow_id: classification.workflow_id,
       classification_at: DateTime.now,

--- a/spec/models/conditions/all_spec.rb
+++ b/spec/models/conditions/all_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Conditions::All do
-  def make_rule(reducer_id, compare_operation, compare_constant)
+  def make_rule(reducer_key, compare_operation, compare_constant)
     described_class.new(
-      reducer_id,
+      reducer_key,
       Conditions::Comparison.new(
         compare_operation, [
           Conditions::Lookup.new('value', 0),
@@ -15,8 +15,8 @@ describe Conditions::All do
 
   let(:reductions){
     [
-      Reduction.new(reducer_id: 'savannah', data: {:serval => 1, :hippo => 1, :cerulean => 1}),
-      Reduction.new(reducer_id: 'mountain', data: {:ibis => 1, :alpaca => 1, :cerulean => 5})
+      Reduction.new(reducer_key: 'savannah', data: {:serval => 1, :hippo => 1, :cerulean => 1}),
+      Reduction.new(reducer_key: 'mountain', data: {:ibis => 1, :alpaca => 1, :cerulean => 5})
     ]
   }
 

--- a/spec/models/conditions/any_spec.rb
+++ b/spec/models/conditions/any_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Conditions::Any do
-  def make_rule(reducer_id, compare_operation, compare_constant)
+  def make_rule(reducer_key, compare_operation, compare_constant)
     described_class.new(
-      reducer_id,
+      reducer_key,
       Conditions::Comparison.new(
         compare_operation, [
           Conditions::Lookup.new('value', 0),
@@ -15,8 +15,8 @@ describe Conditions::Any do
 
   let(:reductions){
     [
-      Reduction.new(reducer_id: 'savannah', data: {:serval => 1, :hippo => 1, :cerulean => 1}),
-      Reduction.new(reducer_id: 'mountain', data: {:ibis => 1, :alpaca => 1, :cerulean => 5})
+      Reduction.new(reducer_key: 'savannah', data: {:serval => 1, :hippo => 1, :cerulean => 1}),
+      Reduction.new(reducer_key: 'mountain', data: {:ibis => 1, :alpaca => 1, :cerulean => 5})
     ]
   }
 

--- a/spec/models/conditions/from_config_spec.rb
+++ b/spec/models/conditions/from_config_spec.rb
@@ -43,7 +43,7 @@ describe Conditions::FromConfig do
 
     binding = RuleBindings.new(
       [
-        Reduction.new(reducer_id: 'desert', data: {:snek => 1, :sand_cat => 1})
+        Reduction.new(reducer_key: 'desert', data: {:snek => 1, :sand_cat => 1})
       ]
     )
 

--- a/spec/models/exporters/csv_extract_exporter_spec.rb
+++ b/spec/models/exporters/csv_extract_exporter_spec.rb
@@ -7,7 +7,7 @@ describe Exporters::CsvExtractExporter do
 
   let(:sample){
     Extract.new(
-      extractor_id: "x",
+      extractor_key: "x",
       classification_id: 1236,
       classification_at: DateTime.now,
       workflow_id: workflow.id,
@@ -22,7 +22,7 @@ describe Exporters::CsvExtractExporter do
     end
 
     Extract.new(
-      extractor_id: "x",
+      extractor_key: "x",
       classification_id: 1234,
       classification_at: DateTime.now,
       workflow_id: workflow.id,
@@ -30,7 +30,7 @@ describe Exporters::CsvExtractExporter do
       data: {"key1" => "val1"}
     ).save
     Extract.new(
-      extractor_id: "x",
+      extractor_key: "x",
       classification_id: 1235,
       classification_at: DateTime.now,
       workflow_id: workflow.id,
@@ -39,7 +39,7 @@ describe Exporters::CsvExtractExporter do
     ).save
     sample.save
     Extract.new(
-      extractor_id: "x",
+      extractor_key: "x",
       classification_id: 1237,
       classification_at: DateTime.now,
       workflow_id: workflow.id,
@@ -47,7 +47,7 @@ describe Exporters::CsvExtractExporter do
       data: {"key1" => "val1", "key3" => "val3" }
     ).save
     Extract.new(
-      extractor_id: "x",
+      extractor_key: "x",
       classification_id: 1238,
       classification_at: DateTime.now,
       workflow_id: create(:workflow).id,
@@ -59,7 +59,7 @@ describe Exporters::CsvExtractExporter do
   it 'should give the right header row for the csv' do
     keys = exporter.get_csv_headers
     expect(keys).to include("id")
-    expect(keys).to include("extractor_id")
+    expect(keys).to include("extractor_key")
     expect(keys).to include("classification_id")
     expect(keys).not_to include("data")
     expect(keys).not_to include("sdfjkasdfjk")

--- a/spec/models/exporters/csv_reduction_exporter_spec.rb
+++ b/spec/models/exporters/csv_reduction_exporter_spec.rb
@@ -6,7 +6,7 @@ describe Exporters::CsvReductionExporter do
   let(:exporter) { described_class.new workflow_id: workflow.id }
   let(:sample){
     Reduction.new(
-      reducer_id: "x",
+      reducer_key: "x",
       workflow_id: workflow.id,
       subject_id: subject.id,
       data: {"key1" => "val1", "key2" => "val2"}
@@ -19,32 +19,32 @@ describe Exporters::CsvReductionExporter do
     end
 
     Reduction.new(
-      reducer_id: "x",
+      reducer_key: "x",
       workflow_id: workflow.id,
       subject_id: Subject.create!.id,
       data: {"key2" => "val2"}
     ).save
     Reduction.new(
-      reducer_id: "x",
+      reducer_key: "x",
       workflow_id: workflow.id,
       subject_id: Subject.create!.id,
       data: {"key2" => "val2"}
     ).save
     sample.save
     Reduction.new(
-      reducer_id: "x",
+      reducer_key: "x",
       workflow_id: workflow.id,
       subject_id: Subject.create!.id,
       data: {"key1" => "val1", "key2" => "val2"}
     ).save
     Reduction.new(
-      reducer_id: "x",
+      reducer_key: "x",
       workflow_id: workflow.id,
       subject_id: Subject.create!.id,
       data: {"key1" => "val1", "key3" => "val3"}
     ).save
     Reduction.new(
-      reducer_id: "x",
+      reducer_key: "x",
       workflow_id: create(:workflow).id,
       subject_id: Subject.create!.id,
       data: {"key4" => "val4"}
@@ -55,7 +55,7 @@ describe Exporters::CsvReductionExporter do
   it 'should give the right header row for the csv' do
     keys = exporter.get_csv_headers
     expect(keys).to include("id")
-    expect(keys).to include("reducer_id")
+    expect(keys).to include("reducer_key")
     expect(keys).not_to include("data")
     expect(keys).not_to include("sdfjkasdfjk")
     expect(keys).to include("data.key1")

--- a/spec/models/extract_filter_spec.rb
+++ b/spec/models/extract_filter_spec.rb
@@ -6,35 +6,35 @@ describe ExtractFilter do
     [
       Extract.new(
         id: 0,
-        extractor_id: "foo",
+        extractor_key: "foo",
         classification_id: 1234,
         classification_at: Date.new(2014, 12, 4),
         data: {"foo" => "bar"}
       ),
       Extract.new(
         id: 1,
-        extractor_id: "foo",
+        extractor_key: "foo",
         classification_id: 1234,
         classification_at: Date.new(2014, 12, 4),
         data: {"foo" => "baz"}
       ),
       Extract.new(
         id: 2,
-        extractor_id: "bar",
+        extractor_key: "bar",
         classification_id: 1235,
         classification_at: Date.new(1980, 10, 22),
         data: {"bar" => "baz"}
       ),
       Extract.new(
         id: 3,
-        extractor_id: "baz",
+        extractor_key: "baz",
         classification_id: 1236,
         classification_at: Date.new(2017, 2, 7),
         data: {"baz" => "bar"}
       ),
       Extract.new(
         id: 4,
-        extractor_id: "foo",
+        extractor_key: "foo",
         classification_id: 1237,
         classification_at: Date.new(2017, 2, 7),
         data: {"foo" => "fufufu"}
@@ -74,7 +74,7 @@ describe ExtractFilter do
 
   describe 'extractor filtering' do
     it 'returns extracts from the given extractor' do
-      filter = described_class.new(extracts, extractor_ids: ["foo"])
+      filter = described_class.new(extracts, extractor_keys: ["foo"])
       expect(filter.to_a).to eq([extracts[0], extracts[1], extracts[4]])
     end
   end
@@ -95,12 +95,12 @@ describe ExtractFilter do
     describe 'set to keep first' do
       it 'keeps the first classification for a given user' do
         extracts = [
-          Extract.new(id: 1, classification_id: 1, user_id: 1, extractor_id: "a"),
-          Extract.new(id: 2, classification_id: 1, user_id: 1, extractor_id: "b"),
-          Extract.new(id: 3, classification_id: 2, user_id: 2, extractor_id: "a"),
-          Extract.new(id: 4, classification_id: 2, user_id: 2, extractor_id: "b"),
-          Extract.new(id: 5, classification_id: 3, user_id: 1, extractor_id: "a"),
-          Extract.new(id: 6, classification_id: 3, user_id: 1, extractor_id: "b")
+          Extract.new(id: 1, classification_id: 1, user_id: 1, extractor_key: "a"),
+          Extract.new(id: 2, classification_id: 1, user_id: 1, extractor_key: "b"),
+          Extract.new(id: 3, classification_id: 2, user_id: 2, extractor_key: "a"),
+          Extract.new(id: 4, classification_id: 2, user_id: 2, extractor_key: "b"),
+          Extract.new(id: 5, classification_id: 3, user_id: 1, extractor_key: "a"),
+          Extract.new(id: 6, classification_id: 3, user_id: 1, extractor_key: "b")
         ]
 
         filter = described_class.new(extracts, repeated_classifications: "keep_first")
@@ -122,12 +122,12 @@ describe ExtractFilter do
     describe 'set to keep last' do
       it 'keeps the last classification for a given user' do
         extracts = [
-          Extract.new(id: 1, classification_id: 1, user_id: 1, extractor_id: "a"),
-          Extract.new(id: 2, classification_id: 1, user_id: 1, extractor_id: "b"),
-          Extract.new(id: 3, classification_id: 2, user_id: 2, extractor_id: "a"),
-          Extract.new(id: 4, classification_id: 2, user_id: 2, extractor_id: "b"),
-          Extract.new(id: 5, classification_id: 3, user_id: 1, extractor_id: "a"),
-          Extract.new(id: 6, classification_id: 3, user_id: 1, extractor_id: "b")
+          Extract.new(id: 1, classification_id: 1, user_id: 1, extractor_key: "a"),
+          Extract.new(id: 2, classification_id: 1, user_id: 1, extractor_key: "b"),
+          Extract.new(id: 3, classification_id: 2, user_id: 2, extractor_key: "a"),
+          Extract.new(id: 4, classification_id: 2, user_id: 2, extractor_key: "b"),
+          Extract.new(id: 5, classification_id: 3, user_id: 1, extractor_key: "a"),
+          Extract.new(id: 6, classification_id: 3, user_id: 1, extractor_key: "b")
         ]
 
         filter = described_class.new(extracts, repeated_classifications: "keep_last")

--- a/spec/models/rule_bindings_spec.rb
+++ b/spec/models/rule_bindings_spec.rb
@@ -1,8 +1,8 @@
 describe RuleBindings do
   it 'looks up by reducer id and emitted key' do
     reductions = [
-      Reduction.new(reducer_id: 'count', data: {"a" => 1}),
-      Reduction.new(reducer_id: 'other', data: {"b" => 2})
+      Reduction.new(reducer_key: 'count', data: {"a" => 1}),
+      Reduction.new(reducer_key: 'other', data: {"b" => 2})
     ]
 
     rule_bindings = described_class.new(reductions)
@@ -12,8 +12,8 @@ describe RuleBindings do
 
   it 'handles absent keys' do
     reductions = [
-      Reduction.new(reducer_id: 'count', data: {"a" => 1}),
-      Reduction.new(reducer_id: 'other', data: {"b" => 2})
+      Reduction.new(reducer_key: 'count', data: {"a" => 1}),
+      Reduction.new(reducer_key: 'other', data: {"b" => 2})
     ]
 
     unexpected = double
@@ -26,8 +26,8 @@ describe RuleBindings do
 
   it 'works with overlapping data keys' do
     reductions = [
-      Reduction.new(reducer_id: 'count', data: {"a" => 1}),
-      Reduction.new(reducer_id: 'other', data: {"a" => 2})
+      Reduction.new(reducer_key: 'count', data: {"a" => 1}),
+      Reduction.new(reducer_key: 'other', data: {"a" => 2})
     ]
 
     rule_bindings = described_class.new(reductions)

--- a/spec/requests/extracts_spec.rb
+++ b/spec/requests/extracts_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe ExtractsController, type: :controller do
   before { fake_session admin: true }
 
-  let(:extractor_id) { 1 }
+  let(:extractor_key) { 1 }
   let(:extractor_config) { {"type" => "external"} }
-  let(:workflow) { create(:workflow, extractors_config: {extractor_id => extractor_config}) }
+  let(:workflow) { create(:workflow, extractors_config: {extractor_key => extractor_config}) }
 
   describe "GET #index" do
     it "returns http success" do
-      get :index, params: {workflow_id: workflow.id, extractor_id: extractor_id}
+      get :index, params: {workflow_id: workflow.id, extractor_key: extractor_key}
       expect(response).to have_http_status(:success)
     end
   end
@@ -19,7 +19,7 @@ RSpec.describe ExtractsController, type: :controller do
 
     it 'creates a new extract' do
       put :update, as: :json,
-          params: {workflow_id: workflow.id, extractor_id: extractor_id},
+          params: {workflow_id: workflow.id, extractor_key: extractor_key},
           body: {
             extract: {
               classification_id: 123,
@@ -37,13 +37,13 @@ RSpec.describe ExtractsController, type: :controller do
     it 'updates an existing extract' do
       Extract.create!(workflow_id: workflow.id,
                       subject_id: subject.id,
-                      extractor_id: extractor_id,
+                      extractor_key: extractor_key,
                       classification_id: 123,
                       classification_at: 5.days.ago,
                       data: {"foo" => 1})
 
       put :update, as: :json,
-          params: {workflow_id: workflow.id, extractor_id: extractor_id},
+          params: {workflow_id: workflow.id, extractor_key: extractor_key},
           body: {
             extract: {
               classification_id: 123,

--- a/spec/requests/reductions_spec.rb
+++ b/spec/requests/reductions_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe ReductionsController, type: :controller do
   before { fake_session admin: true }
 
-  let(:reducer_id) { 1 }
+  let(:reducer_key) { 1 }
   let(:reducer_config) { {"type" => "external"} }
-  let(:workflow) { create(:workflow, reducers_config: {reducer_id => reducer_config}) }
+  let(:workflow) { create(:workflow, reducers_config: {reducer_key => reducer_config}) }
 
   describe "GET #index" do
     it "returns http success" do
-      get :index, params: {workflow_id: workflow.id, reducer_id: reducer_id}
+      get :index, params: {workflow_id: workflow.id, reducer_key: reducer_key}
       expect(response).to have_http_status(:success)
     end
   end
@@ -19,7 +19,7 @@ RSpec.describe ReductionsController, type: :controller do
 
     it 'creates a new reduction' do
       put :update, as: :json,
-          params: {workflow_id: workflow.id, reducer_id: reducer_id},
+          params: {workflow_id: workflow.id, reducer_key: reducer_key},
           body: {
             reduction: {
               classification_id: 123,
@@ -37,11 +37,11 @@ RSpec.describe ReductionsController, type: :controller do
     it 'updates an existing reduction' do
       Reduction.create!(workflow_id: workflow.id,
                         subject_id: subject.id,
-                        reducer_id: reducer_id,
+                        reducer_key: reducer_key,
                         data: {"foo" => 1})
 
       put :update, as: :json,
-          params: {workflow_id: workflow.id, reducer_id: reducer_id},
+          params: {workflow_id: workflow.id, reducer_key: reducer_key},
           body: {
             reduction: {
               classification_id: 123,


### PR DESCRIPTION
This makes place for turning them into DB records which have actual IDs.

In a future PR, I want to move from `workflow.extractors_config` to extractors being actual models in the DB. That will mean that extracts can have a foreign key relation, and it gives us a place to define validations a bit better. It also means you don't have to override the entire config block every time, and makes writing a UI for it easier.

Anyways, since those "extractor" records will have database-generated IDs, we should go and move this column to extractor_key, so that when I do that other PR, the `extractor_id` column is free to use for the FK-relation.

(of course, same goes for reducers, rules and webhooks)