### PR TITLE
Graphql fixes and updates

### DIFF
--- a/app/graphql/mutation_root.rb
+++ b/app/graphql/mutation_root.rb
@@ -39,13 +39,13 @@ MutationRoot = GraphQL::ObjectType.define do
     argument :workflowId, !types.ID
     argument :subjectId, !types.ID
     argument :classificationId, !types.ID
-    argument :extractorId, !types.String
+    argument :extractorKey, !types.String
     argument :data, Types::JsonType
 
     resolve ->(obj, args, ctx) {
       workflow  = Workflow.accessible_by(ctx[:credential]).find(args[:workflowId])
       subject   = Subject.find(args[:subjectId])
-      extractor = workflow.extractors[args[:extractorId]]
+      extractor = workflow.extractors[args[:extractorKey]]
       extract   = Extract.find_or_initialize_by(workflow_id: workflow.id,
                                                 extractor_id: extractor.id,
                                                 classificationId: args[:classificationId],
@@ -63,13 +63,13 @@ MutationRoot = GraphQL::ObjectType.define do
 
     argument :workflowId, !types.ID
     argument :subjectId, !types.ID
-    argument :reducerId, !types.String
+    argument :reducerKey, !types.String
     argument :data, Types::JsonType
 
     resolve ->(obj, args, ctx) {
       workflow  = Workflow.accessible_by(ctx[:credential]).find(args[:workflowId])
       subject   = Subject.find(args[:subjectId])
-      reducer   = workflow.reducers[args[:reducerId]]
+      reducer   = workflow.reducers[args[:reducerKey]]
       reduction = Reduction.find_or_initialize_by(workflow_id: workflow.id,
                                                   reducer_id: reducer.id,
                                                   subject_id: subject.id)

--- a/app/graphql/query_root.rb
+++ b/app/graphql/query_root.rb
@@ -2,11 +2,14 @@ QueryRoot = GraphQL::ObjectType.define do
   name "QueryRoot"
 
   field :workflow do
-    type Workflow::Type 
+    type Workflow::Type
     argument :id, !types.ID
     description "Find a Workflow by ID"
     resolve ->(obj, args, ctx) {
-      Workflow.accessible_by(ctx[:credential]).find(args["id"])
+      Workflow.accessible_by(ctx[:credential])
+        .or(Workflow.where(public_extracts: true))
+        .or(Workflow.where(public_reductions: true))
+        .find(args["id"])
     }
   end
 end

--- a/app/models/extract.rb
+++ b/app/models/extract.rb
@@ -7,7 +7,7 @@ class Extract < ApplicationRecord
 
     field :workflowId, !types.ID, property: :workflow_id
     field :subjectId, !types.ID, property: :subject_id
-    field :extractorId, !types.ID, property: :extractor_id
+    field :extractorKey, !types.String, property: :extractor_key
     field :userId, types.ID, property: :user_id
 
     field :data, Types::JsonType

--- a/app/models/reduction.rb
+++ b/app/models/reduction.rb
@@ -5,7 +5,7 @@ class Reduction < ApplicationRecord
     field :projectId, types.ID, property: :project_id
     field :workflowId, !types.ID, property: :workflow_id
     field :subjectId, !types.ID, property: :subject_id
-    field :reducerId, types.String, property: :reducer_id
+    field :reducerKey, types.String, property: :reducer_key
 
     field :data, Types::JsonType
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -36,15 +36,18 @@ class Workflow < ApplicationRecord
       argument :subjectId, !types.ID, "Filter by specific subject"
 
       resolve -> (workflow, args, ctx) {
-        Pundit.authorize!(ctx[:credential], workflow, :show)
-        workflow.actions.where(subject_id: args[:subjectId])
+        scope = Pundit.policy_scope!(ctx[:credential], Action)
+        scope = scope.where(workflow_id: workflow.id)
+        scope = scope.where(subject_id: args[:subjectId])
+        scope
       }
     end
 
     field :dataRequests, types[DataRequest::Type] do
       resolve -> (workflow, args, ctx) {
-        Pundit.authorize!(ctx[:credential], workflow, :show)
-        workflow.data_requests
+        scope = Pundit.policy_scope!(ctx[:credential], Action)
+        scope = scope.where(workflow_id: workflow.id)
+        scope
       }
     end
   end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -6,13 +6,13 @@ class Workflow < ApplicationRecord
     field :createdAt, !Types::TimeType, "Timestamp when this workflow was created", property: :created_at
     field :updatedAt, !Types::TimeType, "Timestamp when this workflow was updated", property: :updated_at
 
-
     field :extracts, types[Extract::Type] do
       argument :subjectId, !types.ID, "Filter by specific subject"
       argument :extractorKey, types.String, "Filter by specific extractor"
 
       resolve -> (workflow, args, ctx) {
-        scope = workflow.extracts
+        scope = Pundit.policy_scope!(ctx[:credential], Extract)
+        scope = scope.where(workflow_id: workflow.id)
         scope = scope.where(subject_id: args[:subjectId])
         scope = scope.where(extractor_key: args[:extractorKey]) if args[:extractorKey]
         scope
@@ -24,7 +24,8 @@ class Workflow < ApplicationRecord
       argument :reducerKey, types.String, "Filter by specific reducer"
 
       resolve -> (workflow, args, ctx) {
-        scope = workflow.reductions
+        scope = Pundit.policy_scope!(ctx[:credential], Reduction)
+        scope = scope.where(workflow_id: workflow.id)
         scope = scope.where(subject_id: args[:subjectId])
         scope = scope.where(reducer_key: args[:reducerKey]) if args[:reducerKey]
         scope
@@ -35,12 +36,14 @@ class Workflow < ApplicationRecord
       argument :subjectId, !types.ID, "Filter by specific subject"
 
       resolve -> (workflow, args, ctx) {
+        Pundit.authorize!(ctx[:credential], workflow, :show)
         workflow.actions.where(subject_id: args[:subjectId])
       }
     end
 
     field :dataRequests, types[DataRequest::Type] do
       resolve -> (workflow, args, ctx) {
+        Pundit.authorize!(ctx[:credential], workflow, :show)
         workflow.data_requests
       }
     end

--- a/app/policies/action_policy.rb
+++ b/app/policies/action_policy.rb
@@ -1,0 +1,23 @@
+class ActionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
+
+      scope = self.scope.joins(:workflow).references(:workflows)
+      scope.where(workflow_id: workflow_ids)
+    end
+  end
+
+  def create?
+    update?
+  end
+
+  def update?
+    return true if credential.admin?
+    credential.project_ids.include?(record.workflow.project_id)
+  end
+
+  def destroy?
+    credential.admin?
+  end
+end

--- a/spec/graphql/caesar_schema_spec.rb
+++ b/spec/graphql/caesar_schema_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+describe CaesarSchema do
+  let(:credential) { build :credential }
+  let(:context) { {credential: credential} }
+  let(:variables) { {} }
+  let(:result) {
+    described_class.execute(
+      query_string,
+      context: context,
+      variables: variables
+    )
+  }
+
+  describe 'getting data for a workflow' do
+    let(:workflow) { create :workflow }
+    let(:query_string) do <<-END
+      {workflow(id:#{workflow.id}) {id}}
+    END
+    end
+
+    context 'when there is no current user' do
+      it 'is nil' do
+        expect { result }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it 'returns a workflow' do
+        workflow.update! public_extracts: true
+        expect(result["data"]["workflow"]).to eq("id" => workflow.id.to_s)
+      end
+    end
+
+    context 'for a user with access' do
+      let(:credential) { build :credential, workflows: [workflow] }
+
+      it 'returns a workflow' do
+        expect(result["data"]["workflow"]).to eq("id" => workflow.id.to_s)
+      end
+    end
+
+    context 'with public extracts' do
+      let(:subject) { create :subject }
+      let(:workflow) { create :workflow, public_extracts: true }
+
+      let(:query_string) do <<-END
+        {
+          workflow(id: #{workflow.id}) {
+            extracts(subjectId: #{subject.id}) { data }
+            reductions(subjectId: #{subject.id}) { data }
+          }
+        }
+      END
+      end
+
+      it 'exposes extracts when not logged in' do
+        create :extract, workflow: workflow, subject: subject, data: {a: 1}
+        expect(result["data"]["workflow"]["extracts"].size).to eq(1)
+      end
+
+      it 'does not expose reductions when not logged in' do
+        create :reduction, workflow: workflow, subject: subject, data: {a: 1}
+        expect(result["data"]["workflow"]["reductions"].size).to eq(0)
+      end
+    end
+
+    context 'with public reductions' do
+      let(:subject) { create :subject }
+      let(:workflow) { create :workflow, public_reductions: true }
+
+      let(:query_string) do <<-END
+        {
+          workflow(id: #{workflow.id}) {
+            extracts(subjectId: #{subject.id}) { data }
+            reductions(subjectId: #{subject.id}) { data }
+          }
+        }
+      END
+      end
+
+      it 'exposes reductions when not logged in' do
+        create :reduction, workflow: workflow, subject: subject, data: {a: 1}
+        expect(result["data"]["workflow"]["reductions"].size).to eq(1)
+      end
+
+      it 'does not expose extracts when not logged in' do
+        create :extract, workflow: workflow, subject: subject, data: {a: 1}
+        expect(result["data"]["workflow"]["extracts"].size).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* The `extractor_id` to `extractor_key` refactor got missed during rebasing.
* The `reducer_id` to `reducer_key` refactor got missed during rebasing.
* Add support for looking up public extracts & reductions.