### PR TITLE
Expose subject metadata to rules

### DIFF
--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -59,7 +59,8 @@ class ClassificationPipeline
 
   def check_rules(workflow_id, subject_id)
     return unless rules.present?
-    rule_bindings = RuleBindings.new(reductions(workflow_id, subject_id))
+    subject = Subject.find(subject_id)
+    rule_bindings = RuleBindings.new(reductions(workflow_id, subject_id), subject)
     rules.process(workflow_id, subject_id, rule_bindings)
   end
 

--- a/app/models/rule_bindings.rb
+++ b/app/models/rule_bindings.rb
@@ -1,8 +1,20 @@
 class RuleBindings
   class OverlappingKeys < StandardError; end
 
-  def initialize(reductions)
+  class SubjectBindings
+    def initialize(subject)
+      @subject = subject
+    end
+
+    def data
+      return {} unless @subject
+      @subject.metadata
+    end
+  end
+
+  def initialize(reductions, subject)
     @reductions = reductions.index_by(&:reducer_key)
+    @reductions.merge!("subject" => SubjectBindings.new(subject))
   end
 
   def fetch(key, defaultVal=nil)

--- a/spec/models/conditions/all_spec.rb
+++ b/spec/models/conditions/all_spec.rb
@@ -20,8 +20,9 @@ describe Conditions::All do
     ]
   }
 
+  let(:subject) { build_stubbed(:subject) }
   let(:bindings){
-    RuleBindings.new(reductions)
+    RuleBindings.new(reductions, subject)
   }
 
   it('throws an error on empty bindings') do

--- a/spec/models/conditions/any_spec.rb
+++ b/spec/models/conditions/any_spec.rb
@@ -20,8 +20,9 @@ describe Conditions::Any do
     ]
   }
 
+  let(:subject) { build_stubbed(:subject) }
   let(:bindings){
-    RuleBindings.new(reductions)
+    RuleBindings.new(reductions, subject)
   }
 
   it('throws an error on empty bindings') do

--- a/spec/models/conditions/from_config_spec.rb
+++ b/spec/models/conditions/from_config_spec.rb
@@ -42,9 +42,8 @@ describe Conditions::FromConfig do
     ])
 
     binding = RuleBindings.new(
-      [
-        Reduction.new(reducer_key: 'desert', data: {:snek => 1, :sand_cat => 1})
-      ]
+      [Reduction.new(reducer_key: 'desert', data: {:snek => 1, :sand_cat => 1})],
+      build_stubbed(:subject)
     )
 
     expect(condition.apply(binding)).to be(false)

--- a/spec/models/rule_bindings_spec.rb
+++ b/spec/models/rule_bindings_spec.rb
@@ -1,13 +1,23 @@
 describe RuleBindings do
+  let(:subject) { build_stubbed(:subject) }
+
   it 'looks up by reducer id and emitted key' do
     reductions = [
       Reduction.new(reducer_key: 'count', data: {"a" => 1}),
       Reduction.new(reducer_key: 'other', data: {"b" => 2})
     ]
 
-    rule_bindings = described_class.new(reductions)
+    rule_bindings = described_class.new(reductions, Subject.new)
     expect(rule_bindings.fetch("count.a")).to eq(1)
     expect(rule_bindings.fetch("other.b")).to eq(2)
+  end
+
+  it 'exposes subject metadata' do
+    reductions = []
+    subject = build_stubbed(:subject, metadata: {"region" => "oxford"})
+
+    rule_bindings = described_class.new(reductions, subject)
+    expect(rule_bindings.fetch("subject.region")).to eq("oxford")
   end
 
   it 'handles absent keys' do
@@ -18,7 +28,7 @@ describe RuleBindings do
 
     unexpected = double
 
-    rule_bindings = described_class.new(reductions)
+    rule_bindings = described_class.new(reductions, subject)
     expect(rule_bindings.fetch("count.a")).to eq(1)
     expect(rule_bindings.fetch("count.b")).to be(nil)
     expect(rule_bindings.fetch("count.b",unexpected)).to eq(unexpected)
@@ -30,7 +40,7 @@ describe RuleBindings do
       Reduction.new(reducer_key: 'other', data: {"a" => 2})
     ]
 
-    rule_bindings = described_class.new(reductions)
+    rule_bindings = described_class.new(reductions, subject)
     expect(rule_bindings.fetch("count.a")).to eq(1)
     expect(rule_bindings.fetch("other.a")).to eq(2)
   end


### PR DESCRIPTION
Example use-case: Camera CATalogue has a single "empty-or-not" workflow. When not empty, it needs to get sent to one of many workflows that is specific to each of their regions (because the animals vary between regions). Their subjects have a field in the metadata to indicate the region, and with this change the rules could do:

```
- IF consensus_reached AND region == "a" THEN add_subject_to_set(id_for_set_for_region_a)
- IF consensus_reached AND region == "b" THEN add_subject_to_set(id_for_set_for_region_b)
```

