### PR TITLE
expose subject metadata to caesar

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -46,6 +46,10 @@ class Classification
     attributes.fetch('links').fetch('subjects').first.to_i
   end
 
+  def subject
+    Subject.find(subject_id)
+  end
+
   def gold_standard
     attributes.fetch('gold_standard', nil)
   end
@@ -54,7 +58,7 @@ class Classification
     attributes.fetch('expert_classifier', nil)
   end
 
-  def as_json(_options)
+  def prepare
     {
       id: id,
       project_id: project_id,
@@ -64,10 +68,15 @@ class Classification
       user_id: user_id,
       annotations: annotations,
       metadata: metadata,
+      subject: subject.attributes,
       gold_standard: gold_standard,
       expert_classifier: expert_classifier,
       created_at: created_at,
       updated_at: updated_at
-    }
+    }.with_indifferent_access
+  end
+
+  def as_json(_options)
+    prepare
   end
 end

--- a/app/models/extractors/pluck_field_extractor.rb
+++ b/app/models/extractors/pluck_field_extractor.rb
@@ -10,7 +10,7 @@ module Extractors
 
     def extract_data_for(classification)
       evaluator = JsonPath.new path
-      result = evaluator.on(classification.attributes)
+      result = evaluator.on(classification.prepare)
 
       {}.tap do |hash|
         if result.size == 0

--- a/app/models/stream_events/classification_event.rb
+++ b/app/models/stream_events/classification_event.rb
@@ -4,6 +4,7 @@ module StreamEvents
 
     def initialize(stream, hash)
       @stream = stream
+      @hash = hash
       @data = hash.fetch("data")
       @linked = StreamEvents.linked_to_hash(hash.fetch("linked"))
     end
@@ -12,6 +13,8 @@ module StreamEvents
       return unless enabled?
 
       cache_linked_models!
+
+      merge_metadata!
 
       if workflow.subscribers?
         workflow.webhooks.process "new_classification", @data.as_json
@@ -34,6 +37,12 @@ module StreamEvents
 
     def classification
       @classification ||= Classification.new(@data)
+    end
+
+    def merge_metadata!
+      classification_metadata = @data.fetch("metadata", Hash.new)
+      subject_metadata = @hash.fetch("linked")&.fetch("subjects")&.first&.fetch("metadata")&.permit! || Hash.new
+      @data["metadata"] = classification_metadata.merge(subject_metadata).permit!.to_h
     end
 
     def workflow

--- a/app/models/stream_events/classification_event.rb
+++ b/app/models/stream_events/classification_event.rb
@@ -4,7 +4,6 @@ module StreamEvents
 
     def initialize(stream, hash)
       @stream = stream
-      @hash = hash
       @data = hash.fetch("data")
       @linked = StreamEvents.linked_to_hash(hash.fetch("linked"))
     end
@@ -13,8 +12,6 @@ module StreamEvents
       return unless enabled?
 
       cache_linked_models!
-
-      merge_metadata!
 
       if workflow.subscribers?
         workflow.webhooks.process "new_classification", @data.as_json
@@ -37,12 +34,6 @@ module StreamEvents
 
     def classification
       @classification ||= Classification.new(@data)
-    end
-
-    def merge_metadata!
-      classification_metadata = @data.fetch("metadata", Hash.new)
-      subject_metadata = @hash.fetch("linked")&.fetch("subjects")&.first&.fetch("metadata")&.permit! || Hash.new
-      @data["metadata"] = classification_metadata.merge(subject_metadata).permit!.to_h
     end
 
     def workflow

--- a/spec/models/extractors/external_extractor_spec.rb
+++ b/spec/models/extractors/external_extractor_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Extractors::ExternalExtractor do
+  let(:subject){ create :subject }
   let(:classification) do
     Classification.new(
       "id" => "12329",
@@ -8,7 +9,7 @@ describe Extractors::ExternalExtractor do
       "metadata" => {},
       "created_at" => "",
       "updated_at" => "",
-      "links" => {"project" => "1232", "workflow" => "1021", "subjects" => ["3999"], "user" => nil}
+      "links" => {"project" => "1232", "workflow" => "1021", "subjects" => [subject.id], "user" => nil}
     )
   end
 

--- a/spec/models/extractors/pluck_field_extractor_spec.rb
+++ b/spec/models/extractors/pluck_field_extractor_spec.rb
@@ -1,12 +1,21 @@
 require 'spec_helper'
 
 describe Extractors::PluckFieldExtractor do
+  let(:workflow){ create :workflow }
+  let(:subject){ create :subject, metadata: { "shutter_speed" => ["1/8", "1/4"] } }
   let(:classification) do
     Classification.new(
+      "id" => "5678",
       "annotations" => [{ "some_key": "some_value" }],
-      "metadata" => [{ "shutter_speed" => ["1/8", "1/4"] }],
-      "user_id" => 1234,
-      "links" => {"workflow" => "1021"}
+      "metadata" => [{ "classified_at" => "1234" }],
+      "links" => {
+        "workflow" => workflow.id,
+        "project" => workflow.project_id,
+        "user" => "1234",
+        "subjects" => [
+          subject.id
+        ]
+      }
     )
   end
 
@@ -27,7 +36,7 @@ describe Extractors::PluckFieldExtractor do
       expect(result).to be_a(Hash)
       expect(result["whodunit"]).to eq(1234)
 
-      complex = described_class.new(key: "c", config: {"name" => "how_fast", "path" => "$.metadata[0].shutter_speed"})
+      complex = described_class.new(key: "c", config: {"name" => "how_fast", "path" => "$.subject.metadata.shutter_speed"})
       result = complex.process(classification)
 
       expect(result.blank?).to be(false)


### PR DESCRIPTION
Previously, the subject metadata was inaccessible to caesar; even though there was a metadata field on classification objects, that provided access to the classification metadata, which is a distinct thing from the subject metadata. Because we often want to act on subject metadata, it's important to have this in the caesar classification. ~~This PR takes the contents of the subject metadata hash (if it exists) and merges it onto the classification metadata hash (if it exists). In a name collision, the subject metadata hash will win.~~