### PR TITLE
grab connections when the app needs them

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -5,7 +5,7 @@
 # and maximum, this matches the default thread size of Active Record.
 #
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
-threads threads_count, threads_count
+threads 1, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #


### PR DESCRIPTION
start with 1 thread, let requests start threads as they are needed. This should limit the number of db connections created up to max threads. 