### PR TITLE
transformation of fields from pluck fields

### DIFF
--- a/app/models/extractors/pluck_field_extractor.rb
+++ b/app/models/extractors/pluck_field_extractor.rb
@@ -15,7 +15,15 @@ module Extractors
       end
     end
 
-    def extract_one(classification, path)
+    def extract_one(classification, details)
+      if(details.class == String)
+        path = details
+        after = "itself"
+      else
+        path = details["path"]
+        after = details["transform"]
+      end
+
       evaluator = JsonPath.new path
       result = evaluator.on(classification.prepare)
 
@@ -26,9 +34,9 @@ module Extractors
           nil
         end
       elsif result.size==1
-        result[0]
+        result[0].send(after)
       else
-        result
+        result.send(after)
       end
 
     end

--- a/spec/models/extractors/pluck_field_extractor_spec.rb
+++ b/spec/models/extractors/pluck_field_extractor_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 describe Extractors::PluckFieldExtractor do
   let(:workflow){ create :workflow }
-  let(:subject){ create :subject, metadata: { "shutter_speed" => ["1/8", "1/4"] } }
+  let(:subject){ create :subject, metadata: {
+    "shutter_speed" => ["1/8", "1/4"],
+    "badmatch" => "SERVAL"
+  } }
   let(:classification) do
     Classification.new(
       "id" => "5678",
@@ -55,6 +58,18 @@ describe Extractors::PluckFieldExtractor do
       expect(result["whodunit"]).to eq(1234)
       expect(result["how_fast"]).to be_a(Array)
       expect(result["how_fast"]).to eq(["1/8", "1/4"])
+    end
+
+    it 'applies transformations if asked' do
+      extractor = described_class.new(key: "c", config: { "field_map" => {
+        "num" => {"path"=> "$.user_id", "transform" => "to_i" },
+        "what" => {"path"=> "$.subject.metadata.badmatch", "transform" => "downcase" }
+      }})
+
+      result = extractor.process(classification)
+      expect(result).to be_a(Hash)
+      expect(result['what']).to eq("serval")
+      expect(result['num']).to eq(1234)
     end
 
     it 'throws an error if the path is not matched' do


### PR DESCRIPTION
Give the `PluckFieldExtractor` the ability to apply simple transformations to values that it looks up in the classification. For safety reasons, all it can do is call a method on the value itself.