### PR TITLE
controversial pull request

### DIFF
--- a/app/models/extractors/pluck_field_extractor.rb
+++ b/app/models/extractors/pluck_field_extractor.rb
@@ -1,4 +1,11 @@
+require 'json'
 require 'jsonpath'
+
+class String
+  def parse_json
+    JSON.parse(self)
+  end
+end
 
 module Extractors
   class PluckFieldExtractor < Extractor


### PR DESCRIPTION
My previous pull request from this branch lets people send arbitrary messages to the string resulting from a JSONPath expression. This way they can do things like downcasing or upcasing strings, or parsing integers or floats, etc. by specifying a "transform" function in the extractor config

{"field_map"=>{"experiment_group"=>"$.subject.metadata['#experiment_group']", "machine_prediction"=>{"path"=>"$.subject.metadata['#machine_prediction']", "transform"=>"upcase"}, "machine_probability"=>"$.subject.metadata['#machine_probability']"}}

This pull request monkey-patches string itself to add a `parse_json` method that calls JSON.parse on the contents of the string.

Patching core objects is to be avoided. But this DOES give us the luxury of passing structured metadata into caesar, which a lot of our researchers would early love. Anyways I merged the other PR because we needed it but I want to leave this open for opinions.