### PR TITLE
Support simple math in rules

### DIFF
--- a/app/models/conditions/calculator.rb
+++ b/app/models/conditions/calculator.rb
@@ -1,0 +1,26 @@
+module Conditions
+  class Calculator
+    attr_reader :type, :operations
+
+    def initialize(type, operations)
+      @type = type
+      @operations = operations
+    end
+
+    def apply(bindings)
+      values = operations.map { |op| op.apply(bindings) }
+      case type
+      when '+'
+        values.reduce(&:+)
+      when '-'
+        values.reduce(&:-)
+      when '*'
+        values.reduce(&:*)
+      when '/'
+        values.map(&:to_f).reduce(&:/)
+      when '%'
+        values.reduce(&:%)
+      end
+    end
+  end
+end

--- a/app/models/conditions/from_config.rb
+++ b/app/models/conditions/from_config.rb
@@ -18,6 +18,8 @@ module Conditions
         Comparison.new(config[0], build_many(config[1..-1]))
       when 'const'
         Constant.new(config[1])
+      when '+', '-', '*', '/', '%'
+        Calculator.new(config[0], build_many(config[1..-1]))
       when 'lookup'
         raise InvalidConfig, "Not enough arguments given to lookup" unless config[1..-1].size == 2
         Lookup.new(config[1], config[2])

--- a/app/models/rule_bindings.rb
+++ b/app/models/rule_bindings.rb
@@ -8,7 +8,7 @@ class RuleBindings
 
     def data
       return {} unless @subject
-      @subject.metadata
+      @data ||= @subject.metadata.merge("zooniverse_subject_id" => @subject.id)
     end
   end
 

--- a/spec/models/conditions/calculator_spec.rb
+++ b/spec/models/conditions/calculator_spec.rb
@@ -39,7 +39,6 @@ describe Conditions::Calculator do
     end
   end
 
-
   def const(val)
     Conditions::Constant.new(val)
   end

--- a/spec/models/conditions/calculator_spec.rb
+++ b/spec/models/conditions/calculator_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Conditions::Calculator do
+  let(:bindings) { double("RuleBindings") }
+  let(:operations) { [const(1), const(5), const(-3)] }
+
+  describe '+' do
+    it 'adds arguments' do
+      condition = described_class.new('+', operations)
+      expect(condition.apply(bindings)).to eq(3)
+    end
+  end
+
+  describe '-' do
+    it 'subtracts arguments' do
+      condition = described_class.new('-', operations)
+      expect(condition.apply(bindings)).to eq(-1)
+    end
+  end
+
+  describe '*' do
+    it 'multiplies arguments' do
+      condition = described_class.new('*', operations)
+      expect(condition.apply(bindings)).to eq(-15)
+    end
+  end
+
+  describe '/' do
+    it 'divides arguments' do
+      condition = described_class.new('/', [const(5), const(2)])
+      expect(condition.apply(bindings)).to eq(2.5)
+    end
+  end
+
+  describe '%' do
+    it 'takes the remainder' do
+      condition = described_class.new('%', [const(5), const(2)])
+      expect(condition.apply(bindings)).to eq(1)
+    end
+  end
+
+
+  def const(val)
+    Conditions::Constant.new(val)
+  end
+end

--- a/spec/models/rule_bindings_spec.rb
+++ b/spec/models/rule_bindings_spec.rb
@@ -12,6 +12,14 @@ describe RuleBindings do
     expect(rule_bindings.fetch("other.b")).to eq(2)
   end
 
+  it 'exposes subject id' do
+    reductions = []
+    subject = build_stubbed(:subject, id: 1234, metadata: {})
+
+    rule_bindings = described_class.new(reductions, subject)
+    expect(rule_bindings.fetch("subject.zooniverse_subject_id")).to eq(1234)
+  end
+
   it 'exposes subject metadata' do
     reductions = []
     subject = build_stubbed(:subject, metadata: {"region" => "oxford"})


### PR DESCRIPTION
Primarily added for the modulo operator. That will enable us to split subjects between different subject sets with a rule like `IF subject_id % 2 == 0 THEN add_to_set(A); IF subject_id % 2 == 1 THEN add_to_set(B)`.

