### PR TITLE
Cache enabledness of workflows for 5 minutes

### DIFF
--- a/app/models/stream_events/classification_event.rb
+++ b/app/models/stream_events/classification_event.rb
@@ -29,7 +29,9 @@ module StreamEvents
     private
 
     def enabled?
-      workflow.present?
+      Rails.cache.fetch("workflows/#{workflow_id}/enabled?", expires_in: 5.minutes) do
+        workflow.present?
+      end
     end
 
     def classification
@@ -37,8 +39,11 @@ module StreamEvents
     end
 
     def workflow
-      workflow_id = @data.fetch("links").fetch("workflow")
       Workflow.find_by(id: workflow_id)
+    end
+
+    def workflow_id
+      workflow_id = @data.fetch("links").fetch("workflow")
     end
 
     def linked_subjects

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
I noticed in NewRelic that workflow lookup was one of the highest time consumers. I think this might be one of the places were we could easily avoid it. This PR cuts out the database lookup for workflows that we don't have set up in Caesar.