### PR TITLE
Public data requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   respond_to :html, :json
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from Pundit::NotAuthorizedError, with: :not_authorized
 
   private
 
@@ -64,6 +65,10 @@ class ApplicationController < ActionController::Base
 
   def record_not_found
     head 404
+  end
+
+  def not_authorized
+    head 401
   end
 
   def handle_unauthenticated_request(message)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   respond_to :html, :json
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
 
   private
@@ -65,6 +66,10 @@ class ApplicationController < ActionController::Base
 
   def record_not_found
     head 404
+  end
+
+  def record_invalid(exception)
+    render json: exception.record.errors, status: 422
   end
 
   def not_authorized

--- a/app/controllers/data_requests_controller.rb
+++ b/app/controllers/data_requests_controller.rb
@@ -11,41 +11,22 @@ class DataRequestsController < ApplicationController
   end
 
   def create
-    data_request = params[:data_request] || {}
-    requested_data = data_request[:requested_data] || nil
+    DataRequest.transaction do
+      obj = nil
+      args = (params[:data_request] || {}).merge(workflow_id: params[:workflow_id])
+      ctx = {credential: credential}
 
-    case requested_data
-    when "extracts"
-      make_request(DataRequest.requested_data[:extracts])
-    when "reductions"
-      make_request(DataRequest.requested_data[:reductions])
-    else
-      skip_authorization
-      head 422
+      data_request = CreatesDataRequests.call(obj, args, ctx)
+      authorize data_request
+
+      respond_to do |format|
+        format.html { redirect_to [data_request.workflow, :data_requests] }
+        format.json { respond_with data_request.workflow, data_request }
+      end
     end
   end
 
   private
-
-  def make_request(request_type)
-    data_request = DataRequest.new(
-      user_id: params[:user_id],
-      workflow_id: params[:workflow_id],
-      subgroup: params[:subgroup],
-      requested_data: request_type
-    )
-    authorize data_request
-
-    data_request.status = DataRequest.statuses[:pending]
-    data_request.url = nil
-    data_request.save!
-
-    DataRequestWorker.perform_async(data_request.id)
-    respond_to do |format|
-      format.html { redirect_to [data_request.workflow, :data_requests] }
-      format.json { respond_with data_request.workflow, data_request }
-    end
-  end
 
   def scope
     policy_scope(DataRequest).where(workflow_id: params[:workflow_id])

--- a/app/controllers/data_requests_controller.rb
+++ b/app/controllers/data_requests_controller.rb
@@ -17,7 +17,7 @@ class DataRequestsController < ApplicationController
       ctx = {credential: credential}
 
       data_request = CreatesDataRequests.call(obj, args, ctx)
-      authorize data_request
+      skip_authorization # operations do this themselves and raise if needed
 
       respond_to do |format|
         format.html { redirect_to [data_request.workflow, :data_requests] }

--- a/app/controllers/data_requests_controller.rb
+++ b/app/controllers/data_requests_controller.rb
@@ -1,11 +1,11 @@
 class DataRequestsController < ApplicationController
   def index
-    @data_requests = workflow.data_requests.order(created_at: :desc)
+    @data_requests = scope.order(created_at: :desc)
     respond_with @data_requests
   end
 
   def show
-    data_request = workflow.data_requests.find(params[:id])
+    data_request = scope.find(params[:id])
     authorize data_request
     respond_with data_request
   end
@@ -49,5 +49,9 @@ class DataRequestsController < ApplicationController
 
   def workflow
     @workflow ||= policy_scope(Workflow).find(params[:workflow_id])
+  end
+
+  def scope
+    policy_scope(DataRequest).where(workflow_id: params[:workflow_id])
   end
 end

--- a/app/graphql/mutation_root.rb
+++ b/app/graphql/mutation_root.rb
@@ -13,14 +13,7 @@ MutationRoot = GraphQL::ObjectType.define do
     argument :subgroup, types.String
     argument :userId, types.Int
 
-    resolve ->(obj, args, ctx) {
-      CreatesDataRequests.call(obj, {
-                                 workflow_id: args[:workflowId],
-                                 requested_data: args[:requestedData],
-                                 subgroup: args[:subgroup],
-                                 user_id: args[:user_id]
-                               }, ctx)
-    }
+    resolve CreatesDataRequests.graphql
   end
 
   field :upsertExtract, Extract::Type do

--- a/app/graphql/mutation_root.rb
+++ b/app/graphql/mutation_root.rb
@@ -14,19 +14,12 @@ MutationRoot = GraphQL::ObjectType.define do
     argument :userId, types.Int
 
     resolve ->(obj, args, ctx) {
-      workflow = Workflow.accessible_by(ctx[:credential]).find(args[:workflowId])
-      data_request = workflow.data_requests.build(
-        user_id: args[:userId],
-        subgroup: args[:subgroup],
-        requested_data: args[:requestedData]
-      )
-
-      data_request.status = DataRequest.statuses[:pending]
-      data_request.url = nil
-      data_request.save!
-
-      DataRequestWorker.perform_async(data_request.workflow_id)
-      data_request
+      CreatesDataRequests.call(obj, {
+                                 workflow_id: args[:workflowId],
+                                 requested_data: args[:requestedData],
+                                 subgroup: args[:subgroup],
+                                 user_id: args[:user_id]
+                               }, ctx)
     }
   end
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -87,6 +87,17 @@ class Workflow < ApplicationRecord
       (rules&.present? and subscribers?)
   end
 
+  def public_data?(type)
+    case type
+    when 'extracts'
+      public_extracts?
+    when 'reductions'
+      public_reductions?
+    else
+      false
+    end
+  end
+
   def subscribers?
     webhooks.size > 0
   end

--- a/app/operations/application_operation.rb
+++ b/app/operations/application_operation.rb
@@ -1,0 +1,27 @@
+class ApplicationOperation
+  include Pundit
+
+  def self.call(obj, args, ctx)
+    operation = new(ctx)
+    result = operation.call(obj, args)
+    operation.send(:verify_authorized)
+    result
+  end
+
+  attr_reader :credential
+
+  def initialize(ctx)
+    @credential = ctx[:credential]
+  end
+
+  # This method is defined to turn +query+ from an optional argument into a required one.
+  # The one we get from Pundit tries to discover the query from the params[:action] which
+  # does not exist outside the scope of a Rails controller.
+  def authorize(record, query)
+    super(record, query)
+  end
+
+  def pundit_user
+    credential
+  end
+end

--- a/app/operations/application_operation.rb
+++ b/app/operations/application_operation.rb
@@ -1,6 +1,22 @@
 class ApplicationOperation
   include Pundit
 
+  class GraphQLWrapper
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def call(obj, args, ctx)
+      @klass.call(obj,
+                  args.to_h.transform_keys { |key| key.to_s.underscore }.with_indifferent_access,
+                  ctx.to_h.transform_keys { |key| key.to_s.underscore }.with_indifferent_access)
+    end
+  end
+
+  def self.graphql
+    GraphQLWrapper.new(self)
+  end
+
   def self.call(obj, args, ctx)
     operation = new(ctx)
     result = operation.call(obj, args)

--- a/app/operations/creates_data_requests.rb
+++ b/app/operations/creates_data_requests.rb
@@ -1,0 +1,21 @@
+class CreatesDataRequests
+  def self.call(obj, args, ctx)
+    credential = ctx[:credential]
+
+    data_request = DataRequest.new(
+      workflow_id: args[:workflow_id],
+      user_id: args[:user_id],
+      subgroup: args[:subgroup],
+      requested_data: args[:requested_data]
+    )
+
+    Pundit.authorize(credential, data_request, :create?)
+
+    data_request.status = DataRequest.statuses[:pending]
+    data_request.url = nil
+    data_request.save!
+
+    DataRequestWorker.perform_async(data_request.workflow_id)
+    data_request
+  end
+end

--- a/app/operations/creates_data_requests.rb
+++ b/app/operations/creates_data_requests.rb
@@ -1,7 +1,5 @@
-class CreatesDataRequests
-  def self.call(obj, args, ctx)
-    credential = ctx[:credential]
-
+class CreatesDataRequests < ApplicationOperation
+  def call(obj, args)
     data_request = DataRequest.new(
       workflow_id: args[:workflow_id],
       user_id: args[:user_id],
@@ -9,7 +7,7 @@ class CreatesDataRequests
       requested_data: args[:requested_data]
     )
 
-    Pundit.authorize(credential, data_request, :create?)
+    authorize(data_request, :create?)
 
     data_request.status = DataRequest.statuses[:pending]
     data_request.url = nil

--- a/app/operations/creates_data_requests.rb
+++ b/app/operations/creates_data_requests.rb
@@ -9,6 +9,7 @@ class CreatesDataRequests < ApplicationOperation
 
     authorize(data_request, :create?)
 
+    data_request.public = data_request.workflow.public_data?(data_request.requested_data)
     data_request.status = DataRequest.statuses[:pending]
     data_request.url = nil
     data_request.save!

--- a/app/policies/data_request_policy.rb
+++ b/app/policies/data_request_policy.rb
@@ -9,11 +9,16 @@ class DataRequestPolicy < ApplicationPolicy
   end
 
   def create?
-    update?
+    return true if credential.admin?
+    return true if record.extracts? && record.workflow.public_extracts
+    return true if record.reductions? && record.workflow.public_reductions
+
+    credential.project_ids.include?(record.workflow.project_id)
   end
 
   def update?
     return true if credential.admin?
+
     credential.project_ids.include?(record.workflow.project_id)
   end
 

--- a/app/policies/data_request_policy.rb
+++ b/app/policies/data_request_policy.rb
@@ -4,7 +4,7 @@ class DataRequestPolicy < ApplicationPolicy
       workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
 
       scope = self.scope.joins(:workflow).references(:workflows)
-      scope.where(workflow_id: workflow_ids)
+      scope.where(workflow_id: workflow_ids).or(scope.where(public: true))
     end
   end
 

--- a/db/migrate/20171103091757_alter_data_requests_add_public.rb
+++ b/db/migrate/20171103091757_alter_data_requests_add_public.rb
@@ -1,0 +1,5 @@
+class AlterDataRequestsAddPublic < ActiveRecord::Migration[5.1]
+  def change
+    add_column :data_requests, :public, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170908141509) do
+ActiveRecord::Schema.define(version: 20171103091757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20170908141509) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "public", default: false, null: false
     t.index ["user_id", "workflow_id", "subgroup", "requested_data"], name: "look_up_existing", unique: true
     t.index ["workflow_id"], name: "index_data_requests_on_workflow_id"
   end

--- a/spec/controllers/data_requests_controller_spec.rb
+++ b/spec/controllers/data_requests_controller_spec.rb
@@ -91,7 +91,7 @@ describe DataRequestsController, :type => :controller do
       end
 
       context 'when not a project collaborator' do
-        it 'returns 404 when workflow does not expose reductions publicly' do
+        it 'returns 401 when workflow does not expose reductions publicly' do
           fake_session(admin: false)
           response = post :create, params: params, format: :json
           expect(response.status).to eq(401)

--- a/spec/graphql/mutation_root_spec.rb
+++ b/spec/graphql/mutation_root_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe MutationRoot do
+  let(:credential) { build :credential, admin: true }
+  let(:context) { {credential: credential} }
+  let(:variables) { {} }
+  let(:result) {
+    CaesarSchema.execute(
+      mutation_string,
+      context: context,
+      variables: variables
+    )
+  }
+
+  describe 'createDataRequest' do
+    let(:workflow) { create :workflow }
+    let(:mutation_string) do <<-END
+      mutation { createDataRequest(workflowId: #{workflow.id}, requestedData: extracts) { id } }
+    END
+    end
+
+    it 'creates data requests' do
+      expect(result["data"]["createDataRequest"]["id"]).to eq(DataRequest.first.id)
+    end
+  end
+end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -2,4 +2,34 @@ require 'rails_helper'
 
 RSpec.describe Workflow, type: :model do
   let(:workflow) { Workflow.new }
+
+  describe 'public_data?' do
+    describe 'public extracts' do
+      it 'is true' do
+        workflow.public_extracts = true
+        expect(workflow.public_data?("extracts")).to be_truthy
+      end
+
+      it 'is false' do
+        workflow.public_extracts = false
+        expect(workflow.public_data?("extracts")).to be_falsey
+      end
+    end
+
+    describe 'public reductions' do
+      it 'is true' do
+        workflow.public_reductions = true
+        expect(workflow.public_data?("reductions")).to be_truthy
+      end
+
+      it 'is false' do
+        workflow.public_reductions = false
+        expect(workflow.public_data?("reductions")).to be_falsey
+      end
+    end
+
+    it 'is false for any other data type' do
+      expect(workflow.public_data?("foobar")).to be_falsey
+    end
+  end
 end

--- a/spec/operations/creates_data_requests_spec.rb
+++ b/spec/operations/creates_data_requests_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe CreatesDataRequests do
+  let(:credential) { build :credential, admin: true }
+  let(:workflow) { create :workflow }
+
+  let(:obj) { nil }
+  let(:args) { {} }
+  let(:ctx) { { credential: credential} }
+
+  describe 'extracts' do
+    let(:args) { {workflow_id: workflow.id, requested_data: 'extracts'} }
+
+    it('should produce a data request item for a new request') do
+      response = described_class.call(obj, args, ctx)
+
+      expect(response).to be_truthy
+      expect(DataRequest.count).to eq(1)
+      expect(DataRequest.first.extracts?).to be(true)
+    end
+
+    context 'when not a project collaborator' do
+      let(:credential) { build :credential, workflows: [] }
+
+      it 'allows creating request when workflow exposes extracts publicly' do
+        workflow.update! public_extracts: true
+        response = described_class.call(obj, args, ctx)
+        expect(response).to be_truthy
+      end
+
+      it 'fails when workflow does not expose extracts publicly' do
+        expect { described_class.call(obj, args, ctx) }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+
+  describe 'reductions' do
+    let(:args) { {workflow_id: workflow.id, requested_data: 'reductions'} }
+
+    it('should produce reduction requests instead of extract requests') do
+      response = described_class.call(obj, args, ctx)
+
+      expect(response).to be_truthy
+      expect(DataRequest.count).to eq(1)
+      expect(DataRequest.first.reductions?).to be(true)
+    end
+
+    context 'when not a project collaborator' do
+      let(:credential) { build :credential, workflows: [] }
+
+      it 'allows creating request when workflow exposes reductions publicly' do
+        workflow.update! public_reductions: true
+        response = described_class.call(obj, args, ctx)
+        expect(response).to be_truthy
+      end
+
+      it 'fails when workflow does not expose reductions publicly' do
+        expect { described_class.call(obj, args, ctx) }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+end

--- a/spec/operations/creates_data_requests_spec.rb
+++ b/spec/operations/creates_data_requests_spec.rb
@@ -19,6 +19,12 @@ describe CreatesDataRequests do
       expect(DataRequest.first.extracts?).to be(true)
     end
 
+    it 'creates public requests when data is public' do
+      workflow.update! public_extracts: true
+      response = described_class.call(obj, args, ctx)
+      expect(response).to be_public
+    end
+
     context 'when not a project collaborator' do
       let(:credential) { build :credential, workflows: [] }
 

--- a/spec/policies/data_request_policy_spec.rb
+++ b/spec/policies/data_request_policy_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe DataRequestPolicy do
   subject { described_class }
 
+  let(:workflow) { build :workflow }
+
   permissions ".scope" do
     let!(:data_requests) { create_list :data_request, 4 }
 
@@ -56,6 +58,46 @@ RSpec.describe DataRequestPolicy do
     end
   end
 
+  permissions :create? do
+    let(:data_request) { create :data_request }
+
+    it 'grants access to an admin' do
+      credential = build(:credential, :admin, workflows: [])
+      expect(subject).to permit(credential, data_request)
+    end
+
+    it 'grants access to data_requests of collaborated project' do
+      credential = build(:credential, workflows: [data_request.workflow])
+      expect(subject).to permit(credential, data_request)
+    end
+
+    it 'grants access to data_requests of a workflow with public extracts' do
+      workflow.update! public_extracts: true
+      data_request = build(:data_request, workflow: workflow, requested_data: 'extracts')
+      credential = build(:credential, workflows: [])
+      expect(subject).to permit(credential, data_request)
+    end
+
+    it 'grants access to data_requests of a workflow with public extracts' do
+      workflow.update! public_reductions: true
+      data_request = build(:data_request, workflow: workflow, requested_data: 'reductions')
+      credential = build(:credential, workflows: [])
+      expect(subject).to permit(credential, data_request)
+    end
+
+    it 'does not let non-collaborators create requests for non-public workflows', :aggregate_failures do
+      workflow = build(:workflow, public_extracts: true) # <- Note extracts are public, but request reductions
+      data_request = build(:data_request, workflow: workflow, requested_data: 'reductions')
+      credential = build(:credential, workflows: [])
+      expect(subject).not_to permit(credential, data_request)
+
+      workflow = build(:workflow, public_reductions: true) # <- Note reductions are public, but request extracts
+      data_request = build(:data_request, workflow: workflow, requested_data: 'extracts')
+      credential = build(:credential, workflows: [])
+      expect(subject).not_to permit(credential, data_request)
+    end
+  end
+
   permissions :update? do
     let(:data_request) { create :data_request }
 
@@ -67,6 +109,13 @@ RSpec.describe DataRequestPolicy do
     it 'grants access to data_requests of collaborated project' do
       credential = build(:credential, workflows: [data_request.workflow])
       expect(subject).to permit(credential, data_request)
+    end
+
+    it 'does not let non-collaborators update public data requests' do
+      workflow.update! public_extracts: true
+      data_request = build(:data_request, workflow: workflow, public: true)
+      credential = build(:credential, workflows: [])
+      expect(subject).not_to permit(credential, data_request)
     end
   end
 

--- a/spec/support/fake_session.rb
+++ b/spec/support/fake_session.rb
@@ -1,6 +1,6 @@
 module FakeSession
-  def fake_session(admin: false)
-    @credential = instance_double(Credential, logged_in?: true, admin?: admin, ok?: true, expired?: false)
+  def fake_session(admin: false, logged_in: true)
+    @credential = instance_double(Credential, logged_in?: logged_in, admin?: admin, ok?: true, expired?: false, project_ids: [])
     allow(controller).to receive(:credential).and_return(@credential)
   end
 end

--- a/spec/support/fake_session.rb
+++ b/spec/support/fake_session.rb
@@ -1,6 +1,12 @@
 module FakeSession
-  def fake_session(admin: false, logged_in: true)
-    @credential = instance_double(Credential, logged_in?: logged_in, admin?: admin, ok?: true, expired?: false, project_ids: [])
+  def fake_session(admin: false, logged_in: true, project_ids: [])
+    @credential = instance_double(Credential,
+                                  logged_in?: logged_in,
+                                  admin?: admin,
+                                  ok?: true,
+                                  expired?: false,
+                                  project_ids: project_ids)
+
     allow(controller).to receive(:credential).and_return(@credential)
   end
 end

--- a/spec/support/json_controller_helpers.rb
+++ b/spec/support/json_controller_helpers.rb
@@ -1,3 +1,4 @@
 def json_response
+  expect(response.body).not_to eq("")
   JSON.parse(response.body)
 end


### PR DESCRIPTION
I opted to give data requests a `public` column. This means that if a project decides to close their data later on, existing open sets remain public. It also made the queries for `index` and `show` a lot simpler. ;)