### PR TITLE
allow data requests to be created 

### DIFF
--- a/app/policies/data_request_policy.rb
+++ b/app/policies/data_request_policy.rb
@@ -19,7 +19,13 @@ class DataRequestPolicy < ApplicationPolicy
   def update?
     return true if credential.admin?
 
-    credential.project_ids.include?(record.workflow.project_id)
+    return true if(record.requested_data == "extracts" &&
+      record.workflow&.public_extracts?)
+
+    return true if(record.requested_data == "reductions" &&
+      record.workflow&.public_reductions?)
+
+    credential.project_ids.include?(record.workflow&.project_id)
   end
 
   def destroy?

--- a/spec/policies/data_request_policy_spec.rb
+++ b/spec/policies/data_request_policy_spec.rb
@@ -111,11 +111,12 @@ RSpec.describe DataRequestPolicy do
       expect(subject).to permit(credential, data_request)
     end
 
-    it 'does not let non-collaborators update public data requests' do
-      workflow.update! public_extracts: true
-      data_request = build(:data_request, workflow: workflow, public: true)
-      credential = build(:credential, workflows: [])
-      expect(subject).not_to permit(credential, data_request)
+    it 'can request reduction exports if reductions are public' do
+      special_request = create(:data_request, requested_data: "reductions" )
+      special_request.workflow.public_reductions = true
+
+      credential = build(:credential)
+      expect(subject).to permit(credential, special_request)
     end
   end
 


### PR DESCRIPTION
if reductions or extracts are public we should let non-collaborators create data requests for them