### PR TITLE
DataRequest REST Fixes

### DIFF
--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -48,6 +48,7 @@ class DataRequest < ApplicationRecord
 
   def as_json(options = {})
     {
+      id: id,
       workflow_id: workflow_id,
       user_id: user_id,
       subgroup: subgroup,

--- a/app/operations/creates_data_requests.rb
+++ b/app/operations/creates_data_requests.rb
@@ -14,7 +14,7 @@ class CreatesDataRequests < ApplicationOperation
     data_request.url = nil
     data_request.save!
 
-    DataRequestWorker.perform_async(data_request.workflow_id)
+    DataRequestWorker.perform_async(data_request.id)
     data_request
   end
 end


### PR DESCRIPTION
* the id is needed so that a consumer can check the status of their job
* the export workers were not getting started appropriately