### PR TITLE
obey subgroup parameter if it exists

### DIFF
--- a/app/controllers/data_requests_controller.rb
+++ b/app/controllers/data_requests_controller.rb
@@ -1,6 +1,11 @@
 class DataRequestsController < ApplicationController
   def index
     @data_requests = scope.order(created_at: :desc)
+
+    if(params.has_key?(:subgroup))
+      @data_requests = @data_requests.where(subgroup: params[:subgroup])
+    end
+
     respond_with @data_requests
   end
 


### PR DESCRIPTION
If you request `/workflows/:workflow_id/data_requests/?subgroup=XXXXX` then the resulting list of data requests will be filtered to only show data requests that were created for that subgroup