### PR TITLE
Close `p` tag on reducer from

### DIFF
--- a/app/views/reducers/_form.html.erb
+++ b/app/views/reducers/_form.html.erb
@@ -17,7 +17,7 @@
   <div class="panel panel-default">
     <div class="panel-heading">Filters</div>
     <div class="panel-body">
-      <p>Using filters it is possible to limit which extracts this reducer works on.
+      <p>Using filters it is possible to limit which extracts this reducer works on.</p>
       <%= f.simple_fields_for :filters do |filters| %>
         <%= filters.input :from %>
         <%= filters.input :to %>


### PR DESCRIPTION
Non-closed tags in form views can prevent the submit button from
working.

I think this will close #182 but I can't figure out how to test this locally.