### PR TITLE
avoid syntax errors in ruby-2.4.3+

### DIFF
--- a/spec/factories/extract_factory.rb
+++ b/spec/factories/extract_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  sequence :classification_id { |n| n }
+  sequence(:classification_id) { |n| n }
 
   factory :extract do
     workflow

--- a/spec/models/extract_spec.rb
+++ b/spec/models/extract_spec.rb
@@ -1,4 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Extract, type: :model do
+
+  it "should not fail to build the factory" do
+    expect(build(:extract)).to be_valid
+  end
 end


### PR DESCRIPTION
this was failing to build locally with docker with error:
SyntaxError: /app/spec/factories/extract_factory.rb:2: syntax error, unexpected '{', expecting keyword_end
 sequence :classification_id { |n| n }