### PR TITLE
Fix user promotion logic

### DIFF
--- a/app/models/effects/promote_user.rb
+++ b/app/models/effects/promote_user.rb
@@ -2,11 +2,11 @@ module Effects
   class PromoteUser < Effect
     def perform(workflow_id, user_id)
       project_id = Workflow.find(workflow_id).project_id
-      Effects.panoptes.promote_user_to_workflow(user_id, project_id, workflow_id)
+      Effects.panoptes.promote_user_to_workflow(user_id, project_id, target_workflow_id)
 
       notify_subscribers(workflow_id, :user_promoted, {
         "user_id" => user_id,
-        "target_workflow_id" => workflow_id
+        "target_workflow_id" => target_workflow_id
       })
     end
 

--- a/spec/models/effects/promote_user_spec.rb
+++ b/spec/models/effects/promote_user_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 describe Effects::PromoteUser do
-  let(:workflow){ create :workflow, project_id: 1234}
-  let(:user_id){ 33333 }
+  let(:workflow) { create :workflow, project_id: 1234 }
+  let(:target_workflow_id) { 20004 }
+  let(:user_id) { 33333 }
 
   let(:panoptes) { double("PanoptesAdapter", promote_user_to_workflow: true) }
-  let(:effect) { described_class.new("workflow_id" => workflow.id) }
+  let(:effect) { described_class.new("workflow_id" => target_workflow_id) }
 
   before do
     allow(Effects).to receive(:panoptes).and_return(panoptes)
@@ -15,7 +16,7 @@ describe Effects::PromoteUser do
   it 'promotes the user to the specified workflow' do
     effect.perform(workflow.id, user_id)
     expect(panoptes).to have_received(:promote_user_to_workflow)
-      .with(user_id, workflow.project_id, workflow.id)
+      .with(user_id, workflow.project_id, target_workflow_id)
   end
 
   it 'notifies subscribers' do


### PR DESCRIPTION
I think the old code was promoting users to the workflow that they had classified on, rather than the one in the config. @amyrebecca was this indeed a bug, or am I mistaken?