### PR TITLE
set up queues and allocate tasks to queues

### DIFF
--- a/app/workers/backfill_workflow_worker.rb
+++ b/app/workers/backfill_workflow_worker.rb
@@ -1,5 +1,6 @@
 class BackfillWorkflowWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'batch'
 
   def perform(workflow_id, duration = 24.hours)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/check_rules_worker.rb
+++ b/app/workers/check_rules_worker.rb
@@ -2,6 +2,7 @@ class CheckRulesWorker
   include Sidekiq::Worker
   sidekiq_options retry: 2
   sidekiq_options unique: :until_executing unless Rails.env.test?
+  sidekiq_options queue: 'internal'
 
   def perform(workflow_id, subject_id, user_id = nil)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/data_request_worker.rb
+++ b/app/workers/data_request_worker.rb
@@ -1,6 +1,7 @@
 class DataRequestWorker
   include Sidekiq::Worker
   sidekiq_options retry: 5
+  sidekiq_options queue: 'batch'
   sidekiq_retry_in do |count|
     (count ** 8) + 15 + (rand(30) * count + 1)
   end

--- a/app/workers/extract_worker.rb
+++ b/app/workers/extract_worker.rb
@@ -1,6 +1,7 @@
 class ExtractWorker
   include Sidekiq::Worker
   sidekiq_options retry: 5
+  sidekiq_options queue: 'internal'
   sidekiq_retry_in do |count|
     (count ** 8) + 15 + (rand(30) * count + 1)
   end

--- a/app/workers/fetch_classifications_worker.rb
+++ b/app/workers/fetch_classifications_worker.rb
@@ -1,5 +1,6 @@
 class FetchClassificationsWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'batch'
 
  # note: because this isn't an ApplicationRecord subclass,
   # we can't simply use enum

--- a/app/workers/notify_webhook_worker.rb
+++ b/app/workers/notify_webhook_worker.rb
@@ -2,6 +2,7 @@ require 'uri'
 
 class NotifyWebhookWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'external'
 
   def perform(endpoint, event_name, data)
     return if endpoint.nil? or endpoint.empty?

--- a/app/workers/perform_subject_action_worker.rb
+++ b/app/workers/perform_subject_action_worker.rb
@@ -1,5 +1,6 @@
 class PerformSubjectActionWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'external'
 
   def perform(action_id)
     action = SubjectAction.find(action_id)

--- a/app/workers/perform_user_action_worker.rb
+++ b/app/workers/perform_user_action_worker.rb
@@ -1,5 +1,6 @@
 class PerformUserActionWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'external'
 
   def perform(action_id)
     action = SubjectAction.find(action_id)

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -2,6 +2,7 @@ class ReduceWorker
   include Sidekiq::Worker
   sidekiq_options retry: 5
   sidekiq_options unique: :until_executing unless Rails.env.test?
+  sidekiq_options queue: 'internal'
   sidekiq_retry_in do |count|
     (count ** 8) + 15 + (rand(30) * count + 1)
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,4 +4,7 @@
 :concurrency: <%= ENV["SIDEKIQ_CONCURRENCY"] || 10 %>
 :timeout: 30
 :queues:
-  - default
+  - [internal, 4]
+  - [default, 3]
+  - [external, 2]
+  - [batch, 1]


### PR DESCRIPTION
Use multiple sidekiq queues to keep tasks from getting logjammed.

Resolves #253 