### PR TITLE
Fix User Reductions and Rules WIP

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -123,4 +123,12 @@ class Workflow < ApplicationRecord
   def subscribers?
     webhooks.size > 0
   end
+
+  def concerns_subjects?
+    subject_rules.present? or reducers.where(topic: 'reduce_by_subject').present?
+  end
+
+  def concerns_users?
+    user_rules.present? or reducers.where(topic: 'reduce_by_user').present?
+  end
 end

--- a/app/workers/fetch_classifications_worker.rb
+++ b/app/workers/fetch_classifications_worker.rb
@@ -22,8 +22,7 @@ class FetchClassificationsWorker
     when @@FetchForSubject
       Effects.panoptes.get_subject_classifications(object_id, workflow_id)["classifications"]
     when @@FetchForUser
-      # Effects.panoptes.get_user_classifications(object_id, workflow_id)["classifications"]
-      nil
+      Effects.panoptes.get_user_classifications(object_id, workflow_id)["classifications"]
     else
       nil
     end


### PR DESCRIPTION
We shouldn't backfill classifications on a per-user basis unless the workflow actually needs them. This creates problems in long-running workflows because a user may have thousands of classifications.

This is a WIP.