### PR TITLE
[WIP WIP WIP] #2, Association Adjustment

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -1,6 +1,8 @@
 class Classification < ApplicationRecord
-  belongs_to :workflow
+  belongs_to :configurable, polymorphic: true
   belongs_to :subject
+
+  validates :configurable, presence: true
 
   def self.upsert(data)
     classification = Classification.find_or_initialize_by(id: data.fetch("id"))

--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -44,7 +44,7 @@ class DataRequest < ApplicationRecord
   validates :status, presence: true
   validates :requested_data, presence: true
 
-  belongs_to :workflow
+  belongs_to :configurable, polymorphic: true
 
   def stored_export
     raise "DataRequest needs to be saved to database first" unless id.present?
@@ -59,7 +59,7 @@ class DataRequest < ApplicationRecord
   def as_json(options = {})
     {
       id: id,
-      workflow_id: workflow_id.to_s,
+      configurable_id: configurable_id.to_s,
       user_id: user_id,
       subgroup: subgroup,
       status: status,

--- a/app/models/extract.rb
+++ b/app/models/extract.rb
@@ -5,7 +5,7 @@ class Extract < ApplicationRecord
     field :classificationId, types.String, property: :classification_id
     field :classificationAt, Types::TimeType, property: :classification_at
 
-    field :workflowId, !types.ID, property: :workflow_id
+    field :configurableId, !types.ID, property: :configurable_id
     field :subjectId, !types.ID, property: :subject_id
     field :extractorKey, !types.String, property: :extractor_key
     field :userId, types.ID, property: :user_id
@@ -16,6 +16,8 @@ class Extract < ApplicationRecord
     field :updatedAt, !Types::TimeType, property: :updated_at
   end
 
-  belongs_to :workflow
+  belongs_to :configurable, polymorphic: true
   belongs_to :subject
+
+  validates :configurable, presence: true
 end

--- a/app/models/extractor.rb
+++ b/app/models/extractor.rb
@@ -20,10 +20,10 @@ class Extractor < ApplicationRecord
     end
   end
 
-  belongs_to :workflow
+  belongs_to :configurable, polymorphic: true
 
-  validates :workflow, presence: true
-  validates :key, presence: true, uniqueness: {scope: [:workflow_id]}
+  validates :configurable, presence: true
+  validates :key, presence: true, uniqueness: {scope: [:configurable_id]}
 
   before_validation :nilify_empty_fields
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,16 @@
+class Project < ApplicationRecord
+  include Configurable
+
+  has_many :extractors
+  has_many :reducers, as: :configurable
+  has_many :subject_rules
+  has_many :user_rules
+
+  has_many :extracts
+  has_many :subject_reductions
+  has_many :user_reductions
+  has_many :subject_actions
+  has_many :user_actions
+  has_many :data_requests
+
+end

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -29,10 +29,10 @@ class Reducer < ApplicationRecord
     end
   end
 
-  belongs_to :workflow
+  belongs_to :configurable, polymorphic: true
 
-  validates :workflow, presence: true
-  validates :key, presence: true, uniqueness: {scope: [:workflow_id]}
+  validates :configurable, presence: true
+  validates :key, presence: true, uniqueness: {scope: [:configurable_id]}
   validates :topic, presence: true
   validates_associated :extract_filter
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -53,7 +53,7 @@ class Workflow < ApplicationRecord
   end
 
   has_many :extractors
-  has_many :reducers
+  has_many :reducers, as: :configurable
   has_many :subject_rules
   has_many :user_rules
 

--- a/db/migrate/20180221190503_configurable_refactor.rb
+++ b/db/migrate/20180221190503_configurable_refactor.rb
@@ -1,0 +1,29 @@
+class ConfigurableRefactor < ActiveRecord::Migration[5.1]
+  def change
+    create_table :projects do |t|
+
+      t.jsonb :reducers_config
+      t.jsonb :extractors_config
+      t.jsonb :rules_config
+      t.jsonb :webhooks, null: true
+
+      t.boolean "public_extracts", default: false, null: false
+      t.boolean "public_reductions", default: false, null: false
+
+      t.timestamps
+    end
+
+    rename_column :extractors, :workflow_id, :configurable_id
+    rename_column :reducers, :workflow_id, :configurable_id
+    rename_column :extracts, :workflow_id, :configurable_id
+    rename_column :data_requests, :workflow_id, :configurable_id
+    add_column :classifications, :configurable_id, :integer
+
+    add_column :extractors, :configurable_type, :string
+    add_column :reducers, :configurable_type, :string
+    add_column :extracts, :configurable_type, :string
+    add_column :data_requests, :configurable_type, :string
+    add_column :classifications, :configurable_type, :string
+
+  end
+end

--- a/spec/factories/extract_factory.rb
+++ b/spec/factories/extract_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   sequence(:classification_id) { |n| n }
 
   factory :extract do
-    workflow
+    configurable { |e| e.association(:workflow) }
     subject
 
     classification_id { generate :classification_id }

--- a/spec/factories/extractor_factory.rb
+++ b/spec/factories/extractor_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :extractor do
-    workflow nil
+    configurable nil
     key "MyString"
     config { {} }
     minimum_workflow_version nil

--- a/spec/factories/reducer_factory.rb
+++ b/spec/factories/reducer_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :reducer do
-    workflow nil
+    configurable nil
     key "MyString"
     config { {} }
 


### PR DESCRIPTION
The beginning of the switch from a workflow-centric app to polymorphic "configurable" based. We could probably use a better name..."source", maybe?

This is just to see if I'm on the right track. Basically, changing belongs_to associations pointed at workflows to polymorphic "configurables" that can be a workflow, project, org, w/e. Workflow IDs are passed around the whole app, though, so most everywhere they're used will need to pass configurable ids instead.

Updated some factories and specs as well as starting on the #extract method of the classification pipeline model. Models that I updated the `belongs_to :workflow` association are:
Extractors
Reducers
Extracts
Data requests
Classifications (must specify configurable to above, still has wf and project ids)

Models that will need this update as well, if I'm correct:
subject actions
subject reductions
subject rules
user actions
user reductions

I'd love some feedback either here or in slack about the direction here. 