### PR TITLE
Running/Online Aggregation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'graphiql-rails'
 gem 'stoplight'
 gem 'dotenv-rails'
 gem 'ranked-model'
+gem 'deferred_associations'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
+    deferred_associations (0.6.5)
+      activerecord
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
@@ -351,6 +353,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   byebug
   capybara (~> 2.13)
+  deferred_associations
   dotenv-rails
   factory_girl_rails
   flipper

--- a/app/controllers/extracts_controller.rb
+++ b/app/controllers/extracts_controller.rb
@@ -10,7 +10,11 @@ class ExtractsController < ApplicationController
                                             classification_id: classification_id)
     authorize extract
 
-    extract.update! extract_params
+    Workflow.transaction do
+      SubjectReduction.delete(extract.subject_reduction_ids)
+      UserReduction.delete(extract.user_reduction_ids)
+      extract.update! extract_params
+    end
 
     ReduceWorker.perform_async(workflow.id, subject.id, user_id) if workflow.configured?
 

--- a/app/controllers/extracts_controller.rb
+++ b/app/controllers/extracts_controller.rb
@@ -11,8 +11,8 @@ class ExtractsController < ApplicationController
     authorize extract
 
     Workflow.transaction do
-      SubjectReduction.delete(extract.subject_reduction_ids)
-      UserReduction.delete(extract.user_reduction_ids)
+      extract.subject_reduction.update_all expired: true
+      extract.user_reduction.update_all expired: true
       extract.update! extract_params
     end
 

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -76,11 +76,8 @@ class ClassificationPipeline
       reducer.process(extract_fetcher.for(reducer.topic), reduction_fetcher.for(reducer.topic))
     end.flatten
 
-    return if new_reductions == Reducer::NoData || new_reductions.reject{|reduction| reduction == Reducer::NoData}.empty?
-
     Workflow.transaction do
       new_reductions.each do |reduction|
-        next if reduction == Reducer::NoData
         reduction.save!
       end
     end

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -58,9 +58,9 @@ class ClassificationPipeline
     return [] unless reducers&.present?
     tries ||= 2
 
-    keys = { workflow_id: workflow_id, subject_id: subject_id, user_id: user_id }
-    extract_fetcher = ExtractFetcher.new(keys).including(extract_ids)
-    reduction_fetcher = ReductionFetcher.new(keys)
+    filter = { workflow_id: workflow_id, subject_id: subject_id, user_id: user_id }
+    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids)
+    reduction_fetcher = ReductionFetcher.new(filter)
 
     # if we don't need to fetch everything, try not to
     if reducers.all?{ |reducer| reducer.running_reduction? }

--- a/app/models/counting_hash.rb
+++ b/app/models/counting_hash.rb
@@ -1,12 +1,12 @@
 class CountingHash
-  def self.build
-    results = new
+  def self.build(initial_values = {})
+    results = new(initial_values)
     yield results
     results.to_h
   end
 
-  def initialize
-    @value = {}
+  def initialize(val = {})
+    @value = val
   end
 
   def increment(key, amount = 1)

--- a/app/models/extract.rb
+++ b/app/models/extract.rb
@@ -18,6 +18,6 @@ class Extract < ApplicationRecord
 
   belongs_to :workflow
   belongs_to :subject
-  has_and_belongs_to_many :subject_reduction
-  has_and_belongs_to_many :user_reduction
+  has_and_belongs_to_many_with_deferred_save :subject_reduction
+  has_and_belongs_to_many_with_deferred_save :user_reduction
 end

--- a/app/models/extract.rb
+++ b/app/models/extract.rb
@@ -18,4 +18,6 @@ class Extract < ApplicationRecord
 
   belongs_to :workflow
   belongs_to :subject
+  has_and_belongs_to_many :subject_reduction
+  has_and_belongs_to_many :user_reduction
 end

--- a/app/models/extract_fetcher.rb
+++ b/app/models/extract_fetcher.rb
@@ -1,17 +1,71 @@
 class ExtractFetcher
-  def initialize(workflow_id, subject_id, user_id, extract_ids=[])
-    @workflow_id = workflow_id
-    @subject_id = subject_id
-    @user_id = user_id
-    @extract_ids = extract_ids
+  attr_accessor :reduction_mode, :topic, :extract_ids, :strategy
+  attr_reader :keys
+
+  @@strategies = [ :fetch_all, :fetch_minimal ]
+  def self.strategies
+    @@strategies
+  end
+
+  def initialize(keys)
+    @keys = keys
+
+    @extract_ids = []
+    @topic = :reduce_by_subject
+    @strategy = :fetch_all
+  end
+
+  def strategy!(strategy)
+    @strategy = strategy.to_sym
+    @user_extracts = nil
+    @subject_extracts = nil
+    @exact_extracts = nil
+  end
+
+  def for(topic)
+    ExtractFetcher.new(keys).tap do |fetcher|
+      fetcher.topic = topic.to_sym
+      fetcher.extract_ids = @extract_ids
+      fetcher.strategy = @strategy
+    end
+  end
+
+  def including(extract_ids)
+    ExtractFetcher.new(keys).tap do |fetcher|
+      fetcher.extract_ids = (@extract_ids + extract_ids).uniq
+      fetcher.topic = @topic
+      fetcher.strategy = @strategy
+    end
+  end
+
+  def extracts
+    if fetch_minimal?
+      exact_extracts
+    elsif fetch_subjects?
+      subject_extracts
+    elsif fetch_users?
+      user_extracts
+    end
+  end
+
+  def fetch_minimal?
+    @strategy == :fetch_minimal
+  end
+
+  def fetch_users?
+    @topic == :reduce_by_user
+  end
+
+  def fetch_subjects?
+    @topic == :reduce_by_subject
   end
 
   def user_extracts
-    @user_extracts ||= Extract.where(workflow_id: @workflow_id, user_id: @user_id).order(classification_at: :desc)
+    @user_extracts ||= Extract.where(keys.except(:subject_id)).order(classification_at: :desc)
   end
 
   def subject_extracts
-    @subject_extracts ||= Extract.where(workflow_id: @workflow_id, subject_id: @subject_id).order(classification_at: :desc)
+    @subject_extracts ||= Extract.where(keys.except(:user_id)).order(classification_at: :desc)
   end
 
   def exact_extracts

--- a/app/models/extract_fetcher.rb
+++ b/app/models/extract_fetcher.rb
@@ -1,8 +1,9 @@
 class ExtractFetcher
-  def initialize(workflow_id, subject_id, user_id)
+  def initialize(workflow_id, subject_id, user_id, extract_ids=[])
     @workflow_id = workflow_id
     @subject_id = subject_id
     @user_id = user_id
+    @extract_ids = extract_ids
   end
 
   def user_extracts
@@ -11,5 +12,9 @@ class ExtractFetcher
 
   def subject_extracts
     @subject_extracts ||= Extract.where(workflow_id: @workflow_id, subject_id: @subject_id).order(classification_at: :desc)
+  end
+
+  def exact_extracts
+    @exact_extracts ||= Extract.find(@extract_ids).order(classification_at: :desc)
   end
 end

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -64,9 +64,11 @@ class Reducer < ApplicationRecord
           factory.new(keys)
         end
 
-        filtered = extract_filter.filter(grouped)
-        reduction_data = reduction_data_for(filtered, reduction)
+        filtered_extracts = extract_filter.filter(grouped)
+
+        reduction_data = reduction_data_for(filtered_extracts, reduction)
         reduction.data = reduction_data if reduction.present?
+        reduction.extract << filtered_extracts
 
         if reduction_data == NoData
           Reducer::NoData

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -6,6 +6,11 @@ class Reducer < ApplicationRecord
     reduce_by_user: 1
   }
 
+  enum reduction_mode: {
+    default_reduction: 0,
+    running_reduction: 1
+  }
+
   def self.of_type(type)
     case type.to_s
     when "consensus"

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -45,7 +45,6 @@ class Reducer < ApplicationRecord
 
   NoData = Class.new
 
-  # def process(extracts, reductions=nil)
   def process(extract_fetcher, reduction_fetcher)
     light = Stoplight("reducer-#{id}") do
       # if any of the reductions that this reducer cares about have expired, we're

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -55,7 +55,7 @@ class Reducer < ApplicationRecord
 
       grouped_extracts = ExtractGrouping.new(extract_fetcher.extracts, grouping).to_h
 
-      new_reductions = grouped_extracts.map do |group_key, grouped|
+      grouped_extracts.map do |group_key, grouped|
         reduction = get_reduction(reduction_fetcher, group_key)
         extracts = filter_extracts(grouped, reduction)
 
@@ -66,13 +66,7 @@ class Reducer < ApplicationRecord
           # until the reduction is saved, meaning it happens inside the transaction
           associate_extracts(r, extracts) if running_reduction?
         end
-      end
-
-      if new_reductions.reject{|reduction| reduction.data.blank?}.empty?
-        nil
-      else
-        new_reductions
-      end
+      end.reject{ |reduction| reduction.data.blank? }
     end
 
     light.run

--- a/app/models/reducers/consensus_reducer.rb
+++ b/app/models/reducers/consensus_reducer.rb
@@ -1,8 +1,7 @@
 module Reducers
   class ConsensusReducer < Reducer
     def reduction_data_for(extractions, reduction)
-      store_value = {}
-      store_value = reduction.store if running_reduction? && reduction&.store.present?
+      store_value = reduction&.store || {}
       counter = CountingHash.new(store_value)
 
       extractions.each do |extraction|

--- a/app/models/reducers/consensus_reducer.rb
+++ b/app/models/reducers/consensus_reducer.rb
@@ -1,19 +1,22 @@
 module Reducers
   class ConsensusReducer < Reducer
     def reduction_data_for(extractions, reduction)
-      counter = CountingHash.new
+      store_value = {}
+      store_value = reduction.store if running_reduction? && reduction&.store.present?
+      counter = CountingHash.new(store_value)
 
       extractions.each do |extraction|
-        counter.increment(extraction.data.keys)
+        counter.increment(extraction.data.keys.sort.join("+"))
       end
 
+      reduction.store = counter.to_h if reduction.present?
       most_likely, num_votes = counter.max
 
       if num_votes > 0
         agreement = num_votes.to_f / counter.sum
 
         {
-          "most_likely" => most_likely.sort.join("+"),
+          "most_likely" => most_likely,
           "num_votes" => num_votes,
           "agreement" => agreement
         }

--- a/app/models/reducers/consensus_reducer.rb
+++ b/app/models/reducers/consensus_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class ConsensusReducer < Reducer
-    def reduction_data_for(extractions)
+    def reduction_data_for(extractions, reduction)
       counter = CountingHash.new
 
       extractions.each do |extraction|

--- a/app/models/reducers/consensus_reducer.rb
+++ b/app/models/reducers/consensus_reducer.rb
@@ -1,28 +1,30 @@
 module Reducers
   class ConsensusReducer < Reducer
-    def reduction_data_for(extractions, reduction)
-      store_value = reduction&.store || {}
+    def reduce_into(extractions, reduction)
+      store_value = reduction.store || {}
       counter = CountingHash.new(store_value)
 
       extractions.each do |extraction|
         counter.increment(extraction.data.keys.sort.join("+"))
       end
 
-      reduction.store = counter.to_h if reduction.present?
       most_likely, num_votes = counter.max
 
-      if num_votes > 0
-        agreement = num_votes.to_f / counter.sum
+      reduction.tap do |r|
+        r.store = counter.to_h
+        r.data = if num_votes > 0
+          agreement = num_votes.to_f / counter.sum
 
-        {
-          "most_likely" => most_likely,
-          "num_votes" => num_votes,
-          "agreement" => agreement
-        }
-      else
-        {
-          "num_votes" => num_votes
-        }
+          {
+            "most_likely" => most_likely,
+            "num_votes" => num_votes,
+            "agreement" => agreement
+          }
+        else
+          {
+            "num_votes" => num_votes
+          }
+        end
       end
     end
   end

--- a/app/models/reducers/count_reducer.rb
+++ b/app/models/reducers/count_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class CountReducer < Reducer
-    def reduction_data_for(extracts)
+    def reduction_data_for(extracts, reduction)
       {
         'classifications' => extracts.map(&:classification_id).uniq.size,
         'extracts' => extracts.size

--- a/app/models/reducers/count_reducer.rb
+++ b/app/models/reducers/count_reducer.rb
@@ -8,8 +8,7 @@
 module Reducers
   class CountReducer < Reducer
     def reduction_data_for(extracts, reduction)
-      data = {}
-      data = reduction.data if running_reduction? && reduction&.data.present?
+      data = reduction&.data || {}
 
       classifications_count = data.fetch("classifications", 0)
       extracts_count = data.fetch("extracts",0)

--- a/app/models/reducers/count_reducer.rb
+++ b/app/models/reducers/count_reducer.rb
@@ -1,10 +1,24 @@
+# Reducers::CountReducer
+#
+# data: {
+#  extracts: INT,
+#  classifications: INT
+# }
+#
 module Reducers
   class CountReducer < Reducer
     def reduction_data_for(extracts, reduction)
+      data = {}
+      data = reduction.data if running_reduction? && reduction&.data.present?
+
+      classifications_count = data.fetch("classifications", 0)
+      extracts_count = data.fetch("extracts",0)
+
       {
-        'classifications' => extracts.map(&:classification_id).uniq.size,
-        'extracts' => extracts.size
+        'classifications' => extracts.map(&:classification_id).uniq.size + classifications_count,
+        'extracts' => extracts.size + extracts_count
       }
     end
+
   end
 end

--- a/app/models/reducers/count_reducer.rb
+++ b/app/models/reducers/count_reducer.rb
@@ -7,16 +7,18 @@
 #
 module Reducers
   class CountReducer < Reducer
-    def reduction_data_for(extracts, reduction)
-      data = reduction&.data || {}
+    def reduce_into(extracts, reduction)
+      data = reduction.data || {}
 
       classifications_count = data.fetch("classifications", 0)
       extracts_count = data.fetch("extracts",0)
 
-      {
-        'classifications' => extracts.map(&:classification_id).uniq.size + classifications_count,
-        'extracts' => extracts.size + extracts_count
-      }
+      reduction.tap do |r|
+        r.data = {
+          'classifications' => extracts.map(&:classification_id).uniq.size + classifications_count,
+          'extracts' => extracts.size + extracts_count
+        }
+      end
     end
 
   end

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -21,7 +21,8 @@ module Reducers
       end
     end
 
-    def reduction_data_for(extractions)
+    def reduction_data_for(extractions, reduction)
+      #TODO: is this the right idea here?
       if url
         response = RestClient.post(url, extractions.to_json, {content_type: :json, accept: :json})
 

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -21,18 +21,20 @@ module Reducers
       end
     end
 
-    def reduction_data_for(extractions, reduction)
+    def reduce_into(extractions, reduction)
       #TODO: is this the right idea here?
       #TODO: this has to be a store thing too
       if url
         response = RestClient.post(url, extractions.to_json, {content_type: :json, accept: :json})
 
-        if response.code == 204
-          NoData
-        elsif ([200, 201, 202].include? response.code) and response.body.present?
-          JSON.parse(response.body)
-        else
-          raise StandardError.new 'Remote reducer failed'
+        reduction.tap do |r|
+          r.data = (if response.code == 204
+            nil
+          elsif ([200, 201, 202].include? response.code) and response.body.present?
+            JSON.parse(response.body)
+          else
+            raise StandardError.new 'Remote reducer failed'
+          end)
         end
       else
         raise StandardError.new "External extractor improperly configured: no URL"

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -23,6 +23,7 @@ module Reducers
 
     def reduction_data_for(extractions, reduction)
       #TODO: is this the right idea here?
+      #TODO: this has to be a store thing too
       if url
         response = RestClient.post(url, extractions.to_json, {content_type: :json, accept: :json})
 

--- a/app/models/reducers/first_extract_reducer.rb
+++ b/app/models/reducers/first_extract_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class FirstExtractReducer < Reducer
-    def reduction_data_for(extractions)
+    def reduction_data_for(extractions, reduction)
       extractions&.fetch(0, nil)&.data || {}
     end
   end

--- a/app/models/reducers/first_extract_reducer.rb
+++ b/app/models/reducers/first_extract_reducer.rb
@@ -1,7 +1,17 @@
+# Reducers::FirstExtractReducer
+#
+# data: {
+#   SHAPE OF FIRST MATCHING EXTRACT
+#}
+#
 module Reducers
   class FirstExtractReducer < Reducer
     def reduction_data_for(extractions, reduction)
-      extractions&.fetch(0, nil)&.data || {}
+      if running_reduction? && reduction&.data.present?
+        reduction.data
+      else
+        extractions&.fetch(0, nil)&.data || {}
+      end
     end
   end
 end

--- a/app/models/reducers/first_extract_reducer.rb
+++ b/app/models/reducers/first_extract_reducer.rb
@@ -6,8 +6,10 @@
 #
 module Reducers
   class FirstExtractReducer < Reducer
-    def reduction_data_for(extractions, reduction)
-      if reduction&.data.blank? then (extractions&.fetch(0, nil)&.data || {}) else reduction.data end
+    def reduce_into(extractions, reduction)
+      reduction.tap do |r|
+        r.data = if reduction.data.blank? then (extractions&.fetch(0, nil)&.data || {}) else reduction.data end
+      end
     end
   end
 end

--- a/app/models/reducers/first_extract_reducer.rb
+++ b/app/models/reducers/first_extract_reducer.rb
@@ -7,11 +7,7 @@
 module Reducers
   class FirstExtractReducer < Reducer
     def reduction_data_for(extractions, reduction)
-      if running_reduction? && reduction&.data.present?
-        reduction.data
-      else
-        extractions&.fetch(0, nil)&.data || {}
-      end
+      if reduction&.data.blank? then (extractions&.fetch(0, nil)&.data || {}) else reduction.data end
     end
   end
 end

--- a/app/models/reducers/placeholder_reducer.rb
+++ b/app/models/reducers/placeholder_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class PlaceholderReducer < Reducer
-    def reduction_data_for(extracts)
+    def reduction_data_for(extracts, reduction=nil)
       NoData
     end
   end

--- a/app/models/reducers/placeholder_reducer.rb
+++ b/app/models/reducers/placeholder_reducer.rb
@@ -1,7 +1,9 @@
 module Reducers
   class PlaceholderReducer < Reducer
-    def reduction_data_for(extracts, reduction=nil)
-      NoData
+    def reduce_into(extracts, reduction)
+      reduction.tap do |r|
+        r.data = nil
+      end
     end
   end
 end

--- a/app/models/reducers/stats_reducer.rb
+++ b/app/models/reducers/stats_reducer.rb
@@ -1,16 +1,18 @@
 module Reducers
   class StatsReducer < Reducer
-    def reduction_data_for(extractions, reduction)
-      data = reduction&.data || {}
+    def reduce_into(extractions, reduction)
+      data = reduction.data || {}
 
-      CountingHash.build(data) do |results|
-        extractions.each do |extraction|
-          extraction.data.each do |key, value|
-            case value
-            when TrueClass, FalseClass
-              results.increment(key, value ? 1 : 0)
-            else
-              results.increment(key, value)
+      reduction.tap do |r|
+        r.data = CountingHash.build(data) do |results|
+          extractions.each do |extraction|
+            extraction.data.each do |key, value|
+              case value
+              when TrueClass, FalseClass
+                results.increment(key, value ? 1 : 0)
+              else
+                results.increment(key, value)
+              end
             end
           end
         end

--- a/app/models/reducers/stats_reducer.rb
+++ b/app/models/reducers/stats_reducer.rb
@@ -1,10 +1,9 @@
 module Reducers
   class StatsReducer < Reducer
     def reduction_data_for(extractions, reduction)
-      initial_value = {}
-      initial_value = reduction.data if running_reduction? && reduction&.data.present?
+      data = reduction&.data || {}
 
-      CountingHash.build(initial_value) do |results|
+      CountingHash.build(data) do |results|
         extractions.each do |extraction|
           extraction.data.each do |key, value|
             case value

--- a/app/models/reducers/stats_reducer.rb
+++ b/app/models/reducers/stats_reducer.rb
@@ -1,7 +1,10 @@
 module Reducers
   class StatsReducer < Reducer
     def reduction_data_for(extractions, reduction)
-      CountingHash.build do |results|
+      initial_value = {}
+      initial_value = reduction.data if running_reduction? && reduction&.data.present?
+
+      CountingHash.build(initial_value) do |results|
         extractions.each do |extraction|
           extraction.data.each do |key, value|
             case value

--- a/app/models/reducers/stats_reducer.rb
+++ b/app/models/reducers/stats_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class StatsReducer < Reducer
-    def reduction_data_for(extractions)
+    def reduction_data_for(extractions, reduction)
       CountingHash.build do |results|
         extractions.each do |extraction|
           extraction.data.each do |key, value|

--- a/app/models/reducers/summary_statistics_reducer.rb
+++ b/app/models/reducers/summary_statistics_reducer.rb
@@ -56,64 +56,120 @@ module Reducers
     end
 
     def reduction_data_for(extracts, reduction=nil)
+      @old_store = {}
+      @new_store = {}
+
       @extracts = extracts
-      {}.tap do |result|
+      @old_store = reduction.store if running_reduction? && reduction&.store.present?
+
+      hash = {}.tap do |result|
         operations.each do |operation|
           if @@valid_operations.include? operation
             result[operation] = self.send(operation)
           end
         end
       end
+
+      reduction.store = @new_store if reduction.present?
+      hash
     end
 
     private
 
     def count
-      @count ||= values.count
+      @count = values.count + get_store("count", 0) unless @count.present?
+
+      set_store("count", @count)
       @count
     end
 
     def min
-      @min ||= values.min
+      unless @min.present?
+        old_min = get_store("min", nil)
+        new_min = values.min
+        @min = if old_min.blank? then new_min elsif old_min < new_min then old_min else new_min end
+      end
+
+      set_store("min", @min)
       @min
     end
 
     def max
-      @max ||= values.max
+      unless @max.present?
+        old_max = get_store("max", nil)
+        new_max = values.max
+        @max = if old_max.blank? then new_max elsif old_max > new_max then old_max else new_max end
+      end
+
+      set_store("max", @max)
       @max
     end
 
     def first
-      @first ||= values.first
+      @first = get_store("first", nil) || values.first unless @first.present?
+
+      set_store("first", @first)
       @first
     end
 
     def sum
-      @sum ||= values.reduce(:+)
+      @sum = values.reduce(:+) + get_store("sum", 0) unless @sum.present?
+
+      set_store("sum", @sum)
       @sum
     end
 
     def product
-      @product ||= values.reduce(:*)
+      @product = values.reduce(:*) * get_store("product", 1) unless @product.present?
+
+      set_store("product", @product)
       @product
     end
 
     def mean
       @mean ||= if sum.blank? then nil elsif count.blank? then nil else sum / count end
+
+      set_store("mean", @mean)
       @mean
     end
 
     def sse
-      @sse ||= if mean.blank? then nil else values.map do |value|
-        (value-mean)**2
-      end.reduce(:+) end
+      unless @sse.present?
+        local_sse = get_store("sse", 0)
 
+        if running_reduction?
+          # perform online computation to update SSE without old values present
+          # online SSE algorithm given by https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm
+          local_count = get_store("count", 0)
+          local_mean = get_store("mean", 0)
+
+          values.each do |new_value|
+            local_count = local_count + 1
+            delta = new_value - local_mean
+            local_mean = local_mean + (delta / local_count)
+            delta2 = new_value - local_mean
+            local_sse = local_sse + (delta * delta2)
+          end
+
+          # store intermediate values if they weren't already being computed
+          set_store("count", count) unless @new_store.key?("count")
+          set_store("mean", mean) unless @new_store.key("mean")
+        else
+          # perform simpler calculation if all values are present
+          local_sse = values.map{ |val| (val-mean)**2 }.reduce(:+)
+        end
+
+        @sse = local_sse
+      end
+
+      set_store("sse", @sse)
       @sse
     end
 
     def variance
       @variance ||= if sse.blank? then nil elsif count < 2 then nil else sse / (count-1) end
 
+      set_store("variance", @variance)
       @variance
     end
 
@@ -128,13 +184,43 @@ module Reducers
     end
 
     def mode
-      @mode ||= if count < 1 then nil else values.group_by{|i| i}.sort_by{|key, group| group.count}.last.first end
+      unless @mode.present?
+        @mode = frequencies.sort_by{|k, count| count}.last.first.to_f
+      end
+
+      set_store("mode", @mode)
       @mode
     end
 
+    def frequencies
+      unless @frequencies.present?
+        old_freqs = get_store("frequencies", {})
+        new_freqs = values.group_by{|i| i}.map{|k, v| [k.to_s, v.count]}.to_h
+
+        @frequencies = old_freqs.merge(new_freqs){ |k, oldval, newval| oldval + newval }
+      end
+
+      set_store("frequencies", @frequencies)
+      @frequencies
+    end
+
     def sorted_values
-      @sorted_values ||= values.sort
+      unless @sorted_values.present?
+        previous_values = get_store("sorted_values", [])
+        @sorted_values = (previous_values + values).sort
+      end
+
+      set_store("sorted_values", @sorted_values)
       @sorted_values
+    end
+
+    def get_store(key, default_val)
+      @old_store.fetch(key, default_val) || default_val
+    end
+
+    def set_store(key, value)
+      @new_store[key] = value
+      value
     end
 
     def values

--- a/app/models/reducers/summary_statistics_reducer.rb
+++ b/app/models/reducers/summary_statistics_reducer.rb
@@ -55,8 +55,8 @@ module Reducers
       end
     end
 
-    def reduction_data_for(extracts, reduction=nil)
-      @old_store = reduction&.store || {}
+    def reduce_into(extracts, reduction)
+      @old_store = reduction.store || {}
       @new_store = {}
 
       @extracts = extracts
@@ -69,8 +69,10 @@ module Reducers
         end
       end
 
-      reduction.store = @new_store if reduction.present?
-      hash
+      reduction.tap do |r|
+        r.store = @new_store
+        r.data = hash
+      end
     end
 
     private

--- a/app/models/reducers/summary_statistics_reducer.rb
+++ b/app/models/reducers/summary_statistics_reducer.rb
@@ -55,7 +55,7 @@ module Reducers
       end
     end
 
-    def reduction_data_for(extracts)
+    def reduction_data_for(extracts, reduction=nil)
       @extracts = extracts
       {}.tap do |result|
         operations.each do |operation|

--- a/app/models/reducers/unique_count_reducer.rb
+++ b/app/models/reducers/unique_count_reducer.rb
@@ -3,17 +3,17 @@ module Reducers
     config_field :field
 
     def reduction_data_for(extracts, reduction)
-      initial_value = []
-      initial_value = reduction.store if running_reduction? && reduction&.store.present?
+      store = reduction&.store || {}
+      store["items"] = [] unless store.key? "items"
 
-      mapped = (initial_value + extracts.map do |extract|
+      mapped = (store["items"] + extracts.map do |extract|
         if extract.data.key?(field)
           val = extract.data[field]
           if val.respond_to?('sort') && val.respond_to?('join') then val.sort.join('+') else val end
         end
       end).uniq
 
-      reduction.store = mapped if reduction.present?
+      reduction.store["items"] = mapped if reduction.present?
 
       mapped.size
     end

--- a/app/models/reducers/unique_count_reducer.rb
+++ b/app/models/reducers/unique_count_reducer.rb
@@ -3,13 +3,19 @@ module Reducers
     config_field :field
 
     def reduction_data_for(extracts, reduction)
-      mapped = extracts.map do |extract|
-        if extract.data.key?(field)
-          extract.data[field]
-        end
-      end
+      initial_value = []
+      initial_value = reduction.store if running_reduction? && reduction&.store.present?
 
-      mapped.uniq.size
+      mapped = (initial_value + extracts.map do |extract|
+        if extract.data.key?(field)
+          val = extract.data[field]
+          if val.respond_to?('sort') && val.respond_to?('join') then val.sort.join('+') else val end
+        end
+      end).uniq
+
+      reduction.store = mapped if reduction.present?
+
+      mapped.size
     end
   end
 end

--- a/app/models/reducers/unique_count_reducer.rb
+++ b/app/models/reducers/unique_count_reducer.rb
@@ -2,8 +2,8 @@ module Reducers
   class UniqueCountReducer < Reducer
     config_field :field
 
-    def reduction_data_for(extracts, reduction)
-      store = reduction&.store || {}
+    def reduce_into(extracts, reduction)
+      store = reduction.store || {}
       store["items"] = [] unless store.key? "items"
 
       mapped = (store["items"] + extracts.map do |extract|
@@ -13,9 +13,11 @@ module Reducers
         end
       end).uniq
 
-      reduction.store["items"] = mapped if reduction.present?
-
-      mapped.size
+      reduction.tap do |r|
+        r.store = store
+        r.store["items"] = mapped
+        r.data = mapped.size
+      end
     end
   end
 end

--- a/app/models/reducers/unique_count_reducer.rb
+++ b/app/models/reducers/unique_count_reducer.rb
@@ -2,7 +2,7 @@ module Reducers
   class UniqueCountReducer < Reducer
     config_field :field
 
-    def reduction_data_for(extracts)
+    def reduction_data_for(extracts, reduction)
       mapped = extracts.map do |extract|
         if extract.data.key?(field)
           extract.data[field]

--- a/app/models/reduction_fetcher.rb
+++ b/app/models/reduction_fetcher.rb
@@ -1,0 +1,52 @@
+class ReductionFetcher
+  attr_accessor :topic
+  def initialize(keys)
+    @keys = keys
+    @subject_reductions = SubjectReduction.where(keys.except(:user_id))
+    @user_reductions = UserReduction.where(keys.except(:subject_id))
+
+    @topic = :reduce_by_subject
+  end
+
+  def load
+    @subject_reductions.load
+    @user_reductions.load
+  end
+
+  def for(topic)
+    @topic = topic.to_sym
+    self
+  end
+
+  def subgroup(subgroup)
+    where(@keys.merge(subgroup: subgroup))
+  end
+
+  def reductions
+    return @subject_reductions if reduce_by_subject?
+    return @user_reductions if reduce_by_user?
+  end
+
+  def reduce_by_user?
+    @topic == :reduce_by_user
+  end
+
+  def reduce_by_subject?
+    @topic == :reduce_by_subject
+  end
+
+  def where(query)
+    return @subject_reductions.where(query.except(:user_id)) if reduce_by_subject?
+    return @user_reductions.where(query.except(:subject_id)) if reduce_by_user?
+  end
+
+  def have_expired?
+    has_expired?
+  end
+
+  def has_expired?
+    true if (reduce_by_subject? && @subject_reductions.any?{ |reduction| reduction.expired? })
+    true if (reduce_by_user? && @user_reductions.any?{ |reduction| reduction.expired? })
+    false
+  end
+end

--- a/app/models/subject_reduction.rb
+++ b/app/models/subject_reduction.rb
@@ -15,5 +15,5 @@ class SubjectReduction < ApplicationRecord
 
   belongs_to :workflow
   belongs_to :subject
-  has_and_belongs_to_many :extract
+  has_and_belongs_to_many_with_deferred_save :extract
 end

--- a/app/models/subject_reduction.rb
+++ b/app/models/subject_reduction.rb
@@ -15,4 +15,5 @@ class SubjectReduction < ApplicationRecord
 
   belongs_to :workflow
   belongs_to :subject
+  has_and_belongs_to_many :extract
 end

--- a/app/models/user_reduction.rb
+++ b/app/models/user_reduction.rb
@@ -14,5 +14,5 @@ class UserReduction < ApplicationRecord
   end
 
   belongs_to :workflow
-  has_and_belongs_to_many :extract
+  has_and_belongs_to_many_with_deferred_save :extract
 end

--- a/app/models/user_reduction.rb
+++ b/app/models/user_reduction.rb
@@ -14,4 +14,5 @@ class UserReduction < ApplicationRecord
   end
 
   belongs_to :workflow
+  has_and_belongs_to_many :extract
 end

--- a/app/workers/extract_worker.rb
+++ b/app/workers/extract_worker.rb
@@ -16,12 +16,13 @@ class ExtractWorker
     classification.destroy
 
     if extracts.present?
-      ReduceWorker.perform_async(classification.workflow_id, classification.subject_id, classification.user_id)
-    end
+      ids = extracts.map(&:id)
+      ReduceWorker.perform_async(classification.workflow_id, classification.subject_id, classification.user_id, ids)
 
-    if workflow.subscribers?
-      extracts.each do |extract|
-        workflow.webhooks.process(:new_extraction, extract.data) if workflow.subscribers?
+      if workflow.subscribers?
+        extracts.each do |extract|
+          workflow.webhooks.process(:new_extraction, extract.data) if workflow.subscribers?
+        end
       end
     end
   rescue ActiveRecord::RecordNotFound => e

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -1,7 +1,7 @@
 class ReduceWorker
   include Sidekiq::Worker
   sidekiq_options retry: 5
-  sidekiq_options unique: :until_executing unless Rails.env.test?
+  sidekiq_options unique: :until_executing, unique_args: ->(args) { args[0,1] } unless Rails.env.test?
   sidekiq_options queue: 'internal'
   sidekiq_retry_in do |count|
     (count ** 8) + 15 + (rand(30) * count + 1)

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -9,6 +9,7 @@ class ReduceWorker
 
   def perform(workflow_id, subject_id, user_id, extract_ids = [])
     workflow = Workflow.find(workflow_id)
+
     begin
       reductions = workflow.classification_pipeline.reduce(workflow_id, subject_id, user_id, extract_ids)
     rescue ClassificationPipeline::ReductionConflict
@@ -16,11 +17,11 @@ class ReduceWorker
       return
     end
 
-    return if reductions == Reducer::NoData || reductions.reject{ |r| r==Reducer::NoData }.empty?
+    return if reductions.blank?
 
     CheckRulesWorker.perform_async(workflow_id, subject_id, user_id)
-    reductions.each do |datum|
-      workflow.webhooks.process(:new_reduction, datum) if workflow.subscribers?
+    reductions.each do |item|
+      workflow.webhooks.process(:new_reduction, item) if workflow.subscribers?
     end
   end
 end

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -16,7 +16,7 @@ class ReduceWorker
       return
     end
 
-    return if reductions == Reducer::NoData or reductions.reject{ |r| r==Reducer::NoData }.empty?
+    return if reductions == Reducer::NoData || reductions.reject{ |r| r==Reducer::NoData }.empty?
 
     CheckRulesWorker.perform_async(workflow_id, subject_id, user_id)
     reductions.each do |datum|

--- a/db/migrate/20180302163359_add_columns_to_subject_reductions.rb
+++ b/db/migrate/20180302163359_add_columns_to_subject_reductions.rb
@@ -1,0 +1,6 @@
+class AddColumnsToSubjectReductions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subject_reductions, :lock_version, :int, default: 0, null: false
+    add_column :subject_reductions, :store, :jsonb
+  end
+end

--- a/db/migrate/20180302163610_add_columns_to_user_reductions.rb
+++ b/db/migrate/20180302163610_add_columns_to_user_reductions.rb
@@ -1,0 +1,6 @@
+class AddColumnsToUserReductions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :user_reductions, :lock_version, :int, default: 0, null: false
+    add_column :user_reductions, :store, :jsonb
+  end
+end

--- a/db/migrate/20180302164309_add_reduction_mode_to_reducers.rb
+++ b/db/migrate/20180302164309_add_reduction_mode_to_reducers.rb
@@ -1,0 +1,5 @@
+class AddReductionModeToReducers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :reducers, :reduction_mode, :int, default: 0, null: false
+  end
+end

--- a/db/migrate/20180302170113_create_join_table_extracts_user_reductions.rb
+++ b/db/migrate/20180302170113_create_join_table_extracts_user_reductions.rb
@@ -1,0 +1,11 @@
+class CreateJoinTableExtractsUserReductions < ActiveRecord::Migration[5.1]
+  def change
+    create_join_table :extracts, :user_reductions do |t|
+      # t.index [:extract_id, :user_reduction_id]
+      # t.index [:user_reduction_id, :extract_id]
+    end
+
+    add_foreign_key "extracts_user_reductions", "extracts", on_delete: :cascade
+    add_foreign_key "extracts_user_reductions", "user_reductions", on_delete: :cascade
+  end
+end

--- a/db/migrate/20180302171103_create_join_table_extracts_subject_reductions.rb
+++ b/db/migrate/20180302171103_create_join_table_extracts_subject_reductions.rb
@@ -1,0 +1,11 @@
+class CreateJoinTableExtractsSubjectReductions < ActiveRecord::Migration[5.1]
+  def change
+    create_join_table :extracts, :subject_reductions do |t|
+      # t.index [:extract_id, :subject_reduction_id]
+      # t.index [:subject_reduction_id, :extract_id]
+    end
+
+    add_foreign_key "extracts_subject_reductions", "extracts", on_delete: :cascade
+    add_foreign_key "extracts_subject_reductions", "subject_reductions", on_delete: :cascade
+  end
+end

--- a/db/migrate/20180321162558_add_expired_to_subject_reductions.rb
+++ b/db/migrate/20180321162558_add_expired_to_subject_reductions.rb
@@ -1,0 +1,5 @@
+class AddExpiredToSubjectReductions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :subject_reductions, :expired, :boolean, default: false
+  end
+end

--- a/db/migrate/20180321162724_add_expired_to_user_reductions.rb
+++ b/db/migrate/20180321162724_add_expired_to_user_reductions.rb
@@ -1,0 +1,5 @@
+class AddExpiredToUserReductions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :user_reductions, :expired, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180220111809) do
+ActiveRecord::Schema.define(version: 20180302171103) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,16 @@ ActiveRecord::Schema.define(version: 20180220111809) do
     t.index ["workflow_id"], name: "index_extracts_on_workflow_id"
   end
 
+  create_table "extracts_subject_reductions", id: false, force: :cascade do |t|
+    t.bigint "extract_id", null: false
+    t.bigint "subject_reduction_id", null: false
+  end
+
+  create_table "extracts_user_reductions", id: false, force: :cascade do |t|
+    t.bigint "extract_id", null: false
+    t.bigint "user_reduction_id", null: false
+  end
+
   create_table "reducers", force: :cascade do |t|
     t.bigint "workflow_id"
     t.string "key", null: false
@@ -91,6 +101,7 @@ ActiveRecord::Schema.define(version: 20180220111809) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "topic", default: 0, null: false
+    t.integer "reduction_mode", default: 0, null: false
     t.index ["workflow_id", "key"], name: "index_reducers_on_workflow_id_and_key", unique: true
     t.index ["workflow_id"], name: "index_reducers_on_workflow_id"
   end
@@ -118,9 +129,11 @@ ActiveRecord::Schema.define(version: 20180220111809) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "subgroup", default: "_default", null: false
+    t.integer "lock_version", default: 0, null: false
+    t.jsonb "store"
     t.index ["subject_id"], name: "index_subject_reductions_on_subject_id"
     t.index ["workflow_id", "subgroup"], name: "index_reductions_workflow_id_and_subgroup"
-    t.index ["workflow_id", "subject_id", "reducer_key", "subgroup"], name: "index_reductions_covering", unique: true
+    t.index ["workflow_id", "subject_id", "reducer_key", "subgroup"], name: "index_reductions_subject_covering"
     t.index ["workflow_id", "subject_id"], name: "index_subject_reductions_on_workflow_id_and_subject_id"
     t.index ["workflow_id"], name: "index_subject_reductions_on_workflow_id"
   end
@@ -173,6 +186,8 @@ ActiveRecord::Schema.define(version: 20180220111809) do
     t.string "subgroup", default: "_default", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "lock_version", default: 0, null: false
+    t.jsonb "store"
     t.index ["user_id"], name: "index_user_reductions_on_user_id"
     t.index ["workflow_id", "user_id", "reducer_key", "subgroup"], name: "index_user_reductions_covering"
     t.index ["workflow_id", "user_id"], name: "index_user_reductions_on_workflow_id_and_user_id"
@@ -213,6 +228,10 @@ ActiveRecord::Schema.define(version: 20180220111809) do
   add_foreign_key "extractors", "workflows"
   add_foreign_key "extracts", "subjects"
   add_foreign_key "extracts", "workflows"
+  add_foreign_key "extracts_subject_reductions", "extracts", on_delete: :cascade
+  add_foreign_key "extracts_subject_reductions", "subject_reductions", on_delete: :cascade
+  add_foreign_key "extracts_user_reductions", "extracts", on_delete: :cascade
+  add_foreign_key "extracts_user_reductions", "user_reductions", on_delete: :cascade
   add_foreign_key "reducers", "workflows"
   add_foreign_key "subject_actions", "subjects"
   add_foreign_key "subject_actions", "workflows"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180302171103) do
+ActiveRecord::Schema.define(version: 20180321162724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 20180302171103) do
     t.string "subgroup", default: "_default", null: false
     t.integer "lock_version", default: 0, null: false
     t.jsonb "store"
+    t.boolean "expired", default: false
     t.index ["subject_id"], name: "index_subject_reductions_on_subject_id"
     t.index ["workflow_id", "subgroup"], name: "index_reductions_workflow_id_and_subgroup"
     t.index ["workflow_id", "subject_id", "reducer_key", "subgroup"], name: "index_reductions_subject_covering"
@@ -188,6 +189,7 @@ ActiveRecord::Schema.define(version: 20180302171103) do
     t.datetime "updated_at", null: false
     t.integer "lock_version", default: 0, null: false
     t.jsonb "store"
+    t.boolean "expired", default: false
     t.index ["user_id"], name: "index_user_reductions_on_user_id"
     t.index ["workflow_id", "user_id", "reducer_key", "subgroup"], name: "index_user_reductions_covering"
     t.index ["workflow_id", "user_id"], name: "index_user_reductions_on_workflow_id_and_user_id"

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -191,4 +191,14 @@ describe ClassificationPipeline do
     expect(user_rule1).to have_received(:process).with(user_id, any_args).once
     expect(user_rule2).not_to have_received(:process)
   end
+
+  describe 'running/online aggregation mode' do
+    xit 'selects the proper extracts for processing' do
+      raise NotImplementedError
+    end
+
+    xit 'detects synchronization problems' do
+      raise NotImplementedError
+    end
+  end
 end

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -80,14 +80,11 @@ describe ClassificationPipeline do
   end
 
   it 'fetches classifications from panoptes when there are no other extracts' do
-    pending
-    expect { pipeline.process(classification) }.
-      to change(FetchClassificationsWorker.jobs, :size).by(2)
+    expect { pipeline.extract(classification) }.
+      to change(FetchClassificationsWorker.jobs, :size).by(1)
   end
 
   it 'does not fetch subject classifications when extracts already present' do
-    pending
-
     create(
       :extract,
       classification_id: classification.id,
@@ -98,7 +95,7 @@ describe ClassificationPipeline do
     )
 
     expect { pipeline.process(classification) }.
-      to change(FetchClassificationsWorker.jobs, :size).by(1)
+      not_to change(FetchClassificationsWorker.jobs, :size)
   end
 
   it 'groups extracts before reduction' do

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -119,7 +119,7 @@ describe ClassificationPipeline do
     create :extract, extractor_key: 'g', workflow_id: workflow.id, subject_id: subject.id, classification_id: 55555, data: { classroom: 2 }
 
     # build a simplified pipeline to reduce these extracts
-    reducer = build(:stats_reducer, key: 's', grouping: "g.classroom")
+    reducer = build(:stats_reducer, key: 's', grouping: "g.classroom", workflow_id: workflow.id)
     pipeline = described_class.new(nil, [reducer], nil, nil)
     pipeline.reduce(workflow.id, subject.id, nil)
 
@@ -138,7 +138,7 @@ describe ClassificationPipeline do
     create :extract, extractor_key: 's', workflow_id: workflow.id, user_id: 1235, subject_id: subject.id, classification_id: 33333, data: { TGR: 1 }
     create :extract, extractor_key: 's', workflow_id: workflow.id, user_id: 1236, subject_id: subject.id, classification_id: 44444, data: { BR: 1 }
 
-    reducer = build(:stats_reducer, key: 's', topic: Reducer.topics[:reduce_by_user])
+    reducer = build(:stats_reducer, key: 's', topic: Reducer.topics[:reduce_by_user], workflow_id: workflow.id)
 
     pipeline = described_class.new(nil, [reducer], nil, nil)
     pipeline.reduce(workflow.id, nil, 1234)

--- a/spec/models/counting_hash_spec.rb
+++ b/spec/models/counting_hash_spec.rb
@@ -11,6 +11,10 @@ describe CountingHash do
     it 'returns a hash with the values' do
       expect(described_class.build { |results| results.increment("a") }).to eq({"a" => 1})
     end
+
+    it 'handles an initial set of values correctly' do
+      expect(described_class.build({"a"=>1}) { |results| results.increment("a") }).to eq({"a" => 2})
+    end
   end
 
   describe '#increment' do

--- a/spec/models/reducer_spec.rb
+++ b/spec/models/reducer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Reducer, type: :model do
 
   subject(:reducer) do
     klass = Class.new(described_class) do
-      def reduction_data_for(extracts)
+      def reduction_data_for(extracts, reductions=nil)
         extracts
       end
     end
@@ -90,9 +90,10 @@ RSpec.describe Reducer, type: :model do
     allow(reducer).to receive(:reduction_data_for){ |reduce_me| reduce_me.map(&:data) }
     reductions = reducer.process(fancy_extracts)
 
-    expect(reductions).to include("33", "34")
-    expect(reductions['33'].count).to eq(3)
-    expect(reductions['34'].count).to eq(1)
+    expect(reductions[0][:group_key]).to eq("33")
+    expect(reductions[0][:data].count).to eq(3)
+    expect(reductions[1][:group_key]).to eq("34")
+    expect(reductions[1][:data].count).to eq(1)
   end
 
   describe 'validations' do

--- a/spec/models/reducer_spec.rb
+++ b/spec/models/reducer_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Reducer, type: :model do
   end
 
   it 'composes grouping and filtering correctly' do
+    workflow = build :workflow
     fancy_extracts = [
       build(:extract, extractor_key: 'votes', classification_id: 1, subject_id: 1234, user_id: 5680, data: {"T0" => "ARAI"}),
       build(:extract, extractor_key: 'votes', classification_id: 2, subject_id: 1234, user_id: 5681, data: {"T0" => "ARAI"}),
@@ -86,13 +87,13 @@ RSpec.describe Reducer, type: :model do
       build(:extract, extractor_key: 'user_group', classification_id: 4, subject_id: 1234, user_id: 5679, data: {"id"=>"33"}),
     ]
 
-    reducer = build :reducer, key: 'r', grouping: "user_group.id", filters: {"extractor_keys" => ["votes"]}
+    reducer = build :reducer, key: 'r', grouping: "user_group.id", filters: {"extractor_keys" => ["votes"]}, workflow_id: workflow.id
     allow(reducer).to receive(:reduction_data_for){ |reduce_me| reduce_me.map(&:data) }
     reductions = reducer.process(fancy_extracts)
 
-    expect(reductions[0][:group_key]).to eq("33")
+    expect(reductions[0][:subgroup]).to eq("33")
     expect(reductions[0][:data].count).to eq(3)
-    expect(reductions[1][:group_key]).to eq("34")
+    expect(reductions[1][:subgroup]).to eq("34")
     expect(reductions[1][:data].count).to eq(1)
   end
 

--- a/spec/models/reducers/consensus_reducer_spec.rb
+++ b/spec/models/reducers/consensus_reducer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Reducers::ConsensusReducer do
   def unwrap(reduction)
-    reduction['_default']
+    reduction[0][:data]
   end
 
   subject(:reducer) { described_class.new }

--- a/spec/models/reducers/consensus_reducer_spec.rb
+++ b/spec/models/reducers/consensus_reducer_spec.rb
@@ -18,18 +18,18 @@ describe Reducers::ConsensusReducer do
 
   describe '#process' do
     it 'processes when there are no classifications' do
-      expect(reducer.reduce_into([], create(:subject_reduction)).data).to include({"num_votes" => 0})
+      expect(reducer.reduce_into([], build(:subject_reduction)).data).to include({"num_votes" => 0})
     end
 
     it 'returns the most likely' do
       extracts = build_extracts(["ZEBRA", "ZEBRA", "ZEBRA", ["ZEBRA", "BIRD"]])
-      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data)
+      expect(reducer.reduce_into(extracts, build(:subject_reduction)).data)
         .to include({"most_likely" => "ZEBRA", "agreement" => 0.75, "num_votes" => 3})
     end
 
     it 'handles multiple species' do
       extracts = build_extracts([["ZEBRA", "BIRD"], ["BIRD", "ZEBRA"]])
-      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data)
+      expect(reducer.reduce_into(extracts, build(:subject_reduction)).data)
         .to include({"most_likely" => "BIRD+ZEBRA", "agreement" => 1.0, "num_votes" => 2})
     end
   end
@@ -38,12 +38,12 @@ describe Reducers::ConsensusReducer do
     it 'works in default aggregation mode' do
       default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
 
-      reduction = create :subject_reduction
+      reduction = build :subject_reduction
       result = default_reducer.reduce_into(build_extracts(["ZEBRA", "ZEBRA", "ZEBRA"]), reduction)
       expect(result.data).to include({"most_likely" => "ZEBRA"})
       expect(result.data).to include({"num_votes" => 3})
 
-      reduction = create :subject_reduction
+      reduction = build :subject_reduction
       result = default_reducer.reduce_into(build_extracts(["ZEBRA", "ZEBRA"]), reduction)
       expect(result.data).to include({"most_likely" => "ZEBRA"})
       expect(result.data).to include({"num_votes" => 2})
@@ -52,7 +52,7 @@ describe Reducers::ConsensusReducer do
     it 'works in running aggregation mode' do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
 
-      reduction = create :subject_reduction, store: {"RCCN" => 4}
+      reduction = build :subject_reduction, store: {"RCCN" => 4}
       result = running_reducer.reduce_into(build_extracts(["ZEBRA", "ZEBRA", "ZEBRA"]), reduction)
       expect(result.data).to include({"most_likely" => "RCCN"})
       expect(result.data).to include({"num_votes" => 4})

--- a/spec/models/reducers/consensus_reducer_spec.rb
+++ b/spec/models/reducers/consensus_reducer_spec.rb
@@ -43,11 +43,12 @@ describe Reducers::ConsensusReducer do
     it 'works in default aggregation mode' do
       default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
 
-      reduction = create :subject_reduction, store: {"RCCN" => 4}
+      reduction = create :subject_reduction
       result = default_reducer.reduction_data_for(build_extracts(["ZEBRA", "ZEBRA", "ZEBRA"]), reduction)
       expect(result).to include({"most_likely" => "ZEBRA"})
       expect(result).to include({"num_votes" => 3})
 
+      reduction = create :subject_reduction
       result = default_reducer.reduction_data_for(build_extracts(["ZEBRA", "ZEBRA"]), reduction)
       expect(result).to include({"most_likely" => "ZEBRA"})
       expect(result).to include({"num_votes" => 2})

--- a/spec/models/reducers/consensus_reducer_spec.rb
+++ b/spec/models/reducers/consensus_reducer_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Reducers::ConsensusReducer do
-  def unwrap(reduction)
-    reduction[0][:data]
-  end
-
   subject(:reducer) { described_class.new }
 
   def build_extracts(choices)
@@ -22,20 +18,19 @@ describe Reducers::ConsensusReducer do
 
   describe '#process' do
     it 'processes when there are no classifications' do
-      expect(unwrap(reducer.process([]))).to include({"num_votes" => 0})
+      expect(reducer.reduction_data_for([],nil)).to include({"num_votes" => 0})
     end
 
     it 'returns the most likely' do
       extracts = build_extracts(["ZEBRA", "ZEBRA", "ZEBRA", ["ZEBRA", "BIRD"]])
-      expect(unwrap(reducer.process(extracts)))
+      expect(reducer.reduction_data_for(extracts, nil))
         .to include({"most_likely" => "ZEBRA", "agreement" => 0.75, "num_votes" => 3})
     end
 
     it 'handles multiple species' do
       extracts = build_extracts([["ZEBRA", "BIRD"], ["BIRD", "ZEBRA"]])
-      expect(unwrap(reducer.process(extracts)))
+      expect(reducer.reduction_data_for(extracts,nil))
         .to include({"most_likely" => "BIRD+ZEBRA", "agreement" => 1.0, "num_votes" => 2})
-
     end
   end
 

--- a/spec/models/reducers/consensus_reducer_spec.rb
+++ b/spec/models/reducers/consensus_reducer_spec.rb
@@ -18,18 +18,18 @@ describe Reducers::ConsensusReducer do
 
   describe '#process' do
     it 'processes when there are no classifications' do
-      expect(reducer.reduction_data_for([],nil)).to include({"num_votes" => 0})
+      expect(reducer.reduce_into([], create(:subject_reduction)).data).to include({"num_votes" => 0})
     end
 
     it 'returns the most likely' do
       extracts = build_extracts(["ZEBRA", "ZEBRA", "ZEBRA", ["ZEBRA", "BIRD"]])
-      expect(reducer.reduction_data_for(extracts, nil))
+      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data)
         .to include({"most_likely" => "ZEBRA", "agreement" => 0.75, "num_votes" => 3})
     end
 
     it 'handles multiple species' do
       extracts = build_extracts([["ZEBRA", "BIRD"], ["BIRD", "ZEBRA"]])
-      expect(reducer.reduction_data_for(extracts,nil))
+      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data)
         .to include({"most_likely" => "BIRD+ZEBRA", "agreement" => 1.0, "num_votes" => 2})
     end
   end
@@ -39,28 +39,27 @@ describe Reducers::ConsensusReducer do
       default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
 
       reduction = create :subject_reduction
-      result = default_reducer.reduction_data_for(build_extracts(["ZEBRA", "ZEBRA", "ZEBRA"]), reduction)
-      expect(result).to include({"most_likely" => "ZEBRA"})
-      expect(result).to include({"num_votes" => 3})
+      result = default_reducer.reduce_into(build_extracts(["ZEBRA", "ZEBRA", "ZEBRA"]), reduction)
+      expect(result.data).to include({"most_likely" => "ZEBRA"})
+      expect(result.data).to include({"num_votes" => 3})
 
       reduction = create :subject_reduction
-      result = default_reducer.reduction_data_for(build_extracts(["ZEBRA", "ZEBRA"]), reduction)
-      expect(result).to include({"most_likely" => "ZEBRA"})
-      expect(result).to include({"num_votes" => 2})
+      result = default_reducer.reduce_into(build_extracts(["ZEBRA", "ZEBRA"]), reduction)
+      expect(result.data).to include({"most_likely" => "ZEBRA"})
+      expect(result.data).to include({"num_votes" => 2})
     end
 
     it 'works in running aggregation mode' do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
 
       reduction = create :subject_reduction, store: {"RCCN" => 4}
-      result = running_reducer.reduction_data_for(build_extracts(["ZEBRA", "ZEBRA", "ZEBRA"]), reduction)
-      expect(result).to include({"most_likely" => "RCCN"})
-      expect(result).to include({"num_votes" => 4})
+      result = running_reducer.reduce_into(build_extracts(["ZEBRA", "ZEBRA", "ZEBRA"]), reduction)
+      expect(result.data).to include({"most_likely" => "RCCN"})
+      expect(result.data).to include({"num_votes" => 4})
 
-      result = running_reducer.reduction_data_for(build_extracts(["ZEBRA", "ZEBRA"]), reduction)
-      expect(result).to include({"most_likely" => "ZEBRA"})
-      expect(result).to include({"num_votes" => 5})
+      result = running_reducer.reduce_into(build_extracts(["ZEBRA", "ZEBRA"]), reduction)
+      expect(result.data).to include({"most_likely" => "ZEBRA"})
+      expect(result.data).to include({"num_votes" => 5})
     end
   end
-
 end

--- a/spec/models/reducers/count_reducer_spec.rb
+++ b/spec/models/reducers/count_reducer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Reducers::CountReducer do
   def unwrap(reduction)
-    reduction['_default']
+    reduction[0][:data]
   end
 
   let(:reducer) { described_class.new }

--- a/spec/models/reducers/count_reducer_spec.rb
+++ b/spec/models/reducers/count_reducer_spec.rb
@@ -1,21 +1,26 @@
 require 'spec_helper'
 
 describe Reducers::CountReducer do
-  def unwrap(reduction)
-    reduction[0][:data]
-  end
-
   let(:reducer) { described_class.new }
 
   it 'counts classifications' do
-    expect(unwrap(reducer.process([]))).to include('classifications' => 0)
-    expect(unwrap(reducer.process([Extract.new(classification_id: 1), Extract.new(classification_id: 1),
-                            Extract.new(classification_id: 2), Extract.new(classification_id: 2)]))).to include('classifications' => 2)
+    expect(reducer.reduction_data_for([], nil)).to include('classifications' => 0)
+    expect(reducer.reduction_data_for([
+      Extract.new(classification_id: 1),
+      Extract.new(classification_id: 1),
+      Extract.new(classification_id: 2),
+      Extract.new(classification_id: 2)
+    ], nil)).to include('classifications' => 2)
   end
 
   it 'counts extracts' do
-    expect(unwrap(reducer.process([]))).to include('extracts' => 0)
-    expect(unwrap(reducer.process([Extract.new, Extract.new, Extract.new, Extract.new]))).to include('extracts' => 4)
+    expect(reducer.reduction_data_for([], nil)).to include('classifications' => 0)
+    expect(reducer.reduction_data_for([
+      Extract.new(classification_id: 1),
+      Extract.new(classification_id: 1),
+      Extract.new(classification_id: 2),
+      Extract.new(classification_id: 2)
+    ], nil)).to include('extracts' => 4)
   end
 
   it 'ignores existing reduction data in default mode' do

--- a/spec/models/reducers/count_reducer_spec.rb
+++ b/spec/models/reducers/count_reducer_spec.rb
@@ -21,7 +21,7 @@ describe Reducers::CountReducer do
   it 'ignores existing reduction data in default mode' do
     s = Subject.create!
     default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
-    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'extracts' => 3, 'classifications' => 1 }
+    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default'
 
     result = default_reducer.reduction_data_for([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
     expect(result["classifications"]).to eq(2)

--- a/spec/models/reducers/count_reducer_spec.rb
+++ b/spec/models/reducers/count_reducer_spec.rb
@@ -17,4 +17,24 @@ describe Reducers::CountReducer do
     expect(unwrap(reducer.process([]))).to include('extracts' => 0)
     expect(unwrap(reducer.process([Extract.new, Extract.new, Extract.new, Extract.new]))).to include('extracts' => 4)
   end
+
+  it 'ignores existing reduction data in default mode' do
+    s = Subject.create!
+    default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
+    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'extracts' => 3, 'classifications' => 1 }
+
+    result = default_reducer.reduction_data_for([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
+    expect(result["classifications"]).to eq(2)
+    expect(result["extracts"]).to eq(3)
+  end
+
+  it 'uses existing reduction data in running aggregation mode' do
+    s = Subject.create!
+    running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
+    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'extracts' => 3, 'classifications' => 1 }
+
+    result = running_reducer.reduction_data_for([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
+    expect(result["classifications"]).to eq(3)
+    expect(result["extracts"]).to eq(6)
+  end
 end

--- a/spec/models/reducers/count_reducer_spec.rb
+++ b/spec/models/reducers/count_reducer_spec.rb
@@ -4,23 +4,23 @@ describe Reducers::CountReducer do
   let(:reducer) { described_class.new }
 
   it 'counts classifications' do
-    expect(reducer.reduction_data_for([], nil)).to include('classifications' => 0)
-    expect(reducer.reduction_data_for([
+    expect(reducer.reduce_into([], create(:subject_reduction)).data).to include('classifications' => 0)
+    expect(reducer.reduce_into([
       Extract.new(classification_id: 1),
       Extract.new(classification_id: 1),
       Extract.new(classification_id: 2),
       Extract.new(classification_id: 2)
-    ], nil)).to include('classifications' => 2)
+    ], create(:subject_reduction)).data).to include('classifications' => 2)
   end
 
   it 'counts extracts' do
-    expect(reducer.reduction_data_for([], nil)).to include('classifications' => 0)
-    expect(reducer.reduction_data_for([
+    expect(reducer.reduce_into([], create(:subject_reduction)).data).to include('classifications' => 0)
+    expect(reducer.reduce_into([
       Extract.new(classification_id: 1),
       Extract.new(classification_id: 1),
       Extract.new(classification_id: 2),
       Extract.new(classification_id: 2)
-    ], nil)).to include('extracts' => 4)
+    ], create(:subject_reduction)).data).to include('extracts' => 4)
   end
 
   it 'ignores existing reduction data in default mode' do
@@ -28,9 +28,9 @@ describe Reducers::CountReducer do
     default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
     reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default'
 
-    result = default_reducer.reduction_data_for([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
-    expect(result["classifications"]).to eq(2)
-    expect(result["extracts"]).to eq(3)
+    result = default_reducer.reduce_into([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
+    expect(result.data["classifications"]).to eq(2)
+    expect(result.data["extracts"]).to eq(3)
   end
 
   it 'uses existing reduction data in running aggregation mode' do
@@ -38,8 +38,8 @@ describe Reducers::CountReducer do
     running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
     reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'extracts' => 3, 'classifications' => 1 }
 
-    result = running_reducer.reduction_data_for([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
-    expect(result["classifications"]).to eq(3)
-    expect(result["extracts"]).to eq(6)
+    result = running_reducer.reduce_into([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
+    expect(result.data["classifications"]).to eq(3)
+    expect(result.data["extracts"]).to eq(6)
   end
 end

--- a/spec/models/reducers/count_reducer_spec.rb
+++ b/spec/models/reducers/count_reducer_spec.rb
@@ -4,29 +4,28 @@ describe Reducers::CountReducer do
   let(:reducer) { described_class.new }
 
   it 'counts classifications' do
-    expect(reducer.reduce_into([], create(:subject_reduction)).data).to include('classifications' => 0)
+    expect(reducer.reduce_into([], build(:subject_reduction)).data).to include('classifications' => 0)
     expect(reducer.reduce_into([
       Extract.new(classification_id: 1),
       Extract.new(classification_id: 1),
       Extract.new(classification_id: 2),
       Extract.new(classification_id: 2)
-    ], create(:subject_reduction)).data).to include('classifications' => 2)
+    ], build(:subject_reduction)).data).to include('classifications' => 2)
   end
 
   it 'counts extracts' do
-    expect(reducer.reduce_into([], create(:subject_reduction)).data).to include('classifications' => 0)
+    expect(reducer.reduce_into([], build(:subject_reduction)).data).to include('classifications' => 0)
     expect(reducer.reduce_into([
       Extract.new(classification_id: 1),
       Extract.new(classification_id: 1),
       Extract.new(classification_id: 2),
       Extract.new(classification_id: 2)
-    ], create(:subject_reduction)).data).to include('extracts' => 4)
+    ], build(:subject_reduction)).data).to include('extracts' => 4)
   end
 
   it 'ignores existing reduction data in default mode' do
-    s = Subject.create!
     default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
-    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default'
+    reduction = build :subject_reduction, reducer_key: 'data', subgroup: '_default'
 
     result = default_reducer.reduce_into([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
     expect(result.data["classifications"]).to eq(2)
@@ -34,9 +33,8 @@ describe Reducers::CountReducer do
   end
 
   it 'uses existing reduction data in running aggregation mode' do
-    s = Subject.create!
     running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
-    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'extracts' => 3, 'classifications' => 1 }
+    reduction = build :subject_reduction, reducer_key: 'data', subgroup: '_default', data: { 'extracts' => 3, 'classifications' => 1 }
 
     result = running_reducer.reduce_into([Extract.new(classification_id: 1), Extract.new(classification_id: 1), Extract.new(classification_id: 2)], reduction)
     expect(result.data["classifications"]).to eq(3)

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -45,7 +45,7 @@ describe Reducers::ExternalReducer do
 
     extractor = described_class.new(config: {"url" => "http://example.org/post/extracts/here"})
     result = extractor.process(extracts)
-    expect(unwrap(result)).to eq(Reducer::NoData)
+    expect(result).to eq(Reducer::NoData)
   end
 
   it 'does not post if no url is configured' do

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -22,7 +22,7 @@ describe Reducers::ExternalReducer do
 
   it 'posts the extracts to a foreign API' do
     reducer = described_class.new(config: {"url" => "http://example.org/post/extracts/here"})
-    reducer.reduction_data_for(extracts, nil)
+    reducer.reduce_into(extracts, create(:subject_reduction))
 
     expect(a_request(:post, "example.org/post/extracts/here")
             .with(body: extracts.to_json))
@@ -31,8 +31,8 @@ describe Reducers::ExternalReducer do
 
   it 'passes through the result from the foreign API' do
     reducer = described_class.new(config: {"url" => "http://example.org/post/extracts/here"})
-    result = reducer.reduction_data_for(extracts, nil)
-    expect(result).to eq(response_data)
+    result = reducer.reduce_into(extracts, create(:subject_reduction))
+    expect(result.data).to eq(response_data)
   end
 
   it 'handles 204s' do
@@ -40,15 +40,15 @@ describe Reducers::ExternalReducer do
       to_return(status: 204, body: "", headers: {})
 
     reducer = described_class.new(config: {"url" => "http://example.org/post/extracts/here"})
-    result = reducer.reduction_data_for(extracts, nil)
-    expect(result).to eq(Reducer::NoData)
+    result = reducer.reduce_into(extracts, create(:subject_reduction))
+    expect(result.data).to be(nil)
   end
 
   it 'does not post if no url is configured' do
     reducer = described_class.new(config: {"url" => nil})
 
     expect do
-      reducer.reduction_data_for(extracts, nil)
+      reducer.reduce_into(extracts, create(:subject_reduction))
     end.to raise_error(StandardError)
   end
 

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -22,7 +22,7 @@ describe Reducers::ExternalReducer do
 
   it 'posts the extracts to a foreign API' do
     reducer = described_class.new(config: {"url" => "http://example.org/post/extracts/here"})
-    reducer.reduce_into(extracts, create(:subject_reduction))
+    reducer.reduce_into(extracts, build(:subject_reduction))
 
     expect(a_request(:post, "example.org/post/extracts/here")
             .with(body: extracts.to_json))
@@ -31,7 +31,7 @@ describe Reducers::ExternalReducer do
 
   it 'passes through the result from the foreign API' do
     reducer = described_class.new(config: {"url" => "http://example.org/post/extracts/here"})
-    result = reducer.reduce_into(extracts, create(:subject_reduction))
+    result = reducer.reduce_into(extracts, build(:subject_reduction))
     expect(result.data).to eq(response_data)
   end
 
@@ -40,7 +40,7 @@ describe Reducers::ExternalReducer do
       to_return(status: 204, body: "", headers: {})
 
     reducer = described_class.new(config: {"url" => "http://example.org/post/extracts/here"})
-    result = reducer.reduce_into(extracts, create(:subject_reduction))
+    result = reducer.reduce_into(extracts, build(:subject_reduction))
     expect(result.data).to be(nil)
   end
 
@@ -48,7 +48,7 @@ describe Reducers::ExternalReducer do
     reducer = described_class.new(config: {"url" => nil})
 
     expect do
-      reducer.reduce_into(extracts, create(:subject_reduction))
+      reducer.reduce_into(extracts, build(:subject_reduction))
     end.to raise_error(StandardError)
   end
 

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Reducers::ExternalReducer do
   def unwrap(reduction)
-    reduction['_default']
+    reduction[0][:data]
   end
 
   let(:extracts) {

--- a/spec/models/reducers/first_extract_reducer_spec.rb
+++ b/spec/models/reducers/first_extract_reducer_spec.rb
@@ -16,14 +16,14 @@ describe Reducers::FirstExtractReducer do
 
   it 'handles an empty extract list' do
     reducer = described_class.new
-    expect(reducer.reduction_data_for([], nil)).to eq({})
+    expect(reducer.reduce_into([], create(:subject_reduction)).data).to eq({})
   end
 
   it 'returns whatever is in the first extract no matter what' do
     reducer = described_class.new
 
-    expect(reducer.reduction_data_for(extracts, nil)).to eq({"foo" => "bar", "bar" => "baz"})
-    expect(reducer.reduction_data_for([extracts[1]], nil)).to eq({"foo" => "bar", "bar" => "bar"})
+    expect(reducer.reduce_into(extracts, create(:subject_reduction)).data).to eq({"foo" => "bar", "bar" => "baz"})
+    expect(reducer.reduce_into([extracts[1]], create(:subject_reduction)).data).to eq({"foo" => "bar", "bar" => "bar"})
   end
 
   it 'works correctly in default aggregation mode' do
@@ -31,7 +31,7 @@ describe Reducers::FirstExtractReducer do
     default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
     reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default'
 
-    expect(default_reducer.reduction_data_for(extracts, reduction)).to eq({"foo" => "bar", "bar" => "baz"})
+    expect(default_reducer.reduce_into(extracts, reduction).data).to eq({"foo" => "bar", "bar" => "baz"})
   end
 
   it 'works correctly in running aggregation mode' do
@@ -39,6 +39,6 @@ describe Reducers::FirstExtractReducer do
     running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
     reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'value' => 'first' }
 
-    expect(running_reducer.reduction_data_for(extracts, reduction)).to eq({'value'=>'first'})
+    expect(running_reducer.reduce_into(extracts, reduction).data).to eq({'value'=>'first'})
   end
 end

--- a/spec/models/reducers/first_extract_reducer_spec.rb
+++ b/spec/models/reducers/first_extract_reducer_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Reducers::FirstExtractReducer do
 
   def unwrap(reduction)
-    reduction['_default']
+    reduction[0][:data]
   end
 
   let(:extracts) do

--- a/spec/models/reducers/first_extract_reducer_spec.rb
+++ b/spec/models/reducers/first_extract_reducer_spec.rb
@@ -29,7 +29,7 @@ describe Reducers::FirstExtractReducer do
   it 'works correctly in default aggregation mode' do
     s = Subject.create!
     default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
-    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'value' => 'first' }
+    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default'
 
     expect(default_reducer.reduction_data_for(extracts, reduction)).to eq({"foo" => "bar", "bar" => "baz"})
   end

--- a/spec/models/reducers/first_extract_reducer_spec.rb
+++ b/spec/models/reducers/first_extract_reducer_spec.rb
@@ -14,22 +14,31 @@ describe Reducers::FirstExtractReducer do
 
   end
 
-  describe '#process' do
-    it 'handles an empty extract list' do
-      reducer = described_class.new
-      result = reducer.process([])
+  it 'handles an empty extract list' do
+    reducer = described_class.new
+    expect(reducer.reduction_data_for([], nil)).to eq({})
+  end
 
-      expect(unwrap(result)).to eq({})
-    end
+  it 'returns whatever is in the first extract no matter what' do
+    reducer = described_class.new
 
-    it 'returns whatever is in the first extract no matter what' do
-      reducer = described_class.new
+    expect(reducer.reduction_data_for(extracts, nil)).to eq({"foo" => "bar", "bar" => "baz"})
+    expect(reducer.reduction_data_for([extracts[1]], nil)).to eq({"foo" => "bar", "bar" => "bar"})
+  end
 
-      result = reducer.process(extracts)
-      expect(unwrap(result)).to eq({"foo" => "bar", "bar" => "baz"})
+  it 'works correctly in default aggregation mode' do
+    s = Subject.create!
+    default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
+    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'value' => 'first' }
 
-      result = reducer.process([extracts[0]])
-      expect(unwrap(result)).to eq({"foo" => "bar", "bar" => "baz"})
-    end
+    expect(default_reducer.reduction_data_for(extracts, reduction)).to eq({"foo" => "bar", "bar" => "baz"})
+  end
+
+  it 'works correctly in running aggregation mode' do
+    s = Subject.create!
+    running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
+    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'value' => 'first' }
+
+    expect(running_reducer.reduction_data_for(extracts, reduction)).to eq({'value'=>'first'})
   end
 end

--- a/spec/models/reducers/first_extract_reducer_spec.rb
+++ b/spec/models/reducers/first_extract_reducer_spec.rb
@@ -16,28 +16,26 @@ describe Reducers::FirstExtractReducer do
 
   it 'handles an empty extract list' do
     reducer = described_class.new
-    expect(reducer.reduce_into([], create(:subject_reduction)).data).to eq({})
+    expect(reducer.reduce_into([], build(:subject_reduction)).data).to eq({})
   end
 
   it 'returns whatever is in the first extract no matter what' do
     reducer = described_class.new
 
-    expect(reducer.reduce_into(extracts, create(:subject_reduction)).data).to eq({"foo" => "bar", "bar" => "baz"})
-    expect(reducer.reduce_into([extracts[1]], create(:subject_reduction)).data).to eq({"foo" => "bar", "bar" => "bar"})
+    expect(reducer.reduce_into(extracts, build(:subject_reduction)).data).to eq({"foo" => "bar", "bar" => "baz"})
+    expect(reducer.reduce_into([extracts[1]], build(:subject_reduction)).data).to eq({"foo" => "bar", "bar" => "bar"})
   end
 
   it 'works correctly in default aggregation mode' do
-    s = Subject.create!
     default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
-    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default'
+    reduction = build :subject_reduction, reducer_key: 'data', subgroup: '_default'
 
     expect(default_reducer.reduce_into(extracts, reduction).data).to eq({"foo" => "bar", "bar" => "baz"})
   end
 
   it 'works correctly in running aggregation mode' do
-    s = Subject.create!
     running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
-    reduction = SubjectReduction.create subject_id: s.id, reducer_key: 'data', subgroup: '_default', data: { 'value' => 'first' }
+    reduction = build :subject_reduction, reducer_key: 'data', subgroup: '_default', data: { 'value' => 'first' }
 
     expect(running_reducer.reduce_into(extracts, reduction).data).to eq({'value'=>'first'})
   end

--- a/spec/models/reducers/placeholder_reducer_spec.rb
+++ b/spec/models/reducers/placeholder_reducer_spec.rb
@@ -5,11 +5,11 @@ describe Reducers::PlaceholderReducer do
     it 'does nothing' do
       reducer = described_class.new
 
-      expect(reducer.reduce_into(nil, create(:subject_reduction)).data).to be(nil)
-      expect(reducer.reduce_into([], create(:subject_reduction)).data).to be(nil)
-      expect(reducer.reduce_into([Extractor::NoData], create(:subject_reduction)).data).to be(nil)
-      expect(reducer.reduce_into([build(:extract)], create(:subject_reduction)).data).to be(nil)
-      expect(reducer.reduce_into([build(:extract), build(:extract)], create(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into(nil, build(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into([], build(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into([Extractor::NoData], build(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into([build(:extract)], build(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into([build(:extract), build(:extract)], build(:subject_reduction)).data).to be(nil)
     end
   end
 

--- a/spec/models/reducers/placeholder_reducer_spec.rb
+++ b/spec/models/reducers/placeholder_reducer_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
 
 describe Reducers::PlaceholderReducer do
-  describe '#reduction_data_for' do
+  describe '#reduce_into' do
     it 'does nothing' do
       reducer = described_class.new
 
-      expect(reducer.reduction_data_for(nil)).to eq(Reducer::NoData)
-      expect(reducer.reduction_data_for([])).to eq(Reducer::NoData)
-      expect(reducer.reduction_data_for([Extractor::NoData])).to eq(Reducer::NoData)
-      expect(reducer.reduction_data_for([build(:extract)])).to eq(Reducer::NoData)
-      expect(reducer.reduction_data_for([build(:extract), build(:extract)])).to eq(Reducer::NoData)
+      expect(reducer.reduce_into(nil, create(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into([], create(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into([Extractor::NoData], create(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into([build(:extract)], create(:subject_reduction)).data).to be(nil)
+      expect(reducer.reduce_into([build(:extract), build(:extract)], create(:subject_reduction)).data).to be(nil)
     end
   end
 

--- a/spec/models/reducers/stats_reducer_spec.rb
+++ b/spec/models/reducers/stats_reducer_spec.rb
@@ -29,26 +29,26 @@ describe Reducers::StatsReducer do
 
   describe '#process' do
     it 'processes when there are no classifications' do
-      expect(reducer.reduce_into([], create(:subject_reduction)).data).to eq({})
+      expect(reducer.reduce_into([], build(:subject_reduction)).data).to eq({})
     end
 
     it 'counts occurrences of species' do
       # expect(unwrap(reducer.process(extracts)))
-      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data)
+      expect(reducer.reduce_into(extracts, build(:subject_reduction)).data)
         .to include({"NTHNGHR" => 2, "RCCN" => 3, "BBN" => 1})
     end
 
     it 'counts booleans as 1' do
       extracts = [Extract.new(data: {'blank' => false})]
-      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data).to eq('blank' => 0)
+      expect(reducer.reduce_into(extracts, build(:subject_reduction)).data).to eq('blank' => 0)
 
       extracts = [Extract.new(data: {'blank' => true}), Extract.new(data: {'blank' => false})]
-      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data).to eq('blank' => 1)
+      expect(reducer.reduce_into(extracts, build(:subject_reduction)).data).to eq('blank' => 1)
     end
 
     it 'works in default aggregation mode' do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
-      reduction = SubjectReduction.create
+      reduction = build :subject_reduction
 
       result = running_reducer.reduce_into(extracts, reduction)
       expect(result.data).to include({"NTHNGHR" => 2})
@@ -57,7 +57,7 @@ describe Reducers::StatsReducer do
 
     it 'works in running aggregation mode' do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
-      reduction = SubjectReduction.create data: {"NTHNGHR" => 1, "RCCN" => 2}
+      reduction = build :subject_reduction, data: {"NTHNGHR" => 1, "RCCN" => 2}
 
       result = running_reducer.reduce_into(extracts, reduction)
       expect(result.data).to include({"NTHNGHR" => 3})

--- a/spec/models/reducers/stats_reducer_spec.rb
+++ b/spec/models/reducers/stats_reducer_spec.rb
@@ -53,5 +53,23 @@ describe Reducers::StatsReducer do
       extracts = [Extract.new(data: {'blank' => true}), Extract.new(data: {'blank' => false})]
       expect(unwrap(reducer.process(extracts))).to eq('blank' => 1)
     end
+
+    it 'works in default aggregation mode' do
+      running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
+      reduction = SubjectReduction.create data: {"NTHNGHR" => 1, "RCCN" => 2}
+
+      result = running_reducer.reduction_data_for(extracts, reduction)
+      expect(result).to include({"NTHNGHR" => 2})
+      expect(result).to include({"RCCN" => 3})
+    end
+
+    it 'works in running aggregation mode' do
+      running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
+      reduction = SubjectReduction.create data: {"NTHNGHR" => 1, "RCCN" => 2}
+
+      result = running_reducer.reduction_data_for(extracts, reduction)
+      expect(result).to include({"NTHNGHR" => 3})
+      expect(result).to include({"RCCN" => 5})
+    end
   end
 end

--- a/spec/models/reducers/stats_reducer_spec.rb
+++ b/spec/models/reducers/stats_reducer_spec.rb
@@ -29,41 +29,39 @@ describe Reducers::StatsReducer do
 
   describe '#process' do
     it 'processes when there are no classifications' do
-      expect(reducer.reduction_data_for([], nil)).to eq({})
+      expect(reducer.reduce_into([], create(:subject_reduction)).data).to eq({})
     end
 
     it 'counts occurrences of species' do
       # expect(unwrap(reducer.process(extracts)))
-      expect(reducer.reduction_data_for(extracts, nil))
+      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data)
         .to include({"NTHNGHR" => 2, "RCCN" => 3, "BBN" => 1})
     end
 
     it 'counts booleans as 1' do
       extracts = [Extract.new(data: {'blank' => false})]
-      expect(reducer.reduction_data_for(extracts, nil)).to eq('blank' => 0)
-      # expect(unwrap(reducer.process(extracts))).to eq('blank' => 0)
+      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data).to eq('blank' => 0)
 
       extracts = [Extract.new(data: {'blank' => true}), Extract.new(data: {'blank' => false})]
-      expect(reducer.reduction_data_for(extracts, nil)).to eq('blank' => 1)
-      # expect(unwrap(reducer.process(extracts))).to eq('blank' => 1)
+      expect(reducer.reduce_into(extracts, create(:subject_reduction)).data).to eq('blank' => 1)
     end
 
     it 'works in default aggregation mode' do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
       reduction = SubjectReduction.create
 
-      result = running_reducer.reduction_data_for(extracts, reduction)
-      expect(result).to include({"NTHNGHR" => 2})
-      expect(result).to include({"RCCN" => 3})
+      result = running_reducer.reduce_into(extracts, reduction)
+      expect(result.data).to include({"NTHNGHR" => 2})
+      expect(result.data).to include({"RCCN" => 3})
     end
 
     it 'works in running aggregation mode' do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction])
       reduction = SubjectReduction.create data: {"NTHNGHR" => 1, "RCCN" => 2}
 
-      result = running_reducer.reduction_data_for(extracts, reduction)
-      expect(result).to include({"NTHNGHR" => 3})
-      expect(result).to include({"RCCN" => 5})
+      result = running_reducer.reduce_into(extracts, reduction)
+      expect(result.data).to include({"NTHNGHR" => 3})
+      expect(result.data).to include({"RCCN" => 5})
     end
   end
 end

--- a/spec/models/reducers/stats_reducer_spec.rb
+++ b/spec/models/reducers/stats_reducer_spec.rb
@@ -56,7 +56,7 @@ describe Reducers::StatsReducer do
 
     it 'works in default aggregation mode' do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction])
-      reduction = SubjectReduction.create data: {"NTHNGHR" => 1, "RCCN" => 2}
+      reduction = SubjectReduction.create
 
       result = running_reducer.reduction_data_for(extracts, reduction)
       expect(result).to include({"NTHNGHR" => 2})

--- a/spec/models/reducers/stats_reducer_spec.rb
+++ b/spec/models/reducers/stats_reducer_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Reducers::StatsReducer do
-  def unwrap(reduction)
-    reduction[0][:data]
-  end
-
   subject(:reducer) { described_class.new }
   let(:extracts){
     [
@@ -33,25 +29,23 @@ describe Reducers::StatsReducer do
 
   describe '#process' do
     it 'processes when there are no classifications' do
-      expect(unwrap(reducer.process([]))).to eq({})
+      expect(reducer.reduction_data_for([], nil)).to eq({})
     end
 
     it 'counts occurrences of species' do
-      expect(unwrap(reducer.process(extracts)))
+      # expect(unwrap(reducer.process(extracts)))
+      expect(reducer.reduction_data_for(extracts, nil))
         .to include({"NTHNGHR" => 2, "RCCN" => 3, "BBN" => 1})
-    end
-
-    it 'counts occurrences inside a subrange' do
-      reducer = described_class.new(filters: {"from" => 0, "to" => 2})
-      expect(unwrap(reducer.process(extracts))).to include({"NTHNGHR" => 1})
     end
 
     it 'counts booleans as 1' do
       extracts = [Extract.new(data: {'blank' => false})]
-      expect(unwrap(reducer.process(extracts))).to eq('blank' => 0)
+      expect(reducer.reduction_data_for(extracts, nil)).to eq('blank' => 0)
+      # expect(unwrap(reducer.process(extracts))).to eq('blank' => 0)
 
       extracts = [Extract.new(data: {'blank' => true}), Extract.new(data: {'blank' => false})]
-      expect(unwrap(reducer.process(extracts))).to eq('blank' => 1)
+      expect(reducer.reduction_data_for(extracts, nil)).to eq('blank' => 1)
+      # expect(unwrap(reducer.process(extracts))).to eq('blank' => 1)
     end
 
     it 'works in default aggregation mode' do

--- a/spec/models/reducers/stats_reducer_spec.rb
+++ b/spec/models/reducers/stats_reducer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Reducers::StatsReducer do
   def unwrap(reduction)
-    reduction['_default']
+    reduction[0][:data]
   end
 
   subject(:reducer) { described_class.new }

--- a/spec/models/reducers/summary_statistics_reducer_spec.rb
+++ b/spec/models/reducers/summary_statistics_reducer_spec.rb
@@ -128,7 +128,7 @@ describe Reducers::SummaryStatisticsReducer do
     end
   end
 
-  describe '#reduction_data_for' do
+  describe '#reduce_into' do
 
     describe 'computing min' do
       it 'computes correctly in default mode' do
@@ -141,13 +141,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["min"]).to be_present
-        expect(result["min"]).to eq(4.7)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["min"]).to be_present
+        expect(result.data["min"]).to eq(4.7)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["min"]).to be_present
-        expect(result["min"]).to eq(3)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["min"]).to be_present
+        expect(result.data["min"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -160,13 +160,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["min"]).to be_present
-        expect(result["min"]).to eq(4)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["min"]).to be_present
+        expect(result.data["min"]).to eq(4)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["min"]).to be_present
-        expect(result["min"]).to eq(3)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["min"]).to be_present
+        expect(result.data["min"]).to eq(3)
       end
     end
 
@@ -180,14 +180,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["first"]).to be_present
-        expect(result["first"]).to eq(4.7)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["first"]).to be_present
+        expect(result.data["first"]).to eq(4.7)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["first"]).to be_present
-        expect(result["first"]).to eq(3)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["first"]).to be_present
+        expect(result.data["first"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -200,13 +200,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["first"]).to be_present
-        expect(result["first"]).to eq(4.7)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["first"]).to be_present
+        expect(result.data["first"]).to eq(4.7)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["first"]).to be_present
-        expect(result["first"]).to eq(4.7)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["first"]).to be_present
+        expect(result.data["first"]).to eq(4.7)
       end
     end
 
@@ -220,14 +220,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["max"]).to be_present
-        expect(result["max"]).to eq(5)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["max"]).to be_present
+        expect(result.data["max"]).to eq(5)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["max"]).to be_present
-        expect(result["max"]).to eq(3)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["max"]).to be_present
+        expect(result.data["max"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -240,13 +240,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["max"]).to be_present
-        expect(result["max"]).to eq(5)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["max"]).to be_present
+        expect(result.data["max"]).to eq(5)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["max"]).to be_present
-        expect(result["max"]).to eq(5)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["max"]).to be_present
+        expect(result.data["max"]).to eq(5)
       end
     end
 
@@ -260,14 +260,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["count"]).to be_present
-        expect(result["count"]).to eq(2)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["count"]).to be_present
+        expect(result.data["count"]).to eq(2)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["count"]).to be_present
-        expect(result["count"]).to eq(1)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["count"]).to be_present
+        expect(result.data["count"]).to eq(1)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -280,13 +280,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["count"]).to be_present
-        expect(result["count"]).to eq(7)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["count"]).to be_present
+        expect(result.data["count"]).to eq(7)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["count"]).to be_present
-        expect(result["count"]).to eq(8)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["count"]).to be_present
+        expect(result.data["count"]).to eq(8)
       end
     end
 
@@ -301,14 +301,14 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["sum"]).to be_present
-        expect(result["sum"]).to eq(9.7)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["sum"]).to be_present
+        expect(result.data["sum"]).to eq(9.7)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["sum"]).to be_present
-        expect(result["sum"]).to eq(3)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["sum"]).to be_present
+        expect(result.data["sum"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -321,13 +321,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["sum"]).to be_present
-        expect(result["sum"]).to eq(14.7)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["sum"]).to be_present
+        expect(result.data["sum"]).to eq(14.7)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["sum"]).to be_present
-        expect(result["sum"]).to eq(17.7)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["sum"]).to be_present
+        expect(result.data["sum"]).to eq(17.7)
       end
     end
 
@@ -341,14 +341,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["product"]).to be_present
-        expect(result["product"]).to eq(23.5)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["product"]).to be_present
+        expect(result.data["product"]).to eq(23.5)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["product"]).to be_present
-        expect(result["product"]).to eq(3)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["product"]).to be_present
+        expect(result.data["product"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -361,13 +361,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["product"]).to be_present
-        expect(result["product"]).to eq(23.5)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["product"]).to be_present
+        expect(result.data["product"]).to eq(23.5)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["product"]).to be_present
-        expect(result["product"]).to eq(70.5)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["product"]).to be_present
+        expect(result.data["product"]).to eq(70.5)
       end
     end
 
@@ -381,14 +381,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["mean"]).to be_present
-        expect(result["mean"]).to eq(4.85)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["mean"]).to be_present
+        expect(result.data["mean"]).to eq(4.85)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["mean"]).to be_present
-        expect(result["mean"]).to eq(3)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["mean"]).to be_present
+        expect(result.data["mean"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -401,13 +401,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["mean"]).to be_present
-        expect(result["mean"]).to eq(4.85)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["mean"]).to be_present
+        expect(result.data["mean"]).to eq(4.85)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["mean"]).to be_present
-        expect(result["mean"]).to be_within(0.0001).of(4.2333)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["mean"]).to be_present
+        expect(result.data["mean"]).to be_within(0.0001).of(4.2333)
       end
     end
 
@@ -421,14 +421,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["sse"]).to be_present
-        expect(result["sse"]).to be_within(0.0001).of(0.045)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["sse"]).to be_present
+        expect(result.data["sse"]).to be_within(0.0001).of(0.045)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["sse"]).to be_present
-        expect(result["sse"]).to eq(0)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["sse"]).to be_present
+        expect(result.data["sse"]).to eq(0)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -441,13 +441,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["sse"]).to be_present
-        expect(result["sse"]).to be_within(0.0001).of(0.045)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["sse"]).to be_present
+        expect(result.data["sse"]).to be_within(0.0001).of(0.045)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["sse"]).to be_present
-        expect(result["sse"]).to be_within(0.0001).of(2.3266)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["sse"]).to be_present
+        expect(result.data["sse"]).to be_within(0.0001).of(2.3266)
       end
     end
 
@@ -461,14 +461,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["variance"]).to be_present
-        expect(result["variance"]).to be_within(0.0001).of(0.045)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["variance"]).to be_present
+        expect(result.data["variance"]).to be_within(0.0001).of(0.045)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result.key?("variance")).to be(true)
-        expect(result["variance"]).to eq(nil)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data.key?("variance")).to be(true)
+        expect(result.data["variance"]).to eq(nil)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -481,13 +481,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["variance"]).to be_present
-        expect(result["variance"]).to be_within(0.0001).of(0.045)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["variance"]).to be_present
+        expect(result.data["variance"]).to be_within(0.0001).of(0.045)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["variance"]).to be_present
-        expect(result["variance"]).to be_within(0.0001).of(1.1633)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["variance"]).to be_present
+        expect(result.data["variance"]).to be_within(0.0001).of(1.1633)
       end
     end
 
@@ -501,14 +501,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["stdev"]).to be_present
-        expect(result["stdev"]).to be_within(0.0001).of(0.2121)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["stdev"]).to be_present
+        expect(result.data["stdev"]).to be_within(0.0001).of(0.2121)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result.key?("stdev")).to be(true)
-        expect(result["stdev"]).to eq(nil)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data.key?("stdev")).to be(true)
+        expect(result.data["stdev"]).to eq(nil)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -521,13 +521,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["stdev"]).to be_present
-        expect(result["stdev"]).to be_within(0.0001).of(0.2121)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["stdev"]).to be_present
+        expect(result.data["stdev"]).to be_within(0.0001).of(0.2121)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["stdev"]).to be_present
-        expect(result["stdev"]).to be_within(0.0001).of(1.07857)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["stdev"]).to be_present
+        expect(result.data["stdev"]).to be_within(0.0001).of(1.07857)
       end
     end
 
@@ -541,13 +541,13 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["median"]).to be_present
-        expect(result["median"]).to be_within(0.0001).of(4.85)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["median"]).to be_present
+        expect(result.data["median"]).to be_within(0.0001).of(4.85)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["median"]).to eq(3)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["median"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -560,13 +560,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(extracts1, reduction)
-        expect(result["median"]).to be_present
-        expect(result["median"]).to be_within(0.0001).of(4.85)
+        result = reducer1.reduce_into(extracts1, reduction)
+        expect(result.data["median"]).to be_present
+        expect(result.data["median"]).to be_within(0.0001).of(4.85)
 
-        result = reducer2.reduction_data_for(extracts2, reduction)
-        expect(result["median"]).to be_present
-        expect(result["median"]).to be_within(0.0001).of(4.7)
+        result = reducer2.reduce_into(extracts2, reduction)
+        expect(result.data["median"]).to be_present
+        expect(result.data["median"]).to be_within(0.0001).of(4.7)
       end
     end
 
@@ -591,14 +591,14 @@ describe Reducers::SummaryStatisticsReducer do
         reducer2 = reducer1.clone
 
         reduction = create :subject_reduction
-        result = reducer1.reduction_data_for(mode_extracts1, reduction)
-        expect(result["mode"]).to be_present
-        expect(result["mode"]).to eq(4.7)
+        result = reducer1.reduce_into(mode_extracts1, reduction)
+        expect(result.data["mode"]).to be_present
+        expect(result.data["mode"]).to eq(4.7)
 
         reduction = create :subject_reduction
-        result = reducer2.reduction_data_for(mode_extracts2, reduction)
-        expect(result["mode"]).to be_present
-        expect(result["mode"]).to eq(5)
+        result = reducer2.reduce_into(mode_extracts2, reduction)
+        expect(result.data["mode"]).to be_present
+        expect(result.data["mode"]).to eq(5)
       end
 
       it 'computes correctly in running aggregation mode' do
@@ -611,13 +611,13 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        result = reducer1.reduction_data_for(mode_extracts1, reduction)
-        expect(result["mode"]).to be_present
-        expect(result["mode"]).to eq(4.7)
+        result = reducer1.reduce_into(mode_extracts1, reduction)
+        expect(result.data["mode"]).to be_present
+        expect(result.data["mode"]).to eq(4.7)
 
-        result = reducer2.reduction_data_for(mode_extracts2, reduction)
-        expect(result["mode"]).to be_present
-        expect(result["mode"]).to eq(4.7)
+        result = reducer2.reduce_into(mode_extracts2, reduction)
+        expect(result.data["mode"]).to be_present
+        expect(result.data["mode"]).to eq(4.7)
       end
     end
   end

--- a/spec/models/reducers/summary_statistics_reducer_spec.rb
+++ b/spec/models/reducers/summary_statistics_reducer_spec.rb
@@ -132,7 +132,7 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing min' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["min"]},
@@ -151,7 +151,7 @@ describe Reducers::SummaryStatisticsReducer do
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction, store: { "min" => 4 }
+        reduction = build :subject_reduction, store: { "min" => 4 }
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["min"]},
@@ -179,19 +179,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["first"]).to be_present
         expect(result.data["first"]).to eq(4.7)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data["first"]).to be_present
         expect(result.data["first"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["first"]},
@@ -219,19 +219,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["max"]).to be_present
         expect(result.data["max"]).to eq(5)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data["max"]).to be_present
         expect(result.data["max"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction, store: { }
+        reduction = build :subject_reduction, store: { }
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["max"]},
@@ -259,19 +259,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["count"]).to be_present
         expect(result.data["count"]).to eq(2)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data["count"]).to be_present
         expect(result.data["count"]).to eq(1)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction, store: { "count" => 5 }
+        reduction = build :subject_reduction, store: { "count" => 5 }
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["count"]},
@@ -292,7 +292,7 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing sum' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["sum"]},
@@ -305,14 +305,14 @@ describe Reducers::SummaryStatisticsReducer do
         expect(result.data["sum"]).to be_present
         expect(result.data["sum"]).to eq(9.7)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data["sum"]).to be_present
         expect(result.data["sum"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction, store: { "sum" => 5 }
+        reduction = build :subject_reduction, store: { "sum" => 5 }
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["sum"]},
@@ -340,19 +340,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["product"]).to be_present
         expect(result.data["product"]).to eq(23.5)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data["product"]).to be_present
         expect(result.data["product"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["product"]},
@@ -380,19 +380,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["mean"]).to be_present
         expect(result.data["mean"]).to eq(4.85)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data["mean"]).to be_present
         expect(result.data["mean"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["mean"]},
@@ -420,19 +420,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["sse"]).to be_present
         expect(result.data["sse"]).to be_within(0.0001).of(0.045)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data["sse"]).to be_present
         expect(result.data["sse"]).to eq(0)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["sse"]},
@@ -460,19 +460,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["variance"]).to be_present
         expect(result.data["variance"]).to be_within(0.0001).of(0.045)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data.key?("variance")).to be(true)
         expect(result.data["variance"]).to eq(nil)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["variance"]},
@@ -500,19 +500,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["stdev"]).to be_present
         expect(result.data["stdev"]).to be_within(0.0001).of(0.2121)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data.key?("stdev")).to be(true)
         expect(result.data["stdev"]).to eq(nil)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["stdev"]},
@@ -540,18 +540,18 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(extracts1, reduction)
         expect(result.data["median"]).to be_present
         expect(result.data["median"]).to be_within(0.0001).of(4.85)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(extracts2, reduction)
         expect(result.data["median"]).to eq(3)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["median"]},
@@ -590,19 +590,19 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer1.reduce_into(mode_extracts1, reduction)
         expect(result.data["mode"]).to be_present
         expect(result.data["mode"]).to eq(4.7)
 
-        reduction = create :subject_reduction
+        reduction = build :subject_reduction
         result = reducer2.reduce_into(mode_extracts2, reduction)
         expect(result.data["mode"]).to be_present
         expect(result.data["mode"]).to eq(5)
       end
 
       it 'computes correctly in running aggregation mode' do
-        reduction = create :subject_reduction, store: { "frequencies": { "4.7" => 2 } }
+        reduction = build :subject_reduction, store: { "frequencies": { "4.7" => 2 } }
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["mode"]},

--- a/spec/models/reducers/summary_statistics_reducer_spec.rb
+++ b/spec/models/reducers/summary_statistics_reducer_spec.rb
@@ -132,7 +132,7 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing min' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction, store: { "min" => 4 }
+        reduction = create :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["min"]},
@@ -172,8 +172,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing first' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["first"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -181,10 +179,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["first"]).to be_present
         expect(result["first"]).to eq(4.7)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result["first"]).to be_present
         expect(result["first"]).to eq(3)
@@ -212,8 +212,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing max' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction, store: { }
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["max"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -221,10 +219,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["max"]).to be_present
         expect(result["max"]).to eq(5)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result["max"]).to be_present
         expect(result["max"]).to eq(3)
@@ -252,8 +252,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing count' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction, store: { "count" => 5 }
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["count"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -261,10 +259,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["count"]).to be_present
         expect(result["count"]).to eq(2)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result["count"]).to be_present
         expect(result["count"]).to eq(1)
@@ -292,7 +292,7 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing sum' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction, store: { "sum" => 5 }
+        reduction = create :subject_reduction
 
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["sum"]},
@@ -305,6 +305,7 @@ describe Reducers::SummaryStatisticsReducer do
         expect(result["sum"]).to be_present
         expect(result["sum"]).to eq(9.7)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result["sum"]).to be_present
         expect(result["sum"]).to eq(3)
@@ -332,8 +333,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing product' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["product"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -341,10 +340,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["product"]).to be_present
         expect(result["product"]).to eq(23.5)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result["product"]).to be_present
         expect(result["product"]).to eq(3)
@@ -372,8 +373,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing mean' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["mean"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -381,10 +380,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["mean"]).to be_present
         expect(result["mean"]).to eq(4.85)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result["mean"]).to be_present
         expect(result["mean"]).to eq(3)
@@ -412,8 +413,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing sse' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["sse"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -421,10 +420,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["sse"]).to be_present
         expect(result["sse"]).to be_within(0.0001).of(0.045)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result["sse"]).to be_present
         expect(result["sse"]).to eq(0)
@@ -452,8 +453,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing variance' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["variance"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -461,10 +460,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["variance"]).to be_present
         expect(result["variance"]).to be_within(0.0001).of(0.045)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result.key?("variance")).to be(true)
         expect(result["variance"]).to eq(nil)
@@ -492,8 +493,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing stdev' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["stdev"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -501,10 +500,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["stdev"]).to be_present
         expect(result["stdev"]).to be_within(0.0001).of(0.2121)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result.key?("stdev")).to be(true)
         expect(result["stdev"]).to eq(nil)
@@ -532,8 +533,6 @@ describe Reducers::SummaryStatisticsReducer do
 
     describe 'computing median' do
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["median"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -541,10 +540,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(extracts1, reduction)
         expect(result["median"]).to be_present
         expect(result["median"]).to be_within(0.0001).of(4.85)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(extracts2, reduction)
         expect(result["median"]).to eq(3)
       end
@@ -582,8 +583,6 @@ describe Reducers::SummaryStatisticsReducer do
       ]}
 
       it 'computes correctly in default mode' do
-        reduction = create :subject_reduction, store: { "frequencies": { "4.7" => 2 } }
-
         reducer1 = described_class.new(
           config: {"summarize_field" => "some_field", "operations" => ["mode"]},
           reduction_mode: Reducer.reduction_modes[:default_reduction]
@@ -591,10 +590,12 @@ describe Reducers::SummaryStatisticsReducer do
 
         reducer2 = reducer1.clone
 
+        reduction = create :subject_reduction
         result = reducer1.reduction_data_for(mode_extracts1, reduction)
         expect(result["mode"]).to be_present
         expect(result["mode"]).to eq(4.7)
 
+        reduction = create :subject_reduction
         result = reducer2.reduction_data_for(mode_extracts2, reduction)
         expect(result["mode"]).to be_present
         expect(result["mode"]).to eq(5)

--- a/spec/models/reducers/summary_statistics_reducer_spec.rb
+++ b/spec/models/reducers/summary_statistics_reducer_spec.rb
@@ -3,12 +3,18 @@ require 'spec_helper'
 describe Reducers::SummaryStatisticsReducer do
 
   let(:workflow){ build_stubbed :workflow }
-  let(:extracts){[
-    build_stubbed(:extract, workflow_id: workflow.id, data: {"some_field" => 4.7}),
-    build_stubbed(:extract, workflow_id: workflow.id, data: {"some_field" => "5"}),
-    build_stubbed(:extract, workflow_id: workflow.id, data: {"some_field" => 3}),
-    build_stubbed(:extract, workflow_id: workflow.id, data: {"some_other_field" => 2})
+
+  let(:extracts1){[
+    build_stubbed(:extract, data: {"some_field" => 4.7}),
+    build_stubbed(:extract, data: {"some_field" => "5"})
   ]}
+
+  let(:extracts2){[
+    build_stubbed(:extract, data: {"some_field" => 3}),
+    build_stubbed(:extract, data: {"some_other_field" => 2})
+  ]}
+
+  let(:extracts){ extracts1 + extracts2 }
 
   describe '#configuration' do
     it 'requires configuration fields' do
@@ -100,7 +106,7 @@ describe Reducers::SummaryStatisticsReducer do
     end
   end
 
-  describe '#reduction_data_for' do
+  describe 'miscellaneous' do
     it 'considers only relevant extracts' do
       r1 = described_class.new(workflow_id: workflow.id, config: {"summarize_field" => "simple_field"})
       r2 = described_class.new(workflow_id: workflow.id, config: {"summarize_field" => "complex.field"})
@@ -120,106 +126,498 @@ describe Reducers::SummaryStatisticsReducer do
       expect(r2.send(:relevant_extracts)).not_to eq(extracts)
       expect(r2.send(:relevant_extracts).count).to eq(3)
     end
+  end
 
-    it 'computes minimum correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["min"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["min"]).to be_present
-      expect(result["min"]).to eq(3)
+  describe '#reduction_data_for' do
+
+    describe 'computing min' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction, store: { "min" => 4 }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["min"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["min"]).to be_present
+        expect(result["min"]).to eq(4.7)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["min"]).to be_present
+        expect(result["min"]).to eq(3)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction, store: { "min" => 4 }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["min"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["min"]).to be_present
+        expect(result["min"]).to eq(4)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["min"]).to be_present
+        expect(result["min"]).to eq(3)
+      end
     end
 
-    it 'computes maximum correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["max"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["max"]).to be_present
-      expect(result["max"]).to eq(5)
+    describe 'computing first' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["first"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["first"]).to be_present
+        expect(result["first"]).to eq(4.7)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["first"]).to be_present
+        expect(result["first"]).to eq(3)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["first"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["first"]).to be_present
+        expect(result["first"]).to eq(4.7)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["first"]).to be_present
+        expect(result["first"]).to eq(4.7)
+      end
     end
 
-    it 'counts correctly' do
-      extracts = [
-        build_stubbed(:extract, data: {"some_field" => 4.7}),
-        build_stubbed(:extract, data: {"some_field" => 4.7}),
+    describe 'computing max' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction, store: { }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["max"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["max"]).to be_present
+        expect(result["max"]).to eq(5)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["max"]).to be_present
+        expect(result["max"]).to eq(3)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction, store: { }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["max"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["max"]).to be_present
+        expect(result["max"]).to eq(5)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["max"]).to be_present
+        expect(result["max"]).to eq(5)
+      end
+    end
+
+    describe 'computing count' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction, store: { "count" => 5 }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["count"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["count"]).to be_present
+        expect(result["count"]).to eq(2)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["count"]).to be_present
+        expect(result["count"]).to eq(1)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction, store: { "count" => 5 }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["count"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["count"]).to be_present
+        expect(result["count"]).to eq(7)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["count"]).to be_present
+        expect(result["count"]).to eq(8)
+      end
+    end
+
+    describe 'computing sum' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction, store: { "sum" => 5 }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["sum"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["sum"]).to be_present
+        expect(result["sum"]).to eq(9.7)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["sum"]).to be_present
+        expect(result["sum"]).to eq(3)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction, store: { "sum" => 5 }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["sum"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["sum"]).to be_present
+        expect(result["sum"]).to eq(14.7)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["sum"]).to be_present
+        expect(result["sum"]).to eq(17.7)
+      end
+    end
+
+    describe 'computing product' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["product"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["product"]).to be_present
+        expect(result["product"]).to eq(23.5)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["product"]).to be_present
+        expect(result["product"]).to eq(3)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["product"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["product"]).to be_present
+        expect(result["product"]).to eq(23.5)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["product"]).to be_present
+        expect(result["product"]).to eq(70.5)
+      end
+    end
+
+    describe 'computing mean' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["mean"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["mean"]).to be_present
+        expect(result["mean"]).to eq(4.85)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["mean"]).to be_present
+        expect(result["mean"]).to eq(3)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["mean"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["mean"]).to be_present
+        expect(result["mean"]).to eq(4.85)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["mean"]).to be_present
+        expect(result["mean"]).to be_within(0.0001).of(4.2333)
+      end
+    end
+
+    describe 'computing sse' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["sse"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["sse"]).to be_present
+        expect(result["sse"]).to be_within(0.0001).of(0.045)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["sse"]).to be_present
+        expect(result["sse"]).to eq(0)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["sse"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["sse"]).to be_present
+        expect(result["sse"]).to be_within(0.0001).of(0.045)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["sse"]).to be_present
+        expect(result["sse"]).to be_within(0.0001).of(2.3266)
+      end
+    end
+
+    describe 'computing variance' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["variance"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["variance"]).to be_present
+        expect(result["variance"]).to be_within(0.0001).of(0.045)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result.key?("variance")).to be(true)
+        expect(result["variance"]).to eq(nil)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["variance"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["variance"]).to be_present
+        expect(result["variance"]).to be_within(0.0001).of(0.045)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["variance"]).to be_present
+        expect(result["variance"]).to be_within(0.0001).of(1.1633)
+      end
+    end
+
+    describe 'computing stdev' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["stdev"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["stdev"]).to be_present
+        expect(result["stdev"]).to be_within(0.0001).of(0.2121)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result.key?("stdev")).to be(true)
+        expect(result["stdev"]).to eq(nil)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["stdev"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["stdev"]).to be_present
+        expect(result["stdev"]).to be_within(0.0001).of(0.2121)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["stdev"]).to be_present
+        expect(result["stdev"]).to be_within(0.0001).of(1.07857)
+      end
+    end
+
+    describe 'computing median' do
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["median"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["median"]).to be_present
+        expect(result["median"]).to be_within(0.0001).of(4.85)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["median"]).to eq(3)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["median"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(extracts1, reduction)
+        expect(result["median"]).to be_present
+        expect(result["median"]).to be_within(0.0001).of(4.85)
+
+        result = reducer2.reduction_data_for(extracts2, reduction)
+        expect(result["median"]).to be_present
+        expect(result["median"]).to be_within(0.0001).of(4.7)
+      end
+    end
+
+    describe 'computing mode' do
+      let(:mode_extracts1){[
         build_stubbed(:extract, data: {"some_field" => "5"}),
-        build_stubbed(:extract, data: {"some_field" => 3}),
-        build_stubbed(:extract, data: {"some_other_field" => 2})
-      ]
-
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["count"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["count"]).to be_present
-      expect(result["count"]).to eq(4)
-    end
-
-    it 'computes sum correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["sum"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["sum"]).to be_present
-      expect(result["sum"]).to eq(12.7)
-    end
-
-    it 'computes product correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["product"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["product"]).to be_present
-      expect(result["product"]).to eq(70.5)
-    end
-
-    it 'computes mean correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["mean"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["mean"]).to be_present
-      expect(result["mean"]).to be_within(0.0001).of(4.2333)
-    end
-
-    it 'computes variance correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["variance"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["variance"]).to be_present
-      expect(result["variance"]).to be_within(0.0001).of(1.16333)
-    end
-
-    it 'computes sse correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["sse"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["sse"]).to be_present
-      expect(result["sse"]).to be_within(0.0001).of(2.32666)
-    end
-
-    it 'computes stdev correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["stdev"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["stdev"]).to be_present
-      expect(result["stdev"]).to be_within(0.0001).of(1.07857)
-    end
-
-    it 'computes median correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["median"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["median"]).to be_present
-      expect(result["median"]).to eq(4.7)
-    end
-
-    it 'computes mode correctly' do
-      extracts = [
-        build_stubbed(:extract, data: {"some_field" => "5"}),
         build_stubbed(:extract, data: {"some_field" => 4.7}),
         build_stubbed(:extract, data: {"some_field" => 4.7}),
-        build_stubbed(:extract, data: {"some_field" => 3}),
-        build_stubbed(:extract, data: {"some_other_field" => 2})
-      ]
+      ]}
+      let(:mode_extracts2){[
+        build_stubbed(:extract, data: {"some_field" => 4.7}),
+        build_stubbed(:extract, data: {"some_field" => 5}),
+        build_stubbed(:extract, data: {"some_field" => 5})
+      ]}
 
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["mode"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["mode"]).to be_present
-      expect(result["mode"]).to eq(4.7)
+      it 'computes correctly in default mode' do
+        reduction = create :subject_reduction, store: { "frequencies": { "4.7" => 2 } }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["mode"]},
+          reduction_mode: Reducer.reduction_modes[:default_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(mode_extracts1, reduction)
+        expect(result["mode"]).to be_present
+        expect(result["mode"]).to eq(4.7)
+
+        result = reducer2.reduction_data_for(mode_extracts2, reduction)
+        expect(result["mode"]).to be_present
+        expect(result["mode"]).to eq(5)
+      end
+
+      it 'computes correctly in running aggregation mode' do
+        reduction = create :subject_reduction, store: { "frequencies": { "4.7" => 2 } }
+
+        reducer1 = described_class.new(
+          config: {"summarize_field" => "some_field", "operations" => ["mode"]},
+          reduction_mode: Reducer.reduction_modes[:running_reduction]
+        )
+
+        reducer2 = reducer1.clone
+
+        result = reducer1.reduction_data_for(mode_extracts1, reduction)
+        expect(result["mode"]).to be_present
+        expect(result["mode"]).to eq(4.7)
+
+        result = reducer2.reduction_data_for(mode_extracts2, reduction)
+        expect(result["mode"]).to be_present
+        expect(result["mode"]).to eq(4.7)
+      end
     end
-
-    it 'computes first correctly' do
-      reducer = described_class.new(config: {"summarize_field" => "some_field", "operations" => ["first"]})
-      result = reducer.reduction_data_for(extracts)
-      expect(result["first"]).to be_present
-      expect(result["first"]).to eq(4.7)
-    end
-
   end
 end

--- a/spec/models/reducers/unique_count_reducer_spec.rb
+++ b/spec/models/reducers/unique_count_reducer_spec.rb
@@ -16,12 +16,12 @@ describe Reducers::UniqueCountReducer do
       Extract.new(
         :classification_id => 1235,
         :classification_at => Date.new(2017,2,5),
-        :data => { "choices" => ["RCCN", "RCCN"]}
+        :data => { "choices" => ["RCCN", "BR"]}
       ),
       Extract.new(
         :classification_id => 1237,
         :classification_at => Date.new(2017,2,7),
-        :data => { "choices" => ["NTHNGHR"] }
+        :data => { "choices" => ["BR", "RCCN"] }
       )
     ]
   }
@@ -36,5 +36,28 @@ describe Reducers::UniqueCountReducer do
 
   it 'counts unique things' do
     expect(unwrap(reducer.process(extracts))).to eq(2)
+  end
+
+  describe 'aggregation modes' do
+    it 'works correctly in default aggregation mode' do
+      default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction], config: {"field" => "choices"})
+
+      extracts = [create(:extract, data: {"choices"=>"B"}), create(:extract, data: {"choices"=>"C"})]
+      reduction = create :subject_reduction, store: ["A", "B"]
+
+      expect(default_reducer.reduction_data_for(extracts, reduction)).to eq(2)
+      expect(default_reducer.reduction_data_for(extracts, reduction)).to eq(2)
+      expect(default_reducer.reduction_data_for([extracts[0]], reduction)).to eq(1)
+    end
+
+    it 'works correctly in running aggregation mode' do
+      running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction], config: {"field" => "choices"})
+
+      extracts = [create(:extract, data: {"choices"=>"B"}), create(:extract, data: {"choices"=>"C"})]
+      reduction = create :subject_reduction, store: ["A", "B"]
+
+      expect(running_reducer.reduction_data_for(extracts, reduction)).to eq(3)
+      expect(running_reducer.reduction_data_for([extracts[0]], reduction)).to eq(3)
+    end
   end
 end

--- a/spec/models/reducers/unique_count_reducer_spec.rb
+++ b/spec/models/reducers/unique_count_reducer_spec.rb
@@ -31,15 +31,15 @@ describe Reducers::UniqueCountReducer do
   end
 
   it 'counts unique things' do
-    expect(reducer.reduce_into(extracts, create(:subject_reduction)).data).to eq(2)
+    expect(reducer.reduce_into(extracts, build(:subject_reduction)).data).to eq(2)
   end
 
   describe 'aggregation modes' do
     it 'works correctly in default aggregation mode' do
       default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction], config: {"field" => "choices"})
 
-      extracts = [create(:extract, data: {"choices"=>"B"}), create(:extract, data: {"choices"=>"C"})]
-      reduction = create :subject_reduction, store: {}
+      extracts = [build(:extract, data: {"choices"=>"B"}), build(:extract, data: {"choices"=>"C"})]
+      reduction = build :subject_reduction, store: {}
 
       expect(default_reducer.reduce_into(extracts, reduction).data).to eq(2)
 
@@ -50,8 +50,8 @@ describe Reducers::UniqueCountReducer do
     it 'works correctly in running aggregation mode' do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction], config: {"field" => "choices"})
 
-      extracts = [create(:extract, data: {"choices"=>"B"}), create(:extract, data: {"choices"=>"C"})]
-      reduction = create :subject_reduction, store: { "items" => ["A", "B"] }
+      extracts = [build(:extract, data: {"choices"=>"B"}), build(:extract, data: {"choices"=>"C"})]
+      reduction = build :subject_reduction, store: { "items" => ["A", "B"] }
 
       expect(running_reducer.reduce_into(extracts, reduction).data).to eq(3)
       expect(running_reducer.reduce_into([extracts[0]], reduction).data).to eq(3)

--- a/spec/models/reducers/unique_count_reducer_spec.rb
+++ b/spec/models/reducers/unique_count_reducer_spec.rb
@@ -43,10 +43,11 @@ describe Reducers::UniqueCountReducer do
       default_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:default_reduction], config: {"field" => "choices"})
 
       extracts = [create(:extract, data: {"choices"=>"B"}), create(:extract, data: {"choices"=>"C"})]
-      reduction = create :subject_reduction, store: ["A", "B"]
+      reduction = create :subject_reduction, store: {}
 
       expect(default_reducer.reduction_data_for(extracts, reduction)).to eq(2)
-      expect(default_reducer.reduction_data_for(extracts, reduction)).to eq(2)
+
+      reduction.store = {}
       expect(default_reducer.reduction_data_for([extracts[0]], reduction)).to eq(1)
     end
 
@@ -54,7 +55,7 @@ describe Reducers::UniqueCountReducer do
       running_reducer = described_class.new(reduction_mode: Reducer.reduction_modes[:running_reduction], config: {"field" => "choices"})
 
       extracts = [create(:extract, data: {"choices"=>"B"}), create(:extract, data: {"choices"=>"C"})]
-      reduction = create :subject_reduction, store: ["A", "B"]
+      reduction = create :subject_reduction, store: { "items" => ["A", "B"] }
 
       expect(running_reducer.reduction_data_for(extracts, reduction)).to eq(3)
       expect(running_reducer.reduction_data_for([extracts[0]], reduction)).to eq(3)

--- a/spec/models/reducers/unique_count_reducer_spec.rb
+++ b/spec/models/reducers/unique_count_reducer_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Reducers::UniqueCountReducer do
   def unwrap(reduction)
-    reduction['_default']
+    reduction[0][:data]
   end
 
   let(:reducer) { described_class.new(config: {"field" => "choices"}) }

--- a/spec/models/reducers/unique_count_reducer_spec.rb
+++ b/spec/models/reducers/unique_count_reducer_spec.rb
@@ -31,7 +31,7 @@ describe Reducers::UniqueCountReducer do
   end
 
   it 'counts unique things' do
-    expect(reducer.reduction_data_for(extracts, nil)).to eq(2)
+    expect(reducer.reduce_into(extracts, create(:subject_reduction)).data).to eq(2)
   end
 
   describe 'aggregation modes' do
@@ -41,10 +41,10 @@ describe Reducers::UniqueCountReducer do
       extracts = [create(:extract, data: {"choices"=>"B"}), create(:extract, data: {"choices"=>"C"})]
       reduction = create :subject_reduction, store: {}
 
-      expect(default_reducer.reduction_data_for(extracts, reduction)).to eq(2)
+      expect(default_reducer.reduce_into(extracts, reduction).data).to eq(2)
 
       reduction.store = {}
-      expect(default_reducer.reduction_data_for([extracts[0]], reduction)).to eq(1)
+      expect(default_reducer.reduce_into([extracts[0]], reduction).data).to eq(1)
     end
 
     it 'works correctly in running aggregation mode' do
@@ -53,8 +53,8 @@ describe Reducers::UniqueCountReducer do
       extracts = [create(:extract, data: {"choices"=>"B"}), create(:extract, data: {"choices"=>"C"})]
       reduction = create :subject_reduction, store: { "items" => ["A", "B"] }
 
-      expect(running_reducer.reduction_data_for(extracts, reduction)).to eq(3)
-      expect(running_reducer.reduction_data_for([extracts[0]], reduction)).to eq(3)
+      expect(running_reducer.reduce_into(extracts, reduction).data).to eq(3)
+      expect(running_reducer.reduce_into([extracts[0]], reduction).data).to eq(3)
     end
   end
 end

--- a/spec/models/reducers/unique_count_reducer_spec.rb
+++ b/spec/models/reducers/unique_count_reducer_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Reducers::UniqueCountReducer do
-  def unwrap(reduction)
-    reduction[0][:data]
-  end
-
   let(:reducer) { described_class.new(config: {"field" => "choices"}) }
   let(:extracts) {
     [
@@ -35,7 +31,7 @@ describe Reducers::UniqueCountReducer do
   end
 
   it 'counts unique things' do
-    expect(unwrap(reducer.process(extracts))).to eq(2)
+    expect(reducer.reduction_data_for(extracts, nil)).to eq(2)
   end
 
   describe 'aggregation modes' do


### PR DESCRIPTION
Right now all of our reducers always receive all relevant extracts. This can be quite a lot of data, especially when looking at UserReductions because while most subjects are retired after at most 100 classifications, a user can perform hundreds, thousands, or even tens of thousands of classifications in a given workflow. This PR adds "running reduction" or "online reduction" that can be enabled on a per-reducer basis, affecting the way that it receives extracts and the way it handles them. 

- [x] add a store field to reductions for scratch data
- [x] thread a store field back with reductions to update the reduction store
- [x] add a field to reducer to indicate default mode / running mode
- [x] create a table to track reduction/extract relationships
- [x] thread existing reductions through existing reduction code
- [x] thread novel extracts through existing reduction code
- [x] synchronization mechanism to keep multiple jobs running at once
- [x] new built-ins on reducer base class
- [x] figure out how running aggregations work with filters and grouping
- [x] code to perform full reduction if update occurs or no reduction exists
- [x] consensus reducer
- [x] count reducer
- [x] first extract reducer
- [x] stats reducer
- [x] summary stats reducer
- [x] unique count reducer
- [x] track which extracts already are part of a reduction
- [x] filter out extracts which are already part of a given reduction when reducing
- [x] when an extract is updated, purge its related reductions (any reduction that has consumed it)