### PR TITLE
Keep fetching unique until fully done

### DIFF
--- a/app/workers/fetch_classifications_worker.rb
+++ b/app/workers/fetch_classifications_worker.rb
@@ -15,7 +15,7 @@ class FetchClassificationsWorker
     @@FetchForUser
   end
 
-  sidekiq_options unique: :until_executing unless Rails.env.test?
+  sidekiq_options unique: :until_executed unless Rails.env.test?
 
   def perform(workflow_id, object_id, object_type)
     light = Stoplight("fetch-classifications-#{workflow_id}-#{object_type}") do


### PR DESCRIPTION
At the moment fetching is unique until a worker picks up the job: no duplicates in the queue, but this does leave the possibility for two fetch workers to be running (with the same parameters) at the same time.

This PR changes it so that it's uniqued until the job is completed. In the Fetch worker case, this won't miss any new data (since that'd be coming through on the stream) so this is fine.