### PR TITLE
let workflows be paused or disabled

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -49,6 +49,28 @@ class WorkflowsController < ApplicationController
     respond_with @workflow
   end
 
+  def activate
+    authorize workflow
+    workflow.activate!
+
+    respond_with workflow
+  end
+
+  def pause
+    authorize workflow
+    workflow.paused!
+
+    respond_with workflow
+  end
+
+  def disable
+    authorize workflow
+    workflow.disabled!
+
+    respond_with workflow
+  end
+
+
   def update
     authorize workflow
 

--- a/app/models/extractor.rb
+++ b/app/models/extractor.rb
@@ -38,7 +38,11 @@ class Extractor < ApplicationRecord
       end
     end
 
-    light.run
+    if workflow&.active?
+      light.run
+    elsif workflow&.paused?
+      workflow.pending_classifications << classification
+    end
   end
 
   def extract_data_for(classification)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,10 @@ Rails.application.routes.draw do
     resources :data_requests
   end
 
+  post 'workflows/:workflow_id/activate', to: 'workflows#activate'
+  post 'workflows/:workflow_id/pause', to: 'workflows#pause'
+  post 'workflows/:workflow_id/disable', to: 'workflows#disable'
+
   get 'workflows/:workflow_id/extractors/:extractor_key/extracts', to: 'extracts#index'
   put 'workflows/:workflow_id/extractors/:extractor_key/extracts', to: 'extracts#update', defaults: { format: :json }
 

--- a/db/migrate/20180409150808_add_status_to_workflow.rb
+++ b/db/migrate/20180409150808_add_status_to_workflow.rb
@@ -1,0 +1,5 @@
+class AddStatusToWorkflow < ActiveRecord::Migration[5.1]
+  def change
+    add_column :workflows, :status, :integer, null: false, default: 1
+  end
+end

--- a/db/migrate/20180409152057_create_join_table_workflows_classifications.rb
+++ b/db/migrate/20180409152057_create_join_table_workflows_classifications.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableWorkflowsClassifications < ActiveRecord::Migration[5.1]
+  def change
+    create_join_table :workflows, :classifications, table_name: :pending_classifications do |t|
+      t.index :workflow_id
+      t.index :classification_id
+    end
+  end
+end

--- a/db/migrate/20180410101028_add_foreign_keys_to_pending_classifications.rb
+++ b/db/migrate/20180410101028_add_foreign_keys_to_pending_classifications.rb
@@ -1,0 +1,6 @@
+class AddForeignKeysToPendingClassifications < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key "pending_classifications", "workflows", on_delete: :cascade
+    add_foreign_key "pending_classifications", "classifications", on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180410094538) do
+ActiveRecord::Schema.define(version: 20180410101028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -245,6 +245,8 @@ ActiveRecord::Schema.define(version: 20180410094538) do
   add_foreign_key "extracts_subject_reductions", "subject_reductions", on_delete: :cascade
   add_foreign_key "extracts_user_reductions", "extracts", on_delete: :cascade
   add_foreign_key "extracts_user_reductions", "user_reductions", on_delete: :cascade
+  add_foreign_key "pending_classifications", "classifications", on_delete: :cascade
+  add_foreign_key "pending_classifications", "workflows", on_delete: :cascade
   add_foreign_key "reducers", "workflows"
   add_foreign_key "subject_actions", "subjects"
   add_foreign_key "subject_actions", "workflows"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,6 +94,13 @@ ActiveRecord::Schema.define(version: 20180410094538) do
     t.index ["user_reduction_id", "extract_id"], name: "eur_covering_2"
   end
 
+  create_table "pending_classifications", id: false, force: :cascade do |t|
+    t.bigint "workflow_id", null: false
+    t.bigint "classification_id", null: false
+    t.index ["classification_id"], name: "index_pending_classifications_on_classification_id"
+    t.index ["workflow_id"], name: "index_pending_classifications_on_workflow_id"
+  end
+
   create_table "reducers", force: :cascade do |t|
     t.bigint "workflow_id"
     t.string "key", null: false
@@ -225,6 +232,7 @@ ActiveRecord::Schema.define(version: 20180410094538) do
     t.boolean "public_extracts", default: false, null: false
     t.boolean "public_reductions", default: false, null: false
     t.integer "rules_applied", default: 0, null: false
+    t.integer "status", default: 1, null: false
   end
 
   add_foreign_key "classifications", "subjects"

--- a/spec/models/extractors/blank_extractor_spec.rb
+++ b/spec/models/extractors/blank_extractor_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Extractors::BlankExtractor do
-  let(:extractor) { described_class.new(key: 'blanco', config: {'task_key' => task_key}) }
+  let(:workflow){ create :workflow }
+  let(:extractor) { described_class.new(key: 'blanco', config: {'task_key' => task_key}, workflow_id: workflow.id) }
   let(:task_key) { 'T1' }
   let(:blank_annotations) { [{'task' => task_key, 'value' => []}] }
   let(:present_annotations) do

--- a/spec/models/extractors/external_extractor_spec.rb
+++ b/spec/models/extractors/external_extractor_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Extractors::ExternalExtractor do
   let(:subject){ create :subject }
+  let(:workflow){ create :workflow }
   let(:classification) do
     Classification.new(
       "id" => "12329",
@@ -25,7 +26,7 @@ describe Extractors::ExternalExtractor do
   end
 
   it 'posts the classification to a foreign API' do
-    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"})
+    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"}, workflow_id: workflow.id)
     extractor.process(classification)
 
     expect(a_request(:post, "example.org/post/classification/here")
@@ -34,7 +35,7 @@ describe Extractors::ExternalExtractor do
   end
 
   it 'stores the returned data as an extract' do
-    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"})
+    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"}, workflow_id: workflow.id)
     result = extractor.process(classification)
     expect(result).to eq(response_data)
   end
@@ -43,13 +44,13 @@ describe Extractors::ExternalExtractor do
     stub_request(:post, "http://example.org/post/classification/here").
       to_return(status: 204, body: "", headers: {})
 
-    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"})
+    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"}, workflow_id: workflow.id)
     result = extractor.process(classification)
     expect(result).to eq(Extractor::NoData)
   end
 
   it 'does not post if no url is configured' do
-    extractor = described_class.new(key: "ext")
+    extractor = described_class.new(key: "ext", workflow_id: workflow.id)
 
     expect do
       extractor.process(classification)

--- a/spec/models/extractors/pluck_field_extractor_spec.rb
+++ b/spec/models/extractors/pluck_field_extractor_spec.rb
@@ -27,14 +27,14 @@ describe Extractors::PluckFieldExtractor do
     end
 
     it 'processes a classification for a single key' do
-      simple = described_class.new(key: "s", config: {"field_map" => { "whodunit" => "$.user_id" }})
+      simple = described_class.new(key: "s", config: {"field_map" => { "whodunit" => "$.user_id" }}, workflow: workflow)
       result = simple.process(classification)
 
       expect(result.blank?).to be(false)
       expect(result).to be_a(Hash)
       expect(result["whodunit"]).to eq(1234)
 
-      complex = described_class.new(key: "c", config: { "field_map" => { "how_fast" => "$.subject.metadata.shutter_speed"}})
+      complex = described_class.new(key: "c", config: { "field_map" => { "how_fast" => "$.subject.metadata.shutter_speed"}}, workflow: workflow)
       result = complex.process(classification)
 
       expect(result.blank?).to be(false)
@@ -47,7 +47,7 @@ describe Extractors::PluckFieldExtractor do
       extractor = described_class.new(key: "c", config: { "field_map" => {
         "whodunit" => "$.user_id",
         "how_fast" => "$.subject.metadata.shutter_speed"
-      }})
+      }}, workflow: workflow)
 
       result = extractor.process(classification)
       expect(result.blank?).to be(false)
@@ -58,12 +58,12 @@ describe Extractors::PluckFieldExtractor do
     end
 
     it 'throws an error if the path is not matched' do
-      empty = described_class.new(key: "e", config: {"field_map" => {"cantfind" => "$.missing_element"}})
+      empty = described_class.new(key: "e", config: {"field_map" => {"cantfind" => "$.missing_element"}}, workflow: workflow)
       expect{empty.process(classification)}.to raise_error(Extractors::PluckFieldExtractor::FailedMatch)
     end
 
     it 'ignores errors if we insist' do
-      empty = described_class.new(key: "e", config: {"field_map" => {"cantfind" => "$.missing_element"}, "if_missing" => "ignore"})
+      empty = described_class.new(key: "e", config: {"field_map" => {"cantfind" => "$.missing_element"}, "if_missing" => "ignore"}, workflow: workflow)
       result = empty.process(classification)
 
       expect(result).to be_a(Hash)

--- a/spec/models/extractors/question_extractor_spec.rb
+++ b/spec/models/extractors/question_extractor_spec.rb
@@ -8,7 +8,8 @@ describe Extractors::QuestionExtractor do
     }
   end
 
-  subject(:extractor) { described_class.new(key: "s") }
+  let(:workflow){ create :workflow }
+  subject(:extractor) { described_class.new(key: "s", workflow_id: workflow.id) }
 
   describe '#process' do
     it 'extracts a value correctly' do
@@ -43,7 +44,7 @@ describe Extractors::QuestionExtractor do
       annotations = []
       classification = Classification.new("annotations" => annotations, "links" => {"workflow" => "1021"})
 
-      extractor = described_class.new(config: {"if_missing" => "ignore"})
+      extractor = described_class.new(config: {"if_missing" => "ignore"}, workflow_id: workflow.id)
       expect(extractor.process(classification)).to eq({})
     end
   end

--- a/spec/models/extractors/survey_extractor_spec.rb
+++ b/spec/models/extractors/survey_extractor_spec.rb
@@ -11,12 +11,13 @@ describe Extractors::SurveyExtractor do
   end
 
   let(:annotations) { [make_annotation("OTHER")] }
+  let(:workflow){ create :workflow }
 
   let(:classification) do
     Classification.new(annotations: annotations)
   end
 
-  subject(:extractor) { described_class.new(key: 's') }
+  subject(:extractor) { described_class.new(key: 's', workflow_id: workflow.id) }
 
   describe '#process' do
     it 'can ignore missing task' do

--- a/spec/models/extractors/who_extractor_spec.rb
+++ b/spec/models/extractors/who_extractor_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Extractors::WhoExtractor do
-  let(:extractor){ described_class.new(key: "s") }
+  let(:workflow){ create :workflow }
+  let(:extractor){ described_class.new(key: "s", workflow_id: workflow.id) }
   let(:classification) { build :classification, user_id: 5 }
 
   it 'gives the user who performed the classification' do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -3,6 +3,33 @@ require 'rails_helper'
 RSpec.describe Workflow, type: :model do
   let(:workflow) { Workflow.new }
 
+  describe 'activate!' do
+    it 'activates the workflow' do
+      paused_workflow = create :workflow, status: 'paused'
+      paused_workflow.activate!
+
+      expect(paused_workflow.active?).to be(true)
+    end
+
+    it 'queues up pending classifications if any existed' do
+      subject = create :subject
+      paused_workflow = create :workflow, status: 'paused'
+      paused_workflow.pending_classifications << create(:classification, workflow_id: paused_workflow.id, subject_id: subject.id)
+
+      expect { paused_workflow.activate! }.
+        to change(ExtractWorker.jobs, :size).by(1)
+    end
+
+    it 'leaves no pending classifications' do
+      subject = create :subject
+      paused_workflow = create :workflow, status: 'paused'
+      paused_workflow.pending_classifications << create(:classification, workflow_id: paused_workflow.id, subject_id: subject.id)
+      paused_workflow.activate!
+
+      expect(paused_workflow.pending_classifications).to be_empty
+    end
+  end
+
   describe 'public_data?' do
     describe 'public extracts' do
       it 'is true' do


### PR DESCRIPTION
Related to #141 

I'm not sure whether we actually need to add this check to the reduction, rules, or actions steps. once the extracts stop coming in, the reductions and rules and actions will stop as well in time