### PR TITLE
Fixes timestamps in CSV exports

### DIFF
--- a/app/models/exporters/csv_exporter.rb
+++ b/app/models/exporters/csv_exporter.rb
@@ -52,6 +52,7 @@ module Exporters
         when String then item
         when Array then item.to_json
         when Hash then item.to_json
+        when DateTime, ActiveSupport::TimeWithZone then item
       end
     end
 

--- a/spec/models/exporters/csv_extract_exporter_spec.rb
+++ b/spec/models/exporters/csv_extract_exporter_spec.rb
@@ -84,5 +84,8 @@ describe Exporters::CsvExtractExporter do
     expect(row).to include("")
     expect(row).not_to include("val3")
     expect(row).to include(workflow.id)
+    expect(row).to include(sample.classification_at)
+    expect(row).to include(sample.updated_at)
+    expect(row).to include(sample.created_at)
   end
 end


### PR DESCRIPTION
`DateTime` and `ActiveSupport::TimeWithZone` are now included when the item type is checked by the CsvExporter.

Fixes #293 