### PR TITLE
Allow ignoring empty extracts

### DIFF
--- a/app/models/reducers/consensus_reducer.rb
+++ b/app/models/reducers/consensus_reducer.rb
@@ -1,10 +1,13 @@
 module Reducers
   class ConsensusReducer < Reducer
+    config_field :ignore_empty_extracts, default: false
+
     def reduce_into(extractions, reduction)
       store_value = reduction.store || {}
       counter = CountingHash.new(store_value)
 
       extractions.each do |extraction|
+        next if ignore_empty_extracts && extraction.data.blank?
         counter.increment(extraction.data.keys.sort.join("+"))
       end
 

--- a/spec/models/reducers/consensus_reducer_spec.rb
+++ b/spec/models/reducers/consensus_reducer_spec.rb
@@ -61,5 +61,14 @@ describe Reducers::ConsensusReducer do
       expect(result.data).to include({"most_likely" => "ZEBRA"})
       expect(result.data).to include({"num_votes" => 5})
     end
+
+    context 'empty extracts' do
+      it 'can ignore them' do
+        reducer.ignore_empty_extracts = true
+        extracts = build_extracts([[], [], ["1"]])
+        expect(reducer.reduce_into(extracts, build(:subject_reduction)).data)
+          .to include({"most_likely" => "1", "num_votes" => 1, "agreement" => 1.0})
+      end
+    end
   end
 end


### PR DESCRIPTION
For Scribes of the Cairo Geniza, there are three questions which ask whether something is formal or informal (for the three different languages in the project). In the reduction, we want to collapse that down to a single "formal or not" answer. But two of three questions were skipped, which produce extracts with a data of `{}`. Which then get mapped to `extraction.data.keys.sort.join("+") --> ""`. Which means that there are always two votes for `""` in addition to one vote for formal or informal. Which means that the consensus will always be `""`. This PR fixes that behaviour.