### PR TITLE
Only continue pipeline if changes were committed

### DIFF
--- a/app/controllers/subject_reductions_controller.rb
+++ b/app/controllers/subject_reductions_controller.rb
@@ -12,11 +12,14 @@ class SubjectReductionsController < ApplicationController
                                                 subject_id: subject.id,
                                                 subgroup: subgroup)
     authorize reduction
-    reduction.update! reduction_params
 
-    CheckRulesWorker.perform_async(workflow.id, subject.id) if workflow.configured?
+    if reduction.data != reduction_params[:data]
+      reduction.update! reduction_params
 
-    workflow.webhooks.process(:updated_reduction, data) if workflow.subscribers?
+      CheckRulesWorker.perform_async(workflow.id, subject.id) if workflow.configured?
+
+      workflow.webhooks.process(:updated_reduction, data) if workflow.subscribers?
+    end
 
     render json: reduction
   end

--- a/app/controllers/user_reductions_controller.rb
+++ b/app/controllers/user_reductions_controller.rb
@@ -12,11 +12,12 @@ class UserReductionsController < ApplicationController
                                                 user_id: user_id,
                                                 subgroup: subgroup)
     authorize reduction
-    reduction.update! reduction_params
 
-    CheckRulesWorker.perform_async(workflow.id, user_id) if workflow.configured?
-
-    workflow.webhooks.process(:updated_reduction, data) if workflow.subscribers?
+    if reduction.data != reduction_params[:data]
+      reduction.update! reduction_params
+      CheckRulesWorker.perform_async(workflow.id, user_id) if workflow.configured?
+      workflow.webhooks.process(:updated_reduction, data) if workflow.subscribers?
+    end
 
     render json: reduction
   end

--- a/spec/controllers/extracts_controller_spec.rb
+++ b/spec/controllers/extracts_controller_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe ExtractsController, type: :controller do
   describe 'PUT #update' do
     let(:subject) { Subject.create! }
 
+    before { allow(ReduceWorker).to receive(:perform_async) }
+
     it 'creates a new extract' do
       put :update, as: :json,
           params: {workflow_id: workflow.id, extractor_key: extractor.key},
@@ -56,6 +58,30 @@ RSpec.describe ExtractsController, type: :controller do
       expect(response).to have_http_status(:success)
       expect(Extract.count).to eq(1)
       expect(Extract.first.data).to eq("foo" => 2)
+      expect(ReduceWorker).to have_received(:perform_async).with(workflow.id, subject.id, nil)
+    end
+
+    it 'does not trigger reducers if nothing changed' do
+      Extract.create!(workflow_id: workflow.id,
+                      subject_id: subject.id,
+                      extractor_key: extractor.key,
+                      classification_id: 123,
+                      classification_at: 5.days.ago,
+                      data: {"foo" => 1})
+
+      put :update, as: :json,
+          params: {workflow_id: workflow.id, extractor_key: extractor.key},
+          body: {
+            extract: {
+              classification_id: 123,
+              classification_at: Time.now,
+              subject_id: subject.id,
+              user_id: nil,
+              data: {"foo" => 1}
+            }
+          }.to_json
+
+      expect(ReduceWorker).not_to have_received(:perform_async)
     end
   end
 end

--- a/spec/controllers/user_reductions_controller_spec.rb
+++ b/spec/controllers/user_reductions_controller_spec.rb
@@ -3,13 +3,15 @@ require 'ostruct'
 
 describe UserReductionsController, :type => :controller do
     let(:workflow) { create :workflow }
+    let(:reducer1) { create :external_reducer, workflow: workflow, key: 'r', topic: :reduce_by_user }
+    let(:reducer2) { create :external_reducer, workflow: workflow, key: 's', topic: :reduce_by_user }
     let(:user1_id) { 1234 }
     let(:user2_id) { 2345 }
     let(:reductions) {
     [
-      create(:user_reduction, workflow: workflow, user_id: user1_id, reducer_key: 'r', data: '1'),
-      create(:user_reduction, workflow: workflow, user_id: user1_id, reducer_key: 's', data: '2'),
-      create(:user_reduction, workflow: workflow, user_id: user2_id, reducer_key: 'r', data: '3')
+      create(:user_reduction, workflow: workflow, user_id: user1_id, reducer_key: reducer1.key, data: {'1' => 1}),
+      create(:user_reduction, workflow: workflow, user_id: user1_id, reducer_key: reducer2.key, data: {'2' => 1}),
+      create(:user_reduction, workflow: workflow, user_id: user2_id, reducer_key: reducer1.key, data: {'3' => 1})
     ]
   }
 
@@ -31,61 +33,71 @@ describe UserReductionsController, :type => :controller do
   end
 
   describe '#update' do
-    it 'updates an existing reduction' do
-      r = reductions
+    before { allow(CheckRulesWorker).to receive(:perform_async) }
 
-      #we don't have any real reducers configured, so work around that
-      allow_any_instance_of(UserReductionsController).to receive(:reducer).and_return(
-        OpenStruct.new(key: 'r')
-      )
+    it 'updates an existing reduction' do
+      reductions
 
       post :update, params: {
         workflow_id: workflow.id,
-        reducer_key: 'r',
+        reducer_key: reducer1.key,
         reduction: {
           user_id: user1_id,
           subgroup: '_default',
           data: { blah: 10 }
         }
-      }
+      }, as: :json
 
       updated = UserReduction.find_by(
         workflow_id: workflow.id,
-        reducer_key: 'r',
+        reducer_key: reducer1.key,
         user_id: user1_id
       )
 
       expect(UserReduction.count).to eq(3)
-      expect(updated.id).to eq(r[0].id)
-      expect(updated.data).to eq("blah" => "10")
+      expect(updated.id).to eq(reductions[0].id)
+      expect(updated.data).to eq("blah" => 10)
+      expect(CheckRulesWorker).to have_received(:perform_async).with(workflow.id, user1_id).once
     end
 
     it 'creates new reductions if needed' do
       reductions
 
-      #we don't have any real reducers configured, so work around that
-      allow_any_instance_of(UserReductionsController).to receive(:reducer).and_return(
-        OpenStruct.new(key: 'q')
-      )
-
       post :update, params: {
         workflow_id: workflow.id,
-        reducer_key: 'q',
+        reducer_key: reducer2.key,
         reduction: {
-          user_id: user1_id,
+          user_id: user2_id,
           subgroup: '_default',
           data: { blah: 10 }
         }
-      }
+      }, as: :json
 
       updated = UserReduction.find_by(
         workflow_id: workflow.id,
-        reducer_key: 'q',
-        user_id: user1_id
+        reducer_key: reducer2.key,
+        user_id: user2_id
       )
 
       expect(UserReduction.count).to eq(4)
-      expect(updated.data).to eq("blah" => "10")
+      expect(updated.data).to eq("blah" => 10)
+      expect(CheckRulesWorker).to have_received(:perform_async).with(workflow.id, user2_id).once
+    end
+
+    it 'does not check rules if nothing changed' do
+      reductions
+
+      post :update, params: {
+        workflow_id: workflow.id,
+        reducer_key: reducer1.key,
+        reduction: {
+          user_id: user1_id,
+          subgroup: '_default',
+          data: reductions[0].data
+        }
+      }, as: :json
+
+      expect(CheckRulesWorker).not_to have_received(:perform_async)
     end
   end
 


### PR DESCRIPTION
@camallen noticed that some projects were sending a large amount of retirement API calls in a short period of time. This is caused when a project with an external extractor or reducer just resends all of their data, rather than only sending data that's actually changed. Obviously, I'll be following up with the identified projects, but we also want to guard against this on the backend, I think.