### PR TITLE
Reducible 2: The Copying

### DIFF
--- a/db/migrate/20180607150016_copy_workflow_to_reducible.rb
+++ b/db/migrate/20180607150016_copy_workflow_to_reducible.rb
@@ -1,0 +1,7 @@
+class CopyWorkflowToReducible < ActiveRecord::Migration[5.1]
+  def change
+    Reducer.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
+    UserReduction.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
+    SubjectReduction.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180606193006) do
+ActiveRecord::Schema.define(version: 20180607150016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Now that reducible id and type are being set, let's copy the existing workflow_ids to the reducible_id field and set the type to "workflow". When we're all sync'd up, I can start switching pieces over to use that field instead.