### PR TITLE
Reducible 3: Workers of the World, Reduce!

### DIFF
--- a/app/controllers/extracts_controller.rb
+++ b/app/controllers/extracts_controller.rb
@@ -17,7 +17,7 @@ class ExtractsController < ApplicationController
         extract.update! extract_params
       end
 
-      ReduceWorker.perform_async(workflow.id, subject.id, user_id) if workflow.configured?
+      ReduceWorker.perform_async(workflow.id, "Workflow", subject.id, user_id) if workflow.configured?
 
       workflow.webhooks.process(:updated_extraction, data) if workflow.subscribers?
     end

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -13,7 +13,7 @@ class ClassificationPipeline
 
   def process(classification)
     extract(classification)
-    reduce(classification.workflow_id, classification.subject_id, classification.user_id)
+    reduce(classification.workflow_id, Workflow, classification.subject_id, classification.user_id)
     check_rules(classification.workflow_id, classification.subject_id, classification.user_id)
   end
 
@@ -68,11 +68,13 @@ class ClassificationPipeline
     raise
   end
 
-  def reduce(workflow_id, subject_id, user_id, extract_ids=[])
+  # def reduce(workflow_id, subject_id, user_id, extract_ids=[])
+  def reduce(reducible_id, reducible_class, subject_id, user_id, extract_ids=[])
     return [] unless reducers&.present?
     retries ||= 2
 
-    filter = { workflow_id: workflow_id, subject_id: subject_id, user_id: user_id }
+    # TODO: Update filter when Fetchers are updated
+    filter = { workflow_id: reducible_id, subject_id: subject_id, user_id: user_id }
     extract_fetcher = ExtractFetcher.new(filter).including(extract_ids)
     reduction_fetcher = ReductionFetcher.new(filter)
 

--- a/app/workers/extract_worker.rb
+++ b/app/workers/extract_worker.rb
@@ -17,7 +17,7 @@ class ExtractWorker
 
     if extracts.present?
       ids = extracts.map(&:id)
-      ReduceWorker.perform_async(classification.workflow_id, classification.subject_id, classification.user_id, ids)
+      ReduceWorker.perform_async(classification.workflow_id, "Workflow", classification.subject_id, classification.user_id, ids)
 
       if workflow.subscribers?
         extracts.each do |extract|

--- a/db/migrate/20180607150016_copy_workflow_to_reducible.rb
+++ b/db/migrate/20180607150016_copy_workflow_to_reducible.rb
@@ -1,0 +1,7 @@
+class CopyWorkflowToReducible < ActiveRecord::Migration[5.1]
+  def change
+    Reducer.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
+    UserReduction.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
+    SubjectReduction.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180606193006) do
+ActiveRecord::Schema.define(version: 20180607150016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/extracts_controller_spec.rb
+++ b/spec/controllers/extracts_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ExtractsController, type: :controller do
       expect(response).to have_http_status(:success)
       expect(Extract.count).to eq(1)
       expect(Extract.first.data).to eq("foo" => 2)
-      expect(ReduceWorker).to have_received(:perform_async).with(workflow.id, subject.id, nil)
+      expect(ReduceWorker).to have_received(:perform_async).with(workflow.id, "Workflow", subject.id, nil)
     end
 
     it 'does not trigger reducers if nothing changed' do

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -121,7 +121,7 @@ describe ClassificationPipeline do
     # build a simplified pipeline to reduce these extracts
     reducer = build(:stats_reducer, key: 's', grouping: {"field_name" => "g.classroom"}, workflow_id: workflow.id)
     pipeline = described_class.new(nil, [reducer], nil, nil)
-    pipeline.reduce(workflow.id, subject.id, nil)
+    pipeline.reduce(workflow.id, "Workflow", subject.id, nil)
 
     expect(SubjectReduction.count).to eq(2)
     expect(SubjectReduction.where(subgroup: 1).first.data).to include({"LN" => 2, "TGR" => 1})
@@ -141,7 +141,7 @@ describe ClassificationPipeline do
     reducer = build(:stats_reducer, key: 's', topic: Reducer.topics[:reduce_by_user], workflow_id: workflow.id)
 
     pipeline = described_class.new(nil, [reducer], nil, nil)
-    pipeline.reduce(workflow.id, nil, 1234)
+    pipeline.reduce(workflow.id, "Workflow", nil, 1234)
 
     expect(UserReduction.count).to eq(1)
     expect(UserReduction.first.user_id).to eq(1234)


### PR DESCRIPTION
Updates the ExtractWorker and ReduceWorker along with the places they are called from: ClassificationPipeline and ExtractController. Also updates specs.

Went with a string version of the class because the class itself didn't survive in the Kinesis specs because of the `.perform_async` in there along the way.

This is a branch off of the unmerged `reducible-2` branch since it requires those changes. 

See https://github.com/zooniverse/caesar/issues/334 for details.