### PR TITLE
Reducible 6: A Scope to a Kill

### DIFF
--- a/app/controllers/reducers_controller.rb
+++ b/app/controllers/reducers_controller.rb
@@ -16,7 +16,7 @@ class ReducersController < ApplicationController
 
   def new
     authorize workflow
-    @reducer = Reducer.of_type(params[:type]).new(workflow: workflow)
+    @reducer = Reducer.of_type(params[:type]).new(reducible: workflow)
   end
 
   def edit
@@ -37,7 +37,7 @@ class ReducersController < ApplicationController
     if(@reducer.grouping['field_name'].blank?)
       @reducer.grouping = {}
     end
-
+    
     if @reducer.save
       flash[:success] = 'Reducer created'
     else
@@ -87,6 +87,6 @@ class ReducersController < ApplicationController
       *klass.configuration_fields.keys,
       filters: {},
       grouping: {},
-    ).merge(workflow_id: workflow.id)
+    ).merge(reducible_id: workflow.id, reducible_type: "Workflow")
   end
 end

--- a/app/controllers/subject_reductions_controller.rb
+++ b/app/controllers/subject_reductions_controller.rb
@@ -7,7 +7,8 @@ class SubjectReductionsController < ApplicationController
   end
 
   def update
-    reduction = SubjectReduction.find_or_initialize_by(workflow_id: workflow.id,
+    reduction = SubjectReduction.find_or_initialize_by(reducible_id: workflow.id,
+                                                reducible_type: "Workflow",
                                                 reducer_key: reducer.key,
                                                 subject_id: subject.id,
                                                 subgroup: subgroup)

--- a/app/controllers/subject_reductions_controller.rb
+++ b/app/controllers/subject_reductions_controller.rb
@@ -1,6 +1,6 @@
 class SubjectReductionsController < ApplicationController
   def index
-    reductions = policy_scope(SubjectReduction).where(workflow_id: params[:workflow_id], subject_id: params[:subject_id])
+    reductions = policy_scope(SubjectReduction).where(reducible_id: params[:workflow_id], subject_id: params[:subject_id])
     reductions = reductions.where(reducer_key: params[:reducer_key]) if params.key?(:reducer_key)
 
     render json: reductions

--- a/app/controllers/user_reductions_controller.rb
+++ b/app/controllers/user_reductions_controller.rb
@@ -7,7 +7,8 @@ class UserReductionsController < ApplicationController
   end
 
   def update
-    reduction = UserReduction.find_or_initialize_by(workflow_id: workflow.id,
+    reduction = UserReduction.find_or_initialize_by(reducible_id: workflow.id,
+                                                reducible_type: "Workflow",
                                                 reducer_key: reducer.key,
                                                 user_id: user_id,
                                                 subgroup: subgroup)

--- a/app/models/belongs_to_reducible.rb
+++ b/app/models/belongs_to_reducible.rb
@@ -3,11 +3,15 @@ module BelongsToReducible
 
   included do
     belongs_to :reducible, polymorphic: true, optional: true
-    before_save :set_reducible
+    before_save :set_workflow
   end
 
   def set_reducible
     self.reducible_id = workflow.id
     self.reducible_type = "workflow" 
+  end
+
+  def set_workflow
+    self.workflow_id = reducible.id
   end
 end

--- a/app/models/belongs_to_reducible.rb
+++ b/app/models/belongs_to_reducible.rb
@@ -8,7 +8,7 @@ module BelongsToReducible
 
   def set_reducible
     self.reducible_id = workflow.id
-    self.reducible_type = "workflow" 
+    self.reducible_type = "Workflow" 
   end
 
   def set_workflow

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -14,7 +14,7 @@ class ClassificationPipeline
 
   def process(classification)
     extract(classification)
-    reduce(classification.workflow_id, classification.subject_id, classification.user_id)
+    reduce(classification.workflow_id, Workflow, classification.subject_id, classification.user_id)
     check_rules(classification.workflow_id, classification.subject_id, classification.user_id)
   end
 

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -87,9 +87,9 @@ class ClassificationPipeline
                 #  { workflow_id: workflow_ids, subject_id: subject_id, user_id: user_id }
              end
 
-    # filter = { workflow_id: reducible_id, subject_id: subject_id, user_id: user_id }
+    reduction_filter = { reducible_id: reducible_id, reducible_type: reducible_class.to_s, subject_id: subject_id, user_id: user_id }
     extract_fetcher = ExtractFetcher.new(filter).including(extract_ids)	     
-    reduction_fetcher = ReductionFetcher.new(filter)
+    reduction_fetcher = ReductionFetcher.new(reduction_filter)
           
     # if we don't need to fetch everything, try not to
     if reducers.all?{ |reducer| reducer.running_reduction? }

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -14,7 +14,7 @@ class ClassificationPipeline
 
   def process(classification)
     extract(classification)
-    reduce(classification.workflow_id, Workflow, classification.subject_id, classification.user_id)
+    reduce(classification.workflow_id, classification.subject_id, classification.user_id)
     check_rules(classification.workflow_id, classification.subject_id, classification.user_id)
   end
 

--- a/app/models/clones_workflow_configuration.rb
+++ b/app/models/clones_workflow_configuration.rb
@@ -15,7 +15,7 @@ class ClonesWorkflowConfiguration < ApplicationOperation
     end
 
     from.reducers.each do |reducer|
-      reducer.class.create!(workflow: to,
+      reducer.class.create!(reducible: to,
                             key: reducer.key,
                             config: reducer.config,
                             grouping: reducer.grouping,

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -35,9 +35,6 @@ class Reducer < ApplicationRecord
     end
   end
 
-  belongs_to :workflow
-
-  validates :workflow, presence: true
   validates :key, presence: true, uniqueness: {scope: [:workflow_id]}
   validates :topic, presence: true
   validates_associated :extract_filter

--- a/app/models/subject_reduction.rb
+++ b/app/models/subject_reduction.rb
@@ -15,7 +15,6 @@ class SubjectReduction < ApplicationRecord
     field :updatedAt, !Types::TimeType, property: :updated_at
   end
 
-  belongs_to :workflow
   belongs_to :subject
   has_and_belongs_to_many_with_deferred_save :extracts
 end

--- a/app/models/user_reduction.rb
+++ b/app/models/user_reduction.rb
@@ -15,6 +15,5 @@ class UserReduction < ApplicationRecord
     field :updatedAt, !Types::TimeType, property: :updated_at
   end
 
-  belongs_to :workflow
   has_and_belongs_to_many_with_deferred_save :extracts
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -66,7 +66,7 @@ class Workflow < ApplicationRecord
   end
 
   has_many :extractors
-  has_many :reducers
+  has_many :reducers, as: :reducible
   has_many :subject_rules
   has_many :user_rules
 
@@ -95,7 +95,7 @@ class Workflow < ApplicationRecord
   def classification_pipeline
     ClassificationPipeline.new(Workflow,
                                extractors,
-                               reducers,
+                               reducible,
                                subject_rules.rank(:row_order),
                                user_rules.rank(:row_order),
                                rules_applied)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -95,7 +95,7 @@ class Workflow < ApplicationRecord
   def classification_pipeline
     ClassificationPipeline.new(Workflow,
                                extractors,
-                               reducible,
+                               reducers,
                                subject_rules.rank(:row_order),
                                user_rules.rank(:row_order),
                                rules_applied)

--- a/app/models/workflow/convert_legacy_reducers_config.rb
+++ b/app/models/workflow/convert_legacy_reducers_config.rb
@@ -12,7 +12,7 @@ class Workflow::ConvertLegacyReducersConfig
 
     config.each do |key, conf|
       reducer = workflow.reducers.find_by(key: key)
-      reducer ||= reducer_type(conf).new(workflow: workflow, key: key)
+      reducer ||= reducer_type(conf).new(reducible: workflow, key: key)
       reducer.config = conf.except("filters", "grouping", "group_by", "type")
       reducer.grouping = conf["grouping"] || {}
       reducer.filters = conf["filters"] || {}

--- a/app/policies/subject_reduction_policy.rb
+++ b/app/policies/subject_reduction_policy.rb
@@ -3,8 +3,12 @@ class SubjectReductionPolicy < ApplicationPolicy
     def resolve
       workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
 
-      scope = self.scope.joins(:workflow).references(:workflows)
-      scope.where(workflow_id: workflow_ids).or(scope.where(workflows: {public_reductions: true}))
+      # This is complicated by the polymorphic relationship's inability to LEFT JOIN.
+      # scope = self.scope.joins(:workflow).references(:workflows)
+      # scope.where(workflow_id: workflow_ids).or(scope.where(workflows: {public_reductions: true}))
+
+      # This doesn't include public reductions
+      scope = self.scope.where(reducible_id: workflow_ids)
     end
   end
 
@@ -14,7 +18,8 @@ class SubjectReductionPolicy < ApplicationPolicy
 
   def update?
     return true if credential.admin?
-    credential.project_ids.include?(record.workflow.project_id)
+    # TODO: Either projects respond to #project_id also or this gets a switch
+    credential.project_ids.include?(record.reducible.project_id)
   end
 
   def destroy?

--- a/app/policies/subject_reduction_policy.rb
+++ b/app/policies/subject_reduction_policy.rb
@@ -12,11 +12,6 @@ class SubjectReductionPolicy < ApplicationPolicy
     update?
   end
 
-  def nested_update?
-    return true if credential.admin?
-    credential.project_ids.include?(record.workflow.project_id)
-  end
-
   def update?
     return true if credential.admin?
     credential.project_ids.include?(record.workflow.project_id)

--- a/app/policies/subject_reduction_policy.rb
+++ b/app/policies/subject_reduction_policy.rb
@@ -1,14 +1,9 @@
 class SubjectReductionPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
-
-      # This is complicated by the polymorphic relationship's inability to LEFT JOIN.
-      # scope = self.scope.joins(:workflow).references(:workflows)
-      # scope.where(workflow_id: workflow_ids).or(scope.where(workflows: {public_reductions: true}))
-
-      # This doesn't include public reductions
-      scope = self.scope.where(reducible_id: workflow_ids)
+      public_workflows = Workflow.where(public_reductions: true).pluck(:id)
+      workflow_ids = (Pundit.policy_scope!(credential, Workflow).pluck(:id) + public_workflows).uniq
+      self.scope.where(reducible_type: 'Workflow', reducible_id: workflow_ids)
     end
   end
 

--- a/app/policies/user_reduction_policy.rb
+++ b/app/policies/user_reduction_policy.rb
@@ -3,8 +3,11 @@ class UserReductionPolicy < ApplicationPolicy
     def resolve
       workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
 
-      scope = self.scope.joins(:workflow).references(:workflows)
-      scope.where(workflow_id: workflow_ids).or(scope.where(workflows: {public_reductions: true}))
+      # scope = self.scope.joins(:workflow).references(:workflows)
+      # scope.where(workflow_id: workflow_ids).or(scope.where(workflows: {public_reductions: true}))
+
+      # Temporary, see subject_reduction_policy.rb
+      scope = self.scope.where(reducible_id: workflow_ids)
     end
   end
 
@@ -14,7 +17,7 @@ class UserReductionPolicy < ApplicationPolicy
 
   def update?
     return true if credential.admin?
-    credential.project_ids.include?(record.workflow.project_id)
+    credential.project_ids.include?(record.reducible.project_id)
   end
 
   def destroy?

--- a/app/policies/user_reduction_policy.rb
+++ b/app/policies/user_reduction_policy.rb
@@ -1,13 +1,9 @@
 class UserReductionPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
-
-      # scope = self.scope.joins(:workflow).references(:workflows)
-      # scope.where(workflow_id: workflow_ids).or(scope.where(workflows: {public_reductions: true}))
-
-      # Temporary, see subject_reduction_policy.rb
-      scope = self.scope.where(reducible_id: workflow_ids)
+      public_workflows = Workflow.where(public_reductions: true).pluck(:id)
+      workflow_ids = (Pundit.policy_scope!(credential, Workflow).pluck(:id) + public_workflows).uniq
+      self.scope.where(reducible_type: 'Workflow', reducible_id: workflow_ids)
     end
   end
 

--- a/app/policies/user_reduction_policy.rb
+++ b/app/policies/user_reduction_policy.rb
@@ -12,11 +12,6 @@ class UserReductionPolicy < ApplicationPolicy
     update?
   end
 
-  def nested_update?
-    return true if credential.admin?
-    credential.project_ids.include?(record.workflow.project_id)
-  end
-
   def update?
     return true if credential.admin?
     credential.project_ids.include?(record.workflow.project_id)

--- a/db/migrate/20180607150016_copy_workflow_to_reducible.rb
+++ b/db/migrate/20180607150016_copy_workflow_to_reducible.rb
@@ -1,7 +1,7 @@
 class CopyWorkflowToReducible < ActiveRecord::Migration[5.1]
   def change
-    Reducer.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
-    UserReduction.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
-    SubjectReduction.in_batches.update_all("reducible_id=workflow_id, reducible_type='workflow'")
+    Reducer.in_batches.update_all("reducible_id=workflow_id, reducible_type='Workflow'")
+    UserReduction.in_batches.update_all("reducible_id=workflow_id, reducible_type='Workflow'")
+    SubjectReduction.in_batches.update_all("reducible_id=workflow_id, reducible_type='Workflow'")
   end
 end

--- a/spec/controllers/reducers_controller_spec.rb
+++ b/spec/controllers/reducers_controller_spec.rb
@@ -6,13 +6,13 @@ describe ReducersController, :type => :controller do
   let(:workflow) { create :workflow }
 
   let(:reducer) do
-    create :external_reducer, workflow: workflow
+    create :external_reducer, reducible: workflow
   end
 
   describe '#index' do
     it 'lists reducers for a workflow' do
-      reducers = [create(:external_reducer, workflow: workflow),
-                  create(:stats_reducer, workflow: workflow)]
+      reducers = [create(:external_reducer, reducible: workflow),
+                  create(:stats_reducer, reducible: workflow)]
       get :index, params: {workflow_id: workflow.id}, format: :json
       json_response = JSON.parse(response.body)
       expect(json_response.map { |i| i["id"] }).to match_array(reducers.map(&:id))

--- a/spec/controllers/subject_reductions_controller_spec.rb
+++ b/spec/controllers/subject_reductions_controller_spec.rb
@@ -3,15 +3,15 @@ require 'ostruct'
 
 describe SubjectReductionsController, :type => :controller do
   let(:workflow) { create :workflow }
-  let(:reducer1) { create :external_reducer, workflow: workflow, key: 'r' }
-  let(:reducer2) { create :external_reducer, workflow: workflow, key: 's' }
+  let(:reducer1) { create :external_reducer, reducible: workflow, key: 'r' }
+  let(:reducer2) { create :external_reducer, reducible: workflow, key: 's' }
   let(:subject1) { create :subject }
   let(:subject2) { create :subject }
   let(:reductions) {
     [
-      create(:subject_reduction, workflow: workflow, subject: subject1, reducer_key: reducer1.key, data: {'1' => 1}),
-      create(:subject_reduction, workflow: workflow, subject: subject1, reducer_key: reducer2.key, data: {'2' => 1}),
-      create(:subject_reduction, workflow: workflow, subject: subject2, reducer_key: reducer1.key, data: {'3' => 1})
+      create(:subject_reduction, reducible: workflow, subject: subject1, reducer_key: reducer1.key, data: {'1' => 1}),
+      create(:subject_reduction, reducible: workflow, subject: subject1, reducer_key: reducer2.key, data: {'2' => 1}),
+      create(:subject_reduction, reducible: workflow, subject: subject2, reducer_key: reducer1.key, data: {'3' => 1})
     ]
   }
 
@@ -54,7 +54,8 @@ describe SubjectReductionsController, :type => :controller do
       }, as: :json
 
       updated = SubjectReduction.find_by(
-        workflow_id: workflow.id,
+        reducible_id: workflow.id,
+        reducible_type: "Workflow",
         reducer_key: 'r',
         subject_id: subject1.id
       )

--- a/spec/controllers/user_reductions_controller_spec.rb
+++ b/spec/controllers/user_reductions_controller_spec.rb
@@ -3,15 +3,15 @@ require 'ostruct'
 
 describe UserReductionsController, :type => :controller do
     let(:workflow) { create :workflow }
-    let(:reducer1) { create :external_reducer, workflow: workflow, key: 'r', topic: :reduce_by_user }
-    let(:reducer2) { create :external_reducer, workflow: workflow, key: 's', topic: :reduce_by_user }
+    let(:reducer1) { create :external_reducer, reducible: workflow, key: 'r', topic: :reduce_by_user }
+    let(:reducer2) { create :external_reducer, reducible: workflow, key: 's', topic: :reduce_by_user }
     let(:user1_id) { 1234 }
     let(:user2_id) { 2345 }
     let(:reductions) {
     [
-      create(:user_reduction, workflow: workflow, user_id: user1_id, reducer_key: reducer1.key, data: {'1' => 1}),
-      create(:user_reduction, workflow: workflow, user_id: user1_id, reducer_key: reducer2.key, data: {'2' => 1}),
-      create(:user_reduction, workflow: workflow, user_id: user2_id, reducer_key: reducer1.key, data: {'3' => 1})
+      create(:user_reduction, reducible: workflow, user_id: user1_id, reducer_key: reducer1.key, data: {'1' => 1}),
+      create(:user_reduction, reducible: workflow, user_id: user1_id, reducer_key: reducer2.key, data: {'2' => 1}),
+      create(:user_reduction, reducible: workflow, user_id: user2_id, reducer_key: reducer1.key, data: {'3' => 1})
     ]
   }
 
@@ -49,7 +49,8 @@ describe UserReductionsController, :type => :controller do
       }, as: :json
 
       updated = UserReduction.find_by(
-        workflow_id: workflow.id,
+        reducible_id: workflow.id,
+        reducible_type: "Workflow",
         reducer_key: reducer1.key,
         user_id: user1_id
       )
@@ -74,7 +75,8 @@ describe UserReductionsController, :type => :controller do
       }, as: :json
 
       updated = UserReduction.find_by(
-        workflow_id: workflow.id,
+        reducible_id: workflow.id,
+        reducible_type: "Workflow",
         reducer_key: reducer2.key,
         user_id: user2_id
       )

--- a/spec/factories/reducer_factory.rb
+++ b/spec/factories/reducer_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   end
 
   factory :reducer do
-    workflow nil
+    reducible nil
     key { generate(:key) }
     config { {} }
 

--- a/spec/factories/reducer_factory.rb
+++ b/spec/factories/reducer_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   end
 
   factory :reducer do
-    reducible nil
+    reducible { create :workflow }
     key { generate(:key) }
     config { {} }
 

--- a/spec/factories/subject_reduction_factory.rb
+++ b/spec/factories/subject_reduction_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :subject_reduction do
-    workflow
+    reducible { build :workflow }
     subject
 
     reducer_key "foo"

--- a/spec/factories/subject_reduction_factory.rb
+++ b/spec/factories/subject_reduction_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :subject_reduction do
-    reducible { build :workflow }
+    reducible { create :workflow }
     subject
 
     reducer_key "foo"

--- a/spec/factories/user_reduction_factory.rb
+++ b/spec/factories/user_reduction_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user_reduction do
-    reducible { build :workflow }
+    reducible { create :workflow }
     user_id 1234
 
     reducer_key "foo"

--- a/spec/factories/user_reduction_factory.rb
+++ b/spec/factories/user_reduction_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user_reduction do
-    workflow
+    reducible { build :workflow }
     user_id 1234
 
     reducer_key "foo"

--- a/spec/graphql/caesar_schema_spec.rb
+++ b/spec/graphql/caesar_schema_spec.rb
@@ -58,7 +58,7 @@ describe CaesarSchema do
       end
 
       it 'does not expose reductions when not logged in' do
-        create :subject_reduction, workflow: workflow, subject: subject, data: {a: 1}
+        create :subject_reduction, reducible: workflow, subject: subject, data: {a: 1}
         expect(result["data"]["workflow"]["subject_reductions"].size).to eq(0)
       end
     end
@@ -78,7 +78,7 @@ describe CaesarSchema do
       end
 
       it 'exposes reductions when not logged in' do
-        create :subject_reduction, workflow: workflow, subject: subject, data: {a: 1}
+        create :subject_reduction, reducible: workflow, subject: subject, data: {a: 1}
         expect(result["data"]["workflow"]["subject_reductions"].size).to eq(1)
       end
 

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -140,7 +140,7 @@ describe ClassificationPipeline do
     create :extract, extractor_key: 's', workflow_id: workflow.id, user_id: 1235, subject_id: subject.id, classification_id: 33333, data: { TGR: 1 }
     create :extract, extractor_key: 's', workflow_id: workflow.id, user_id: 1236, subject_id: subject.id, classification_id: 44444, data: { BR: 1 }
 
-    reducer = build(:stats_reducer, key: 's', topic: Reducer.topics[:reduce_by_user], workflow_id: workflow.id)
+    reducer = build(:stats_reducer, key: 's', topic: Reducer.topics[:reduce_by_user], reducible_id: workflow.id, reducible_type: "workflow")
 
     pipeline = described_class.new(Workflow, nil, [reducer], nil, nil)
     pipeline.reduce(workflow.id, nil, 1234)

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -40,19 +40,18 @@ describe ClassificationPipeline do
     )
   end
 
-  let(:reducers) do
-    [
-      build(:stats_reducer, key: 's'),
-      build(:stats_reducer, key: 'g', grouping: {"field_name" => "s.LK"})
-    ]
-  end
-
   let(:workflow) do
     create(:workflow, project_id: 1,
-                      extractors: [build(:survey_extractor, key: 's', config: {"task_key" => "T1"})],
-                      reducers: reducers) do |w|
+                      extractors: [build(:survey_extractor, key: 's', config: {"task_key" => "T1"})]) do |w|
       create :subject_rule, workflow: w, subject_rule_effects: [build(:subject_rule_effect, config: {reason: "consensus"})]
     end
+  end
+
+  let(:reducers) do
+    [
+      create(:stats_reducer, key: 's', reducible: workflow),
+      create(:stats_reducer, key: 'g', grouping: {"field_name" => "s.LK"}, reducible: workflow)
+    ]
   end
 
   let(:subject) { Subject.create }
@@ -121,9 +120,10 @@ describe ClassificationPipeline do
     create :extract, extractor_key: 'g', workflow_id: workflow.id, subject_id: subject.id, classification_id: 55555, data: { classroom: 2 }
 
     # build a simplified pipeline to reduce these extracts
-    reducer = build(:stats_reducer, key: 's', grouping: {"field_name" => "g.classroom"}, workflow_id: workflow.id)
+    reducer = create(:stats_reducer, key: 's', grouping: {"field_name" => "g.classroom"}, reducible: workflow)
     pipeline = described_class.new(Workflow, nil, [reducer], nil, nil)
     pipeline.reduce(workflow.id, subject.id, nil)
+
 
     expect(SubjectReduction.count).to eq(2)
     expect(SubjectReduction.where(subgroup: 1).first.data).to include({"LN" => 2, "TGR" => 1})

--- a/spec/models/clones_workflow_configuration_spec.rb
+++ b/spec/models/clones_workflow_configuration_spec.rb
@@ -15,8 +15,8 @@ describe ClonesWorkflowConfiguration do
   end
 
   it 'copies reducers' do
-    create :external_reducer, key: 'ext', workflow: workflow
-    create :stats_reducer, key: 'stats', workflow: workflow
+    create :external_reducer, key: 'ext', reducible: workflow
+    create :stats_reducer, key: 'stats', reducible: workflow
 
     copier.copy
 

--- a/spec/models/exporters/csv_subject_reduction_exporter_spec.rb
+++ b/spec/models/exporters/csv_subject_reduction_exporter_spec.rb
@@ -7,7 +7,8 @@ describe Exporters::CsvSubjectReductionExporter do
   let(:sample){
     SubjectReduction.new(
       reducer_key: "x",
-      workflow_id: workflow.id,
+      reducible_id: workflow.id,
+      reducible_type: "Workflow",
       subject_id: subject.id,
       data: {"key1" => "val1", "key2" => "val2", "key5" => {"foo" => "bar"}, "key6" => ["foo", "bar"]}
     )
@@ -20,32 +21,37 @@ describe Exporters::CsvSubjectReductionExporter do
 
     SubjectReduction.new(
       reducer_key: "x",
-      workflow_id: workflow.id,
+      reducible_id: workflow.id,
+      reducible_type: "Workflow",
       subject_id: Subject.create!.id,
       data: {"key2" => "val2"}
     ).save
     SubjectReduction.new(
       reducer_key: "x",
-      workflow_id: workflow.id,
+      reducible_id: workflow.id,
+      reducible_type: "Workflow",
       subject_id: Subject.create!.id,
       data: {"key2" => "val2"}
     ).save
     sample.save
     SubjectReduction.new(
       reducer_key: "x",
-      workflow_id: workflow.id,
+      reducible_id: workflow.id,
+      reducible_type: "Workflow",
       subject_id: Subject.create!.id,
       data: {"key1" => "val1", "key2" => "val2"}
     ).save
     SubjectReduction.new(
       reducer_key: "x",
-      workflow_id: workflow.id,
+      reducible_id: workflow.id,
+      reducible_type: "Workflow",
       subject_id: Subject.create!.id,
       data: {"key1" => "val1", "key3" => "val3"}
     ).save
     SubjectReduction.new(
       reducer_key: "x",
-      workflow_id: create(:workflow).id,
+      reducible_id: create(:workflow).id,
+      reducible_type: "Workflow",
       subject_id: Subject.create!.id,
       data: {"key4" => "val4"}
     ).save

--- a/spec/models/reducer_spec.rb
+++ b/spec/models/reducer_spec.rb
@@ -124,10 +124,9 @@ RSpec.describe Reducer, type: :model do
 
   it 'saves reducible attributes' do
     workflow = create :workflow
-    reducer = build :stats_reducer, workflow_id: workflow.id
-    reducer.save!
+    reducer = create :stats_reducer, reducible_id: workflow.id, reducible_type: "Workflow"
     expect(reducer.reducible_id).to eq(workflow.id)
-    expect(reducer.reducible_type).to eq("workflow")
+    expect(reducer.reducible_type).to eq("Workflow")
   end
 
   describe 'running/online aggregation' do
@@ -139,7 +138,7 @@ RSpec.describe Reducer, type: :model do
         extractor_key: 'foo', subject_id: subject.id, workflow_id: workflow.id
 
       reduction = create :subject_reduction,
-        reducer_key: 'bar', subject_id: subject.id, workflow_id: workflow.id
+        reducer_key: 'bar', subject_id: subject.id, reducible_id: workflow.id, reducible_type: "Workflow"
 
       reduction.extracts << extract
 
@@ -178,7 +177,8 @@ RSpec.describe Reducer, type: :model do
         type: 'Reducers::PlaceholderReducer',
         topic: Reducer.topics[:reduce_by_subject],
         reduction_mode: Reducer.reduction_modes[:running_reduction],
-        workflow_id: workflow.id
+        reducible_id: workflow.id,
+        reducible_type: "Workflow"
 
       extract_fetcher = instance_double(ExtractFetcher, extracts: [extract1, extract2])
       reduction_fetcher = instance_double(ReductionFetcher, retrieve: [subject_reduction_double], has_expired?: false)
@@ -222,7 +222,8 @@ RSpec.describe Reducer, type: :model do
         type: 'Reducers::PlaceholderReducer',
         topic: Reducer.topics[:reduce_by_subject],
         reduction_mode: Reducer.reduction_modes[:running_reduction],
-        workflow_id: workflow.id
+        reducible_id: workflow.id,
+        reducible_type: "Workflow"
 
       allow(running_reducer).to receive(:get_reduction).and_return(subject_reduction_double)
       allow(running_reducer).to receive(:reduce_into).and_return(subject_reduction_double)

--- a/spec/models/workflow/convert_legacy_reducers_config_spec.rb
+++ b/spec/models/workflow/convert_legacy_reducers_config_spec.rb
@@ -4,7 +4,7 @@ describe Workflow::ConvertLegacyReducersConfig do
   let(:workflow) { create :workflow }
 
   it 'updates config for existing reducers' do
-    reducer = create :stats_reducer, key: 'stat', workflow: workflow
+    reducer = create :stats_reducer, key: 'stat', reducible: workflow
 
     described_class.new(workflow).update(
       "stat" => {"a" => "b", "filters" => {"from" => 1}, "group_by" => "s.LK"}
@@ -22,8 +22,8 @@ describe Workflow::ConvertLegacyReducersConfig do
   end
 
   it 'removes reducers that are no longer mentioned' do
-    create :stats_reducer, key: 'stat', workflow: workflow
-    create :stats_reducer, key: 'old', workflow: workflow
+    create :stats_reducer, key: 'stat', reducible: workflow
+    create :stats_reducer, key: 'old', reducible: workflow
 
     expect {
       described_class.new(workflow).update("stat" => {})
@@ -31,8 +31,8 @@ describe Workflow::ConvertLegacyReducersConfig do
   end
 
   it 'allows removing all reducers' do
-    create :stats_reducer, key: 'stat', workflow: workflow
-    create :stats_reducer, key: 'old', workflow: workflow
+    create :stats_reducer, key: 'stat', reducible: workflow
+    create :stats_reducer, key: 'old', reducible: workflow
 
     expect {
       described_class.new(workflow).update({})
@@ -40,7 +40,7 @@ describe Workflow::ConvertLegacyReducersConfig do
   end
 
   it 'does nothing if no config given' do
-    create :stats_reducer, key: 'stat', workflow: workflow
+    create :stats_reducer, key: 'stat', reducible: workflow
 
     expect {
       described_class.new(workflow).update(nil)

--- a/spec/policies/subject_reduction_policy_spec.rb
+++ b/spec/policies/subject_reduction_policy_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe SubjectReductionPolicy do
       expect(subject).to permit(credential, reduction)
     end
 
+    it 'returns both public and scoped reductions' do
+      public_reduction = create(:subject_reduction)
+      public_reduction.reducible.update! public_reductions: true
+      credential = build(:credential, workflows: [reduction.reducible])
+      expect(subject).to permit(credential, reduction)
+      expect(subject).to permit(credential, public_reduction)
+    end
+
   end
 
   permissions :update? do

--- a/spec/policies/subject_reduction_policy_spec.rb
+++ b/spec/policies/subject_reduction_policy_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SubjectReductionPolicy do
     end
 
     it 'denies access when token has expired' do
-      credential = build(:credential, :expired, workflows: [reduction.workflow])
+      credential = build(:credential, :expired, workflows: [reduction.reducible])
       expect(subject).not_to permit(credential, reduction)
     end
 
@@ -51,12 +51,12 @@ RSpec.describe SubjectReductionPolicy do
     end
 
     it 'grants access to reductions of collaborated project' do
-      credential = build(:credential, workflows: [reduction.workflow])
+      credential = build(:credential, workflows: [reduction.reducible])
       expect(subject).to permit(credential, reduction)
     end
 
     it 'grants access if the workflow has public reductions' do
-      reduction.workflow.update! public_reductions: true
+      reduction.reducible.update! public_reductions: true
       credential = build(:credential, :not_logged_in)
       expect(subject).to permit(credential, reduction)
     end
@@ -72,12 +72,12 @@ RSpec.describe SubjectReductionPolicy do
     end
 
     it 'grants access to reduction of collaborated project' do
-      credential = build(:credential, workflows: [reduction.workflow])
+      credential = build(:credential, workflows: [reduction.reducible])
       expect(subject).to permit(credential, reduction)
     end
 
     it 'denies access to non-collabs for public reduction' do
-      reduction.workflow.update! public_reductions: true
+      reduction.reducible.update! public_reductions: true
       credential = build(:credential)
       expect(subject).not_to permit(credential, reduction)
     end

--- a/spec/policies/user_reduction_policy_spec.rb
+++ b/spec/policies/user_reduction_policy_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe UserReductionPolicy do
     end
 
     it 'denies access when token has expired' do
-      credential = build(:credential, :expired, workflows: [reduction.workflow])
+      credential = build(:credential, :expired, workflows: [reduction.reducible])
       expect(subject).not_to permit(credential, reduction)
     end
 
@@ -51,12 +51,12 @@ RSpec.describe UserReductionPolicy do
     end
 
     it 'grants access to reductions of collaborated project' do
-      credential = build(:credential, workflows: [reduction.workflow])
+      credential = build(:credential, workflows: [reduction.reducible])
       expect(subject).to permit(credential, reduction)
     end
 
     it 'grants access if the workflow has public reductions' do
-      reduction.workflow.update! public_reductions: true
+      reduction.reducible.update! public_reductions: true
       credential = build(:credential, :not_logged_in)
       expect(subject).to permit(credential, reduction)
     end
@@ -72,12 +72,12 @@ RSpec.describe UserReductionPolicy do
     end
 
     it 'grants access to reduction of collaborated project' do
-      credential = build(:credential, workflows: [reduction.workflow])
+      credential = build(:credential, workflows: [reduction.reducible])
       expect(subject).to permit(credential, reduction)
     end
 
     it 'denies access to non-collabs for public reduction' do
-      reduction.workflow.update! public_reductions: true
+      reduction.reducible.update! public_reductions: true
       credential = build(:credential)
       expect(subject).not_to permit(credential, reduction)
     end

--- a/spec/requests/kinesis_spec.rb
+++ b/spec/requests/kinesis_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Kinesis stream", sidekiq: :inline do
                   subject_rule_effects: [rule_effect])
     workflow = create(:workflow, id: 338,
                       extractors: [build(:survey_extractor, key: 's')],
-                      reducers: [build(:stats_reducer, key: 's')],
+                      reducers: [build(:stats_reducer, key: 's', reducible: nil)],
                       subject_rules: [rule])
 
     post "/kinesis",

--- a/spec/requests/subject_reductions_spec.rb
+++ b/spec/requests/subject_reductions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SubjectReductionsController, type: :controller do
 
   describe "GET #index" do
     it "returns http success" do
-      get :index, params: {reducible_id: workflow.id, reducible_type: "workflow", reducer_key: reducer_key}
+      get :index, params: {workflow_id: workflow.id, reducer_key: reducer_key}
       expect(response).to have_http_status(:success)
     end
   end
@@ -34,7 +34,8 @@ RSpec.describe SubjectReductionsController, type: :controller do
     end
 
     it 'updates an existing reduction' do
-      SubjectReduction.create!(workflow_id: workflow.id,
+      SubjectReduction.create!(reducible_id: workflow.id,
+                        reducible_type: "Workflow",
                         subject_id: subject.id,
                         reducer_key: reducer_key,
                         data: {"foo" => 1})

--- a/spec/requests/subject_reductions_spec.rb
+++ b/spec/requests/subject_reductions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SubjectReductionsController, type: :controller do
 
   describe "GET #index" do
     it "returns http success" do
-      get :index, params: {workflow_id: workflow.id, reducer_key: reducer_key}
+      get :index, params: {reducible_id: workflow.id, reducible_type: "workflow", reducer_key: reducer_key}
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
OK, this is nearly caught up with that monstrous PR and we're in pretty good shape. This PR removes  `belongs_to :workflow` from Reducer, SubjectReduction, and UserReduction, which caused a whole bunch of exciting spec failures. I added a `set_workflow` method as a mirror to the `set_reducible` one and switched the `before_save` callback to use it instead, then went about fixing specs. 

~~So this brings me back 'round to the question that I had before the refactor of the refactor began, which is basically this: how do I reconcile the policy scopes with the polymorphic association that this introduces?~~

~~Policy scopes through Pundit are passed around everywhere, starting with the `policy_scope` call in the SubjectReductionsController up through to the associated policy. Building this scope the same way would require a join that rails refuses to do on a polymorphic relationship. I can't filter `where.(reducible: {public_reductions: true})` or return a scope that includes every SubjectReduction that is associated with any reducible that has that boolean true.~~

~~I thought about just merging a couple different non-AR hashes of reducibles and just using a dumber filter in the controller. But that'd be a step backwards performance-wise and there's probably a better way. Thoughts?~~

Skirted the issue by just adding all public workflow ids to the scope pre-AR. Should work to just tack on an `.or(reducible_type: 'Project')` etc. This was a pretty...naïve refactoring, as it was mainly to get the existing specs to pass (with a few additions). This one in particular should be tested on staging as best as we can before deploying.