### PR TITLE
Reducible 7: Data for Data's Sake

### DIFF
--- a/app/controllers/data_requests_controller.rb
+++ b/app/controllers/data_requests_controller.rb
@@ -26,8 +26,8 @@ class DataRequestsController < ApplicationController
       skip_authorization # operations do this themselves and raise if needed
 
       respond_to do |format|
-        format.html { redirect_to [data_request.workflow, :data_requests] }
-        format.json { respond_with data_request.workflow, data_request }
+        format.html { redirect_to [data_request.exportable, :data_requests] }
+        format.json { respond_with data_request.exportable, data_request }
       end
     end
   end

--- a/app/controllers/user_reductions_controller.rb
+++ b/app/controllers/user_reductions_controller.rb
@@ -23,26 +23,6 @@ class UserReductionsController < ApplicationController
     render json: reduction
   end
 
-  def nested_update
-    reductions = reduction_params[:data].to_h.map do |key, data|
-      UserReduction.find_or_initialize_by(
-        workflow_id: workflow.id,
-        reducer_key: reducer.key,
-        user_id: user_id,
-        subgroup: key
-      ).tap do |item|
-        authorize item
-        item.save
-      end
-    end
-
-    CheckRulesWorker.perform_async(workflow.id, user_id) if workflow.configured?
-
-    workflow.webhooks.process(:updated_reduction, data) if workflow.subscribers?
-
-    render json: reductions
-  end
-
   private
 
   def workflow

--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -45,6 +45,11 @@ class DataRequest < ApplicationRecord
   validates :requested_data, presence: true
 
   belongs_to :exportable, polymorphic: true
+  before_save :set_workflow
+
+  def set_workflow
+    self.workflow_id = exportable.id
+  end
 
   def stored_export
     raise "DataRequest needs to be saved to database first" unless id.present?
@@ -60,7 +65,7 @@ class DataRequest < ApplicationRecord
     {
       id: id,
       reducible_id: exportable.id.to_s,
-      reducible_type: exportable.to_s,
+      reducible_type: exportable.class.to_s,
       user_id: user_id,
       subgroup: subgroup,
       status: status,

--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -64,8 +64,8 @@ class DataRequest < ApplicationRecord
   def as_json(options = {})
     {
       id: id,
-      reducible_id: exportable.id.to_s,
-      reducible_type: exportable.class.to_s,
+      exportable_id: exportable.id.to_s,
+      exportable_type: exportable.class.to_s,
       user_id: user_id,
       subgroup: subgroup,
       status: status,

--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -44,7 +44,7 @@ class DataRequest < ApplicationRecord
   validates :status, presence: true
   validates :requested_data, presence: true
 
-  belongs_to :workflow
+  belongs_to :exportable, polymorphic: true
 
   def stored_export
     raise "DataRequest needs to be saved to database first" unless id.present?
@@ -59,7 +59,8 @@ class DataRequest < ApplicationRecord
   def as_json(options = {})
     {
       id: id,
-      workflow_id: workflow_id.to_s,
+      reducible_id: exportable.id.to_s,
+      reducible_type: exportable.to_s,
       user_id: user_id,
       subgroup: subgroup,
       status: status,

--- a/app/models/exporters/csv_exporter.rb
+++ b/app/models/exporters/csv_exporter.rb
@@ -4,17 +4,18 @@ module Exporters
   class UnknownExporter < StandardError; end
 
   class CsvExporter
-    attr_reader :workflow_id, :user_id, :subgroup
+    attr_reader :resource_id, :resource_type, :user_id, :subgroup
 
     def initialize(params)
-      @workflow_id = params[:workflow_id]
+      @resource_id = params[:exportable_id]
+      @resource_type = params[:exportable_type]
       @user_id = params[:user_id]
       @subgroup = params[:subgroup]
     end
 
     def dump(path=nil)
       if path.blank?
-        path = "tmp/#{get_topic.name.demodulize.underscore.pluralize}_#{workflow_id}.csv"
+        path = "tmp/#{get_topic.name.demodulize.underscore.pluralize}_#{resource_id}.csv"
       end
 
       items = get_items
@@ -60,7 +61,11 @@ module Exporters
     end
 
     def get_items
-      find_hash = { :workflow_id => workflow_id }
+      if get_topic == Extract
+        find_hash = { :workflow_id => resource_id }
+      elsif get_topic == SubjectReduction
+        find_hash = { :reducible_id => resource_id }
+      end
       find_hash[:user_id] = user_id unless user_id.blank?
       find_hash[:subgroup] = subgroup unless subgroup.blank?
       get_topic.where(find_hash)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -75,8 +75,8 @@ class Workflow < ApplicationRecord
   has_many :user_reductions
   has_many :subject_actions
   has_many :user_actions
-  has_many :data_requests
-
+  has_many :data_requests, as: :exportable
+  
   enum rules_applied: [:all_matching_rules, :first_matching_rule]
 
   def self.accessible_by(credential)

--- a/app/operations/creates_data_requests.rb
+++ b/app/operations/creates_data_requests.rb
@@ -1,7 +1,13 @@
 class CreatesDataRequests < ApplicationOperation
   def call(obj, args)
+    resource = if args[:workflow_id]
+      Workflow.find(args[:workflow_id])
+    elsif args[:project_id]
+      Project.find(args[:project_id])
+    end
+
     data_request = DataRequest.new(
-      workflow_id: args[:workflow_id],
+      exportable: resource,
       user_id: args[:user_id],
       subgroup: args[:subgroup],
       requested_data: args[:requested_data]
@@ -9,7 +15,7 @@ class CreatesDataRequests < ApplicationOperation
 
     authorize(data_request, :create?)
 
-    data_request.public = data_request.workflow.public_data?(data_request.requested_data)
+    data_request.public = data_request.exportable.public_data?(data_request.requested_data)
     data_request.status = DataRequest.statuses[:pending]
     data_request.save!
 

--- a/app/policies/data_request_policy.rb
+++ b/app/policies/data_request_policy.rb
@@ -2,7 +2,7 @@ class DataRequestPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
-      self.scope.where(exportable_type: 'Workflow', exportable_id: workflow_ids)
+      self.scope.where(exportable_type: 'Workflow', exportable_id: workflow_ids).or(self.scope.where(public: true))
     end
   end
 

--- a/app/policies/data_request_policy.rb
+++ b/app/policies/data_request_policy.rb
@@ -2,24 +2,23 @@ class DataRequestPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
-
-      scope = self.scope.joins(:workflow).references(:workflows)
-      scope.where(workflow_id: workflow_ids).or(scope.where(public: true))
+      self.scope.where(exportable_type: 'Workflow', exportable_id: workflow_ids)
     end
   end
 
   def create?
     return true if credential.admin?
-    return true if record.extracts? && record.workflow.public_extracts
-    return true if record.reductions? && record.workflow.public_reductions
+    return true if record.extracts? && record.exportable.public_extracts
+    return true if record.reductions? && record.exportable.public_reductions
 
-    credential.project_ids.include?(record.workflow.project_id)
+    # TODO: Projects need to respond to project_id or this becomes a conditional
+    credential.project_ids.include?(record.exportable.project_id)
   end
 
   def update?
     return true if credential.admin?
 
-    credential.project_ids.include?(record.workflow.project_id)
+    credential.project_ids.include?(record.exportable.project_id)
   end
 
   def destroy?

--- a/app/workers/data_request_worker.rb
+++ b/app/workers/data_request_worker.rb
@@ -46,26 +46,3 @@ class DataRequestWorker
     end
   end
 end
-
-        :user_id => request.user_id,
-        :subgroup => request.subgroup
-      )
-
-      exporter.dump(path) do |progress, total|
-        if progress % 1000 == 0
-          request.records_count = total
-          request.records_exported = progress
-          request.save
-        end
-      end
-
-      request.stored_export.upload(path)
-      request.complete!
-    rescue
-      request.failed!
-      raise
-    ensure
-      ::File.unlink path
-    end
-  end
-end

--- a/db/migrate/20180716210957_add_exportable_to_data_requests.rb
+++ b/db/migrate/20180716210957_add_exportable_to_data_requests.rb
@@ -1,0 +1,6 @@
+class AddExportableToDataRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_column :data_requests, :exportable_id, :integer
+    add_column :data_requests, :exportable_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180607150016) do
+ActiveRecord::Schema.define(version: 20180716210957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,8 @@ ActiveRecord::Schema.define(version: 20180607150016) do
     t.boolean "public", default: false, null: false
     t.integer "records_count"
     t.integer "records_exported"
+    t.integer "exportable_id"
+    t.string "exportable_type"
     t.index ["user_id", "workflow_id", "subgroup", "requested_data"], name: "look_up_existing", unique: true
     t.index ["workflow_id"], name: "index_data_requests_on_workflow_id"
   end

--- a/spec/controllers/data_requests_controller_spec.rb
+++ b/spec/controllers/data_requests_controller_spec.rb
@@ -9,7 +9,7 @@ describe DataRequestsController, :type => :controller do
 
   let(:data_request) do
     DataRequest.new(
-      workflow: workflow,
+      exportable: workflow,
       subgroup: nil,
       requested_data: DataRequest.requested_data[:extracts]
     )
@@ -23,8 +23,8 @@ describe DataRequestsController, :type => :controller do
     let(:params) { {workflow_id: workflow.id} }
 
     it 'returns data requests for workflow' do
-      data_request1 = create(:data_request, workflow: workflow, created_at: 5.days.ago)
-      data_request2 = create(:data_request, workflow: workflow, created_at: 2.days.ago)
+      data_request1 = create(:data_request, exportable: workflow, created_at: 5.days.ago)
+      data_request2 = create(:data_request, exportable: workflow, created_at: 2.days.ago)
 
       get :index, params: params, format: :json
       expect(json_response).to eq([data_request2.as_json.stringify_keys,
@@ -33,8 +33,8 @@ describe DataRequestsController, :type => :controller do
 
     it 'returns public requests for unauthorized users' do
       fake_session(logged_in: false)
-      data_request1 = create(:data_request, workflow: workflow, created_at: 5.days.ago, public: true)
-      data_request2 = create(:data_request, workflow: workflow, created_at: 2.days.ago)
+      data_request1 = create(:data_request, exportable: workflow, created_at: 5.days.ago, public: true)
+      data_request2 = create(:data_request, exportable: workflow, created_at: 2.days.ago)
 
       get :index, params: params, format: :json
       expect(json_response).to eq([data_request1.as_json.stringify_keys])

--- a/spec/factories/data_request_factory.rb
+++ b/spec/factories/data_request_factory.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :data_request do
-    workflow
+    exportable { create :workflow }
+    workflow_id { exportable.id }
     requested_data :extracts
   end
 end

--- a/spec/models/exporters/csv_extract_exporter_spec.rb
+++ b/spec/models/exporters/csv_extract_exporter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Exporters::CsvExtractExporter do
   let(:workflow) { create :workflow }
   let(:subject) { Subject.create! }
-  let(:exporter){ described_class.new workflow_id: workflow.id }
+  let(:exporter){ described_class.new exportable_id: workflow.id }
 
   let(:sample){
     Extract.new(

--- a/spec/models/exporters/csv_subject_reduction_exporter_spec.rb
+++ b/spec/models/exporters/csv_subject_reduction_exporter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Exporters::CsvSubjectReductionExporter do
   let(:workflow) { create :workflow }
   let(:subject) { Subject.create! }
-  let(:exporter) { described_class.new workflow_id: workflow.id }
+  let(:exporter) { described_class.new exportable_id: workflow.id }
   let(:sample){
     SubjectReduction.new(
       reducer_key: "x",

--- a/spec/policies/data_request_policy_spec.rb
+++ b/spec/policies/data_request_policy_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DataRequestPolicy do
     end
 
     it 'denies access when token has expired' do
-      credential = build(:credential, :expired, workflows: [data_request.workflow])
+      credential = build(:credential, :expired, workflows: [data_request.exportable])
       expect(subject).not_to permit(credential, data_request)
     end
 
@@ -53,7 +53,7 @@ RSpec.describe DataRequestPolicy do
     end
 
     it 'grants access to data_requests of collaborated project' do
-      credential = build(:credential, workflows: [data_request.workflow])
+      credential = build(:credential, workflows: [data_request.exportable])
       expect(subject).to permit(credential, data_request)
     end
   end
@@ -67,32 +67,32 @@ RSpec.describe DataRequestPolicy do
     end
 
     it 'grants access to data_requests of collaborated project' do
-      credential = build(:credential, workflows: [data_request.workflow])
+      credential = build(:credential, workflows: [data_request.exportable])
       expect(subject).to permit(credential, data_request)
     end
 
     it 'grants access to data_requests of a workflow with public extracts' do
       workflow.update! public_extracts: true
-      data_request = build(:data_request, workflow: workflow, requested_data: 'extracts')
+      data_request = build(:data_request, exportable: workflow, requested_data: 'extracts')
       credential = build(:credential, workflows: [])
       expect(subject).to permit(credential, data_request)
     end
 
     it 'grants access to data_requests of a workflow with public extracts' do
       workflow.update! public_reductions: true
-      data_request = build(:data_request, workflow: workflow, requested_data: 'reductions')
+      data_request = build(:data_request, exportable: workflow, requested_data: 'reductions')
       credential = build(:credential, workflows: [])
       expect(subject).to permit(credential, data_request)
     end
 
     it 'does not let non-collaborators create requests for non-public workflows', :aggregate_failures do
       workflow = build(:workflow, public_extracts: true) # <- Note extracts are public, but request reductions
-      data_request = build(:data_request, workflow: workflow, requested_data: 'reductions')
+      data_request = build(:data_request, exportable: workflow, requested_data: 'reductions')
       credential = build(:credential, workflows: [])
       expect(subject).not_to permit(credential, data_request)
 
       workflow = build(:workflow, public_reductions: true) # <- Note reductions are public, but request extracts
-      data_request = build(:data_request, workflow: workflow, requested_data: 'extracts')
+      data_request = build(:data_request, exportable: workflow, requested_data: 'extracts')
       credential = build(:credential, workflows: [])
       expect(subject).not_to permit(credential, data_request)
     end
@@ -107,13 +107,13 @@ RSpec.describe DataRequestPolicy do
     end
 
     it 'grants access to data_requests of collaborated project' do
-      credential = build(:credential, workflows: [data_request.workflow])
+      credential = build(:credential, workflows: [data_request.exportable])
       expect(subject).to permit(credential, data_request)
     end
 
     it 'does not let non-collaborators update public data requests' do
       workflow.update! public_extracts: true
-      data_request = build(:data_request, workflow: workflow, public: true)
+      data_request = build(:data_request, exportable: workflow, public: true)
       credential = build(:credential, workflows: [])
       expect(subject).not_to permit(credential, data_request)
     end

--- a/spec/workers/data_request_worker_spec.rb
+++ b/spec/workers/data_request_worker_spec.rb
@@ -5,12 +5,13 @@ describe DataRequestWorker do
 
   let(:stored_export) { double("StoredExport", "download_url" => "hi", "upload" => nil)}
 
-  let(:workflow) { build :workflow }
+  let(:workflow) { create :workflow }
 
   let(:request) do
     DataRequest.new(
       user_id: 1234,
-      workflow: workflow,
+      exportable: workflow,
+      workflow_id: workflow.id,
       subgroup: nil,
       requested_data: DataRequest.requested_data[:extracts]
     )


### PR DESCRIPTION
Adds a new association, `exportable`, to DataRequests so that they'll be able to export extracts from workflows or reductions from workflows or projects. Updates the DataRequest model, controller, operation, policy, and worker as well as the CSV exporter. 