### PR TITLE
Broaden the fetch classifications stoplight

### DIFF
--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -88,9 +88,9 @@ class ClassificationPipeline
              end
 
     reduction_filter = { reducible_id: reducible_id, reducible_type: reducible_class.to_s, subject_id: subject_id, user_id: user_id }
-    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids)	     
+    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids)
     reduction_fetcher = ReductionFetcher.new(reduction_filter)
-          
+
     # if we don't need to fetch everything, try not to
     if reducers.all?{ |reducer| reducer.running_reduction? }
       extract_fetcher.strategy! :fetch_minimal

--- a/app/workers/fetch_classifications_worker.rb
+++ b/app/workers/fetch_classifications_worker.rb
@@ -26,9 +26,9 @@ class FetchClassificationsWorker
     light = Stoplight("fetch-classifications") do
       case object_type
       when @@FetchForSubject
-        Effects.panoptes.get_subject_classifications(object_id, workflow_id)["classifications"]
+        Effects.panoptes.get_subject_classifications(object_id, workflow_id).fetch("classifications")
       when @@FetchForUser
-        Effects.panoptes.get_user_classifications(object_id, workflow_id)["classifications"]
+        Effects.panoptes.get_user_classifications(object_id, workflow_id).fetch("classifications")
       else
         []
       end

--- a/app/workers/fetch_classifications_worker.rb
+++ b/app/workers/fetch_classifications_worker.rb
@@ -33,13 +33,11 @@ class FetchClassificationsWorker
     when @@FetchForUser
       Effects.panoptes.get_user_classifications(object_id, workflow_id)["classifications"]
     else
-      nil
+      []
     end
   end
 
   def process_classifications(workflow_id, classifications)
-    return unless classifications
-
     classifications.each do |attributes|
       attributes["workflow_version"] ||= attributes["metadata"]["workflow_version"]
       classification = Classification.upsert(attributes)

--- a/app/workers/fetch_classifications_worker.rb
+++ b/app/workers/fetch_classifications_worker.rb
@@ -19,19 +19,22 @@ class FetchClassificationsWorker
 
   def perform(workflow_id, object_id, object_type)
     light = Stoplight("fetch-classifications-#{workflow_id}-#{object_type}") do
-      classifications = case object_type
-      when @@FetchForSubject
-        Effects.panoptes.get_subject_classifications(object_id, workflow_id)["classifications"]
-      when @@FetchForUser
-        Effects.panoptes.get_user_classifications(object_id, workflow_id)["classifications"]
-      else
-        nil
-      end
-
+      classifications = fetch_classifications(workflow_id, object_id, object_type)
       process_classifications(workflow_id, classifications)
     end
 
     light.run
+  end
+
+  def fetch_classifications(workflow_id, object_id, object_type)
+    case object_type
+    when @@FetchForSubject
+      Effects.panoptes.get_subject_classifications(object_id, workflow_id)["classifications"]
+    when @@FetchForUser
+      Effects.panoptes.get_user_classifications(object_id, workflow_id)["classifications"]
+    else
+      nil
+    end
   end
 
   def process_classifications(workflow_id, classifications)

--- a/spec/models/classification_pipeline_spec.rb
+++ b/spec/models/classification_pipeline_spec.rb
@@ -66,8 +66,8 @@ describe ClassificationPipeline do
       retire_subject: true,
       workflow: {},
       project: {},
-      get_subject_classifications: {},
-      get_user_classifications: {}
+      get_subject_classifications: {"classifications" => []},
+      get_user_classifications: {"classifications" => []}
     )
   }
 


### PR DESCRIPTION
Main goal here was the realisation that if fetching fails, it's probably a Panoptes-wide issue and so there is no use in keeping stoplights for each workflow for fetching classifications.