### PR TITLE
performance overhaul for workflow summary and project summary

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,6 +11,7 @@ class ProjectsController < ApplicationController
   # GET /projects/1
   def show
     authorize project
+    @summary = ProjectSummary.new(project)
     respond_with project
   end
 

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -9,7 +9,7 @@ class WorkflowsController < ApplicationController
 
   def show
     authorize workflow
-    @heartbeat = Heartbeat.new(workflow)
+    @summary = WorkflowSummary.new(workflow)
     respond_with @workflow
   end
 

--- a/app/models/belongs_to_reducible.rb
+++ b/app/models/belongs_to_reducible.rb
@@ -1,14 +1,14 @@
-module BelongsToReducible 
+module BelongsToReducible
   extend ActiveSupport::Concern
 
   included do
-    belongs_to :reducible, polymorphic: true, optional: true
+    belongs_to :reducible, polymorphic: true, optional: true, counter_cache: true
     before_save :set_workflow
   end
 
   def set_reducible
     self.reducible_id = workflow.id
-    self.reducible_type = "Workflow" 
+    self.reducible_type = "Workflow"
   end
 
   def set_workflow

--- a/app/models/belongs_to_reducible_cached.rb
+++ b/app/models/belongs_to_reducible_cached.rb
@@ -1,8 +1,8 @@
-module BelongsToReducible
+module BelongsToReducibleCached
   extend ActiveSupport::Concern
 
   included do
-    belongs_to :reducible, polymorphic: true, optional: true
+    belongs_to :reducible, polymorphic: true, optional: true, counter_cache: true
     before_save :set_workflow
   end
 

--- a/app/models/extract.rb
+++ b/app/models/extract.rb
@@ -16,7 +16,7 @@ class Extract < ApplicationRecord
     field :updatedAt, !Types::TimeType, property: :updated_at
   end
 
-  belongs_to :workflow
+  belongs_to :workflow, counter_cache: true
   belongs_to :subject
   has_and_belongs_to_many_with_deferred_save :subject_reduction
   has_and_belongs_to_many_with_deferred_save :user_reduction

--- a/app/models/project_summary.rb
+++ b/app/models/project_summary.rb
@@ -1,0 +1,24 @@
+class ProjectSummary
+  def initialize(project)
+    @project = project
+  end
+
+  def reductions_count
+    subject_reductions + user_reductions
+  end
+
+  def subject_reductions
+    @project.subject_reductions_count || 0
+  end
+
+  def user_reductions
+    @project.user_reductions_count || 0
+  end
+
+  def last_reduction
+    [
+      @project.subject_reductions.order(updated_at: :desc).first&.updated_at,
+      @project.user_reductions.order(updated_at: :desc).first&.updated_at,
+    ].compact.max
+  end
+end

--- a/app/models/subject_action.rb
+++ b/app/models/subject_action.rb
@@ -31,7 +31,7 @@ class SubjectAction < ApplicationRecord
 
   enum status: [:pending, :completed, :failed]
 
-  belongs_to :workflow
+  belongs_to :workflow, counter_cache: true
   belongs_to :subject
 
   def perform

--- a/app/models/subject_reduction.rb
+++ b/app/models/subject_reduction.rb
@@ -1,5 +1,5 @@
 class SubjectReduction < ApplicationRecord
-  include BelongsToReducible
+  include BelongsToReducibleCached
 
   Type = GraphQL::ObjectType.define do
     name "SubjectReduction"

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -1,6 +1,6 @@
 class UserAction < ApplicationRecord
   enum status: [:pending, :completed, :failed]
-  belongs_to :workflow
+  belongs_to :workflow, counter_cache: true
 
   def perform
     effect.perform(workflow_id, user_id)

--- a/app/models/user_reduction.rb
+++ b/app/models/user_reduction.rb
@@ -1,5 +1,5 @@
 class UserReduction < ApplicationRecord
-  include BelongsToReducible
+  include BelongsToReducibleCached
 
   Type = GraphQL::ObjectType.define do
     name "SubjectReduction"

--- a/app/models/workflow_summary.rb
+++ b/app/models/workflow_summary.rb
@@ -1,6 +1,34 @@
-class Heartbeat
+class WorkflowSummary
   def initialize(workflow)
     @workflow = workflow
+  end
+
+  def extracts_count
+    @workflow.extracts_count || 0
+  end
+
+  def reductions_count
+    subject_reductions + user_reductions
+  end
+
+  def actions_count
+    subject_actions + user_actions
+  end
+
+  def subject_reductions
+    @workflow.subject_reductions_count || 0
+  end
+
+  def user_reductions
+    @workflow.user_reductions_count || 0
+  end
+
+  def subject_actions
+    @workflow.subject_actions_count || 0
+  end
+
+  def user_actions
+    @workflow.user_actions_count || 0
   end
 
   def last_extract
@@ -19,10 +47,6 @@ class Heartbeat
       SubjectAction.where(workflow_id: @workflow.id).order(updated_at: :desc).first&.updated_at,
       UserAction.where(workflow_id: @workflow.id).order(updated_at: :desc).first&.updated_at
     ].compact.max
-  end
-
-  def action_count
-    SubjectAction.where(workflow_id: @workflow.id).count + UserAction.where(workflow_id: @workflow.id).count
   end
 
   def subject_count

--- a/app/views/projects/_summary.html.erb
+++ b/app/views/projects/_summary.html.erb
@@ -25,7 +25,7 @@
       <div class="col-md-6">
         <dl class="dl-horizontal">
           <dt>Total Reductions</dt>
-          <dd><%= @project.subject_reductions.count + @project.user_reductions.count %></dd>
+          <dd><%= @summary.reductions_count %></dd>
         </dl>
       </div>
     </div>

--- a/app/views/workflows/_subjects.html.erb
+++ b/app/views/workflows/_subjects.html.erb
@@ -8,7 +8,7 @@
         <%= form.text_field :id, class: 'form-control', placeholder: 'Subject id to search for' %>
         <br />
         <%= form.submit 'Search', class: 'btn btn-primary pull-right'  %>
-        <p><strong><%= @heartbeat.subject_count %></strong> subjects known</p>
+        <p><strong><%= @summary.subject_count %></strong> subjects known</p>
       <% end  %>
     </div>
   </div>

--- a/app/views/workflows/_summary.html.erb
+++ b/app/views/workflows/_summary.html.erb
@@ -45,21 +45,21 @@
       <div class="col-md-6">
         <dl class="dl-horizontal">
           <dt>Total Extracts</dt>
-          <dd><%= @workflow.extracts.count %></dd>
+          <dd><%= @summary.extracts_count %></dd>
           <dt>Total Reductions</dt>
-          <dd><%= @workflow.subject_reductions.count + @workflow.user_reductions.count %></dd>
+          <dd><%= @summary.reductions_count %></dd>
           <dt>Total Actions</dt>
-          <dd><%= @heartbeat.action_count %></dd>
+          <dd><%= @summary.actions_count %></dd>
         </dl>
       </div>
       <div class="col-md-6">
         <dl class="dl-horizontal">
           <dt>Last Extract</dt>
-          <dd><%= @heartbeat.last_extract || "Never" %></dd>
+          <dd><%= @summary.last_extract || "Never" %></dd>
           <dt>Last Reduction</dt>
-          <dd><%= @heartbeat.last_reduction || "Never" %></dd>
+          <dd><%= @summary.last_reduction || "Never" %></dd>
           <dt>Last Action</dt>
-          <dd><%= @heartbeat.last_action || "Never" %></dd>
+          <dd><%= @summary.last_action || "Never" %></dd>
         </dl>
       </div>
     </div>

--- a/db/migrate/20180829154238_add_extracts_count_to_workflows.rb
+++ b/db/migrate/20180829154238_add_extracts_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddExtractsCountToWorkflows < ActiveRecord::Migration[5.1]
+  def change
+    add_column :workflows, :extracts_count, :int
+  end
+end

--- a/db/migrate/20180829154313_add_subject_reductions_count_to_workflows.rb
+++ b/db/migrate/20180829154313_add_subject_reductions_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddSubjectReductionsCountToWorkflows < ActiveRecord::Migration[5.1]
+  def change
+    add_column :workflows, :subject_reductions_count, :int
+  end
+end

--- a/db/migrate/20180829154326_add_user_reductions_count_to_workflows.rb
+++ b/db/migrate/20180829154326_add_user_reductions_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddUserReductionsCountToWorkflows < ActiveRecord::Migration[5.1]
+  def change
+    add_column :workflows, :user_reductions_count, :int
+  end
+end

--- a/db/migrate/20180829154419_add_subject_actions_count_to_workflows.rb
+++ b/db/migrate/20180829154419_add_subject_actions_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddSubjectActionsCountToWorkflows < ActiveRecord::Migration[5.1]
+  def change
+    add_column :workflows, :subject_actions_count, :int
+  end
+end

--- a/db/migrate/20180829154435_add_user_actions_count_to_workflows.rb
+++ b/db/migrate/20180829154435_add_user_actions_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddUserActionsCountToWorkflows < ActiveRecord::Migration[5.1]
+  def change
+    add_column :workflows, :user_actions_count, :int
+  end
+end

--- a/db/migrate/20180829154523_add_subject_reductions_count_to_projects.rb
+++ b/db/migrate/20180829154523_add_subject_reductions_count_to_projects.rb
@@ -1,0 +1,5 @@
+class AddSubjectReductionsCountToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :subject_reductions_count, :int
+  end
+end

--- a/db/migrate/20180829154543_add_user_reductions_count_to_projects.rb
+++ b/db/migrate/20180829154543_add_user_reductions_count_to_projects.rb
@@ -1,0 +1,5 @@
+class AddUserReductionsCountToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :user_reductions_count, :int
+  end
+end

--- a/db/migrate/20180829170321_add_indexes_for_summary.rb
+++ b/db/migrate/20180829170321_add_indexes_for_summary.rb
@@ -1,0 +1,46 @@
+class AddIndexesForSummary < ActiveRecord::Migration[5.1]
+  def up
+    unless index_exists?(:extracts, ["workflow_id", "updated_at"], name: "extracts_updated_by_workflow")
+      add_index :extracts, ["workflow_id", "updated_at"], name: "extracts_updated_by_workflow"
+    end
+
+    unless index_exists?(:subject_reductions, ["workflow_id", "updated_at"], name: "subject_reductions_updated_by_workflow")
+      add_index :subject_reductions, ["workflow_id", "updated_at"], name: "subject_reductions_updated_by_workflow"
+    end
+
+    unless index_exists?(:user_reductions, ["workflow_id", "updated_at"], name: "user_reductions_updated_by_workflow")
+      add_index :user_reductions, ["workflow_id", "updated_at"], name: "user_reductions_updated_by_workflow"
+    end
+
+    unless index_exists?(:subject_actions, ["workflow_id", "updated_at"], name: "subject_actions_updated_by_workflow")
+      add_index :subject_actions, ["workflow_id", "updated_at"], name: "subject_actions_updated_by_workflow"
+    end
+
+    unless index_exists?(:user_actions, ["workflow_id", "updated_at"], name: "user_actions_updated_by_workflow")
+      add_index :user_actions, ["workflow_id", "updated_at"], name: "user_actions_updated_by_workflow"
+    end
+
+  end
+
+  def down
+    if index_exists?(:extracts, ["workflow_id", "updated_at"], name: "extracts_updated_by_workflow")
+      remove_index :extracts, name: "extracts_updated_by_workflow"
+    end
+
+    if index_exists?(:subject_reductions, ["workflow_id", "updated_at"], name: "subject_reductions_updated_by_workflow")
+      remove_index :subject_reductions, name: "subject_reductions_updated_by_workflow"
+    end
+
+    if index_exists?(:user_reductions, ["workflow_id", "updated_at"], name: "user_reductions_updated_by_workflow")
+      remove_index :user_reductions, name: "user_reductions_updated_by_workflow"
+    end
+
+    if index_exists?(:subject_actions, ["workflow_id", "updated_at"], name: "subject_actions_updated_by_workflow")
+      remove_index :subject_actions, name: "subject_actions_updated_by_workflow"
+    end
+
+    if index_exists?(:user_actions, ["workflow_id", "updated_at"], name: "user_actions_updated_by_workflow")
+      remove_index :user_actions, name: "user_actions_updated_by_workflow"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180822211217) do
+ActiveRecord::Schema.define(version: 20180829170321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 20180822211217) do
     t.index ["classification_id", "extractor_key"], name: "index_extracts_on_classification_id_and_extractor_key", unique: true
     t.index ["subject_id"], name: "index_extracts_on_subject_id"
     t.index ["user_id"], name: "index_extracts_on_user_id"
+    t.index ["workflow_id", "updated_at"], name: "extracts_updated_by_workflow"
     t.index ["workflow_id"], name: "index_extracts_on_workflow_id"
   end
 
@@ -107,6 +108,8 @@ ActiveRecord::Schema.define(version: 20180822211217) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "display_name"
+    t.integer "subject_reductions_count"
+    t.integer "user_reductions_count"
   end
 
   create_table "reducers", force: :cascade do |t|
@@ -138,6 +141,7 @@ ActiveRecord::Schema.define(version: 20180822211217) do
     t.datetime "updated_at", null: false
     t.integer "rule_id"
     t.index ["subject_id"], name: "index_subject_actions_on_subject_id"
+    t.index ["workflow_id", "updated_at"], name: "subject_actions_updated_by_workflow"
     t.index ["workflow_id"], name: "index_subject_actions_on_workflow_id"
   end
 
@@ -158,6 +162,7 @@ ActiveRecord::Schema.define(version: 20180822211217) do
     t.index ["subject_id"], name: "index_subject_reductions_on_subject_id"
     t.index ["workflow_id", "subgroup"], name: "index_reductions_workflow_id_and_subgroup"
     t.index ["workflow_id", "subject_id"], name: "index_subject_reductions_on_workflow_id_and_subject_id"
+    t.index ["workflow_id", "updated_at"], name: "subject_reductions_updated_by_workflow"
     t.index ["workflow_id"], name: "index_subject_reductions_on_workflow_id"
   end
 
@@ -198,6 +203,7 @@ ActiveRecord::Schema.define(version: 20180822211217) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_user_subject_actions_on_user_id"
+    t.index ["workflow_id", "updated_at"], name: "user_actions_updated_by_workflow"
     t.index ["workflow_id"], name: "index_user_actions_on_workflow_id"
   end
 
@@ -215,6 +221,7 @@ ActiveRecord::Schema.define(version: 20180822211217) do
     t.integer "reducible_id"
     t.string "reducible_type"
     t.index ["user_id"], name: "index_user_reductions_on_user_id"
+    t.index ["workflow_id", "updated_at"], name: "user_reductions_updated_by_workflow"
     t.index ["workflow_id", "user_id", "reducer_key", "subgroup"], name: "index_user_reductions_covering"
     t.index ["workflow_id", "user_id"], name: "index_user_reductions_on_workflow_id_and_user_id"
     t.index ["workflow_id"], name: "index_user_reductions_on_workflow_id"
@@ -248,6 +255,11 @@ ActiveRecord::Schema.define(version: 20180822211217) do
     t.string "name"
     t.string "project_name"
     t.integer "status", default: 1, null: false
+    t.integer "extracts_count"
+    t.integer "subject_reductions_count"
+    t.integer "user_reductions_count"
+    t.integer "subject_actions_count"
+    t.integer "user_actions_count"
   end
 
   add_foreign_key "classifications", "subjects"

--- a/lib/tasks/project_counters.rake
+++ b/lib/tasks/project_counters.rake
@@ -1,7 +1,7 @@
 desc 'Update counter caches for projects'
 
 namespace :counters do
-  namespace :rebuild do
+  namespace :update do
     task projects: :environment do
       Project.reset_column_information
       Project.pluck(:id).each do |id|

--- a/lib/tasks/project_counters.rake
+++ b/lib/tasks/project_counters.rake
@@ -1,0 +1,12 @@
+desc 'Update counter caches for projects'
+
+namespace :counters do
+  namespace :rebuild do
+    task projects: :environment do
+      Project.reset_column_information
+      Project.pluck(:id).each do |id|
+        Project.reset_counters id, :subject_reductions, :user_reductions
+      end
+    end
+  end
+end

--- a/lib/tasks/workflow_counters.rake
+++ b/lib/tasks/workflow_counters.rake
@@ -1,6 +1,6 @@
 desc 'Update counter caches for workflows'
 namespace :counters do
-  namespace :rebuild do
+  namespace :update do
     task workflows: :environment do
       Workflow.reset_column_information
       Workflow.pluck(:id).each do |id|

--- a/lib/tasks/workflow_counters.rake
+++ b/lib/tasks/workflow_counters.rake
@@ -1,0 +1,11 @@
+desc 'Update counter caches for workflows'
+namespace :counters do
+  namespace :rebuild do
+    task workflows: :environment do
+      Workflow.reset_column_information
+      Workflow.pluck(:id).each do |id|
+        Workflow.reset_counters id, :extracts, :subject_reductions, :user_reductions, :subject_actions, :user_actions
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Project, type: :model do
   let(:project) { Project.new }
+  let(:subject) { create :subject }
 
   describe 'public_data?' do
     describe 'public reductions' do
@@ -18,6 +19,18 @@ RSpec.describe Project, type: :model do
 
     it 'is false for any other data type' do
       expect(project.public_data?("foobar")).to be_falsey
+    end
+  end
+
+  describe 'cached counters' do
+    it 'increments the subject reduction count when new reductions are added' do
+      SubjectReduction.create! reducible: project, subject_id: subject.id, reducer_key: 'key'
+      expect(Project.find(project.id).subject_reductions_count).to eq(1)
+    end
+
+    it 'increments the user reduction count when new reductions are added' do
+      UserReduction.create! reducible: project, user_id: 12345, reducer_key: 'key'
+      expect(Project.find(project.id).user_reductions_count).to eq(1)
     end
   end
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Workflow, type: :model do
-  let(:workflow) { Workflow.new }
+  let(:workflow) { create :workflow }
+  let(:subject) { create :subject }
 
   describe 'public_data?' do
     describe 'public extracts' do
@@ -30,6 +31,35 @@ RSpec.describe Workflow, type: :model do
 
     it 'is false for any other data type' do
       expect(workflow.public_data?("foobar")).to be_falsey
+    end
+  end
+
+  describe 'cached counters' do
+    it 'increments the extract count when new extracts are added' do
+      Extract.create! workflow_id: workflow.id, subject_id: subject.id, classification_id: 12345, classification_at: DateTime.now, extractor_key: 'key'
+      expect(Workflow.find(workflow.id).extracts_count).to eq(1)
+      Extract.create! workflow_id: workflow.id, subject_id: subject.id, classification_id: 12346, classification_at: DateTime.now, extractor_key: 'key'
+      expect(Workflow.find(workflow.id).extracts_count).to eq(2)
+    end
+
+    it 'increments the subject reduction count when new reductions are added' do
+      SubjectReduction.create! reducible: workflow, subject_id: subject.id, reducer_key: 'key'
+      expect(Workflow.find(workflow.id).subject_reductions_count).to eq(1)
+    end
+
+    it 'increments the user reduction count when new reductions are added' do
+      UserReduction.create! reducible: workflow, user_id: 12345, reducer_key: 'key'
+      expect(Workflow.find(workflow.id).user_reductions_count).to eq(1)
+    end
+
+    it 'increments the subject action count when new actions are added' do
+      SubjectAction.create! workflow_id: workflow.id, subject_id: subject.id, effect_type: 'retire_subject'
+      expect(Workflow.find(workflow.id).subject_actions_count).to eq(1)
+    end
+
+    it 'increments the user action count when new actions are added' do
+      UserAction.create! workflow_id: workflow.id, user_id: 12345, effect_type: 'promote_user'
+      expect(Workflow.find(workflow.id).user_actions_count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
1. Add indexes to help locate most recent extracts, subject reductions, user reductions, subject actions, and user actions
2. Add columns for cached counters on workflows and projects
3. Configure relationships of extracts, subject reductions, user reductions, subject actions, and user actions to use caching counters
4. Update views to use cached counters
5. Add rake task to rebuild counters