### PR TITLE
Fix broken delete buttons

### DIFF
--- a/app/views/subject_rules/edit.html.erb
+++ b/app/views/subject_rules/edit.html.erb
@@ -33,7 +33,7 @@
           <i class="glyphicon glyphicon-cog text-warning"></i>
           <span class="sr-only">Edit</i>
         <% end %>
-        <%= link_to [:edit, @workflow, @subject_rule, rule_effect], method: :delete, data: {confirm: "Are you sure?"} do %>
+        <%= link_to [@workflow, @subject_rule, rule_effect], method: :delete, data: {confirm: "Are you sure?"} do %>
           <i class="glyphicon glyphicon-trash text-danger"></i>
           <span class="sr-only">Delete</i>
         <% end %>

--- a/app/views/user_rules/edit.html.erb
+++ b/app/views/user_rules/edit.html.erb
@@ -31,7 +31,7 @@
           <i class="glyphicon glyphicon-cog text-warning"></i>
           <span class="sr-only">Edit</i>
         <% end %>
-        <%= link_to [:edit, @workflow, @user_rule, rule_effect], method: :delete, data: {confirm: "Are you sure?"} do %>
+        <%= link_to [@workflow, @user_rule, rule_effect], method: :delete, data: {confirm: "Are you sure?"} do %>
           <i class="glyphicon glyphicon-trash text-danger"></i>
           <span class="sr-only">Delete</i>
         <% end %>

--- a/app/views/workflows/_extractors.html.erb
+++ b/app/views/workflows/_extractors.html.erb
@@ -49,7 +49,7 @@
             <i class="glyphicon glyphicon-cog text-warning"></i>
             <span class="sr-only">Edit</i>
           <% end %>
-          <%= link_to [:edit, @workflow, extractor.becomes(Extractor)], method: :delete, data: {confirm: "Are you sure?"} do %>
+          <%= link_to [@workflow, extractor.becomes(Extractor)], method: :delete, data: {confirm: "Are you sure?"} do %>
             <i class="glyphicon glyphicon-trash text-danger"></i>
             <span class="sr-only">Delete</i>
           <% end %>

--- a/app/views/workflows/_reducers.html.erb
+++ b/app/views/workflows/_reducers.html.erb
@@ -59,7 +59,7 @@
             <i class="glyphicon glyphicon-cog text-warning"></i>
             <span class="sr-only">Edit</i>
           <% end %>
-          <%= link_to [:edit, @workflow, reducer.becomes(Reducer)], method: :delete, data: {confirm: "Are you sure?"} do %>
+          <%= link_to [@workflow, reducer.becomes(Reducer)], method: :delete, data: {confirm: "Are you sure?"} do %>
             <i class="glyphicon glyphicon-trash text-danger"></i>
             <span class="sr-only">Delete</i>
           <% end %>

--- a/app/views/workflows/_rules.html.erb
+++ b/app/views/workflows/_rules.html.erb
@@ -29,7 +29,7 @@
             <i class="glyphicon glyphicon-cog text-warning"></i>
             <span class="sr-only">Edit</i>
           <% end %>
-          <%= link_to [:edit, @workflow, rule], method: :delete, data: {confirm: "Are you sure?"} do %>
+          <%= link_to [@workflow, rule], method: :delete, data: {confirm: "Are you sure?"} do %>
             <i class="glyphicon glyphicon-trash text-danger"></i>
             <span class="sr-only">Delete</i>
           <% end %>
@@ -77,7 +77,7 @@
             <i class="glyphicon glyphicon-cog text-warning"></i>
             <span class="sr-only">Edit</i>
           <% end %>
-          <%= link_to [:edit, @workflow, rule], method: :delete, data: {confirm: "Are you sure?"} do %>
+          <%= link_to [@workflow, rule], method: :delete, data: {confirm: "Are you sure?"} do %>
             <i class="glyphicon glyphicon-trash text-danger"></i>
             <span class="sr-only">Delete</i>
           <% end %>


### PR DESCRIPTION
The delete buttons for extractors, reducers, rules, and rule effects were all mistakenly routed to :edit which caused them to fail. 