### PR TITLE
correct unique arguments for ReduceWorker

### DIFF
--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -8,7 +8,16 @@ class ReduceWorker
   end
 
   def self.unique_args(args)
-    [args[0], args[1], args[2]]
+    reducible_id, reducible_class, subject_id, user_id, extract_ids = args
+    reducible = reducible_class.constantize.find(reducible_id)
+    reducers = reducible.reducers
+
+    uniques = [reducible_id, reducible_class]
+    uniques.push subject_id if reducers.any? { |r| r.reduce_by_subject? }
+    uniques.push user_id if reducers.any? { |r| r.reduce_by_user? }
+    uniques.push extract_ids if reducers.any? { |r| r.running_reduction? }
+
+    uniques
   end
 
   def perform(reducible_id, reducible_class, subject_id, user_id, extract_ids = [])

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -26,4 +26,12 @@ class ReduceWorker
     reductions = reducible.classification_pipeline.reduce(reducible_id, subject_id, user_id, extract_ids)
     CheckRulesWorker.perform_async(reducible_id, reducible_class, subject_id, user_id) unless reductions.blank?
   end
+
+  def self.test_uniq(testing)
+    if testing
+      sidekiq_options unique: :until_and_while_executing, unique_args: :unique_args
+    else
+      sidekiq_options unique: :until_and_while_executing, unique_args: :unique_args unless Rails.env.test?
+    end
+  end
 end

--- a/spec/factories/reducer_factory.rb
+++ b/spec/factories/reducer_factory.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     key { generate(:key) }
     config { {} }
 
+    factory :placeholder_reducer, class: Reducers::PlaceholderReducer
     factory :stats_reducer, class: Reducers::StatsReducer
     factory :external_reducer, class: Reducers::ExternalReducer
   end

--- a/spec/workers/reduce_worker_spec.rb
+++ b/spec/workers/reduce_worker_spec.rb
@@ -1,13 +1,202 @@
-require 'rails_helper'
+require 'spec_helper'
 
-RSpec.describe ReduceWorker, type: :worker do
-  let(:reducible) { create :project }
-  let(:subject) { create :subject }
-  let(:reducer) { create(:stats_reducer, key: 's', reducible: reducible) }
-  let(:pipeline) { reducible.classification_pipeline }
+describe ReduceWorker, type: :worker do
+  describe '#perform' do
+    let(:reducible) { create :project }
+    let(:subject) { create :subject }
+    let(:reducer) { create(:stats_reducer, key: 's', reducible: reducible) }
+    let(:pipeline) { reducible.classification_pipeline }
 
-  it "calls #reduce on the correct pipeline" do
-    expect_any_instance_of(ClassificationPipeline).to receive(:reduce).once.with(reducible.id, subject.id, nil, [])
-    described_class.new.perform(reducible.id, reducible.class.to_s, subject.id, nil)
+    it "calls #reduce on the correct pipeline" do
+      expect_any_instance_of(ClassificationPipeline).to receive(:reduce).once.with(reducible.id, subject.id, nil, [])
+      described_class.new.perform(reducible.id, reducible.class.to_s, subject.id, nil)
+    end
+  end
+
+  describe '#unique_args' do
+    let(:s1) { create :subject }
+    let(:s2) { create :subject }
+
+    let(:workflow_subject_only){ create :workflow }
+    let(:workflow_user_only){ create :workflow }
+    let(:workflow_both){ create :workflow }
+
+    before(:each) do
+      ReduceWorker.test_uniq true
+    end
+
+    after(:each) do
+      ReduceWorker.test_uniq false
+    end
+
+    describe 'with default reduction' do
+      it 'deduplicates correctly when only subject reducers are present' do
+        create :placeholder_reducer, reducible: workflow_subject_only, topic: 0, reduction_mode: 0
+        create :placeholder_reducer, reducible: workflow_subject_only, topic: 0, reduction_mode: 0
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1, nil, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s2, nil, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1, nil, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1, nil, [5, 6])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1, 7, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+      end
+
+      it 'deduplicates correctly when only user reducers are present' do
+        create :placeholder_reducer, reducible: workflow_user_only, topic: 1, reduction_mode: 0
+        create :placeholder_reducer, reducible: workflow_user_only, topic: 1, reduction_mode: 0
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', nil, 7, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', nil, 8, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', nil, 7, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', nil, 7, [5, 6])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 7, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+      end
+
+      it 'deduplicates correctly when both user and subject reducers are present' do
+        create :placeholder_reducer, reducible: workflow_both, topic: 0, reduction_mode: 0
+        create :placeholder_reducer, reducible: workflow_both, topic: 1, reduction_mode: 0
+
+        expect do
+          ReduceWorker.perform_async(workflow_both.id, 'Workflow', nil, 7, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_both.id, 'Workflow', nil, 8, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_both.id, 'Workflow', s1.id, 7, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_both.id, 'Workflow', s1.id, 8, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_both.id, 'Workflow', s2.id, 9, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_both.id, 'Workflow', nil, 7, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_both.id, 'Workflow', s1.id, 7, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_both.id, 'Workflow', s1.id, 7, [5,6])
+        end.not_to change(ReduceWorker.jobs, :size)
+      end
+    end
+
+    describe 'with running reduction' do
+      it 'deduplicates correctly when only subject reducers are present' do
+        create :placeholder_reducer, reducible: workflow_subject_only, topic: 0, reduction_mode: 0
+        create :placeholder_reducer, reducible: workflow_subject_only, topic: 0, reduction_mode: 1
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1.id, nil, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s2.id, nil, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1.id, nil, [5, 6])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1.id, nil, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1.id, 7, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_subject_only.id, 'Workflow', s1.id, nil, [5, 6])
+        end.not_to change(ReduceWorker.jobs, :size)
+      end
+
+      it 'deduplicates correctly when only user reducers are present' do
+        create :placeholder_reducer, reducible: workflow_user_only, topic: 1, reduction_mode: 0
+        create :placeholder_reducer, reducible: workflow_user_only, topic: 1, reduction_mode: 1
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 3, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 4, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 3, [5, 6])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s2.id, 3, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 3, [5])
+        end.not_to change(ReduceWorker.jobs, :size)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 3, [5, 6])
+        end.not_to change(ReduceWorker.jobs, :size)
+      end
+
+      it 'deduplicates correctly when both reducers are present' do
+        create :placeholder_reducer, reducible: workflow_user_only, topic: 0, reduction_mode: 0
+        create :placeholder_reducer, reducible: workflow_user_only, topic: 1, reduction_mode: 1
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 3, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 4, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s2.id, 3, [5])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+
+        expect do
+          ReduceWorker.perform_async(workflow_user_only.id, 'Workflow', s1.id, 3, [5, 6])
+        end.to change(ReduceWorker.jobs, :size).by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
The unique detection for reduction jobs was wonky and has been since the introduction of user reduction and running reduction. This should correctly calculate the arguments for uniquing--note that because these arguments are stored in the redis DB, they are only computed when the item is added to the queue, not every time a sort is performed.

Resolves #319 