### PR TITLE
Add user reductions/actions to graphql schema

### DIFF
--- a/app/graphql/types/action_status_type.rb
+++ b/app/graphql/types/action_status_type.rb
@@ -1,0 +1,8 @@
+Types::ActionStatusType = GraphQL::EnumType.define do
+  name "ActionStatus"
+  description "Status of a pending or performed action"
+
+  value("pending", "Action is not performed yet")
+  value("completed", "Action has been performed successfully")
+  value("failed", "Action failed even after retries")
+end

--- a/app/models/subject_action.rb
+++ b/app/models/subject_action.rb
@@ -1,15 +1,6 @@
 class SubjectAction < ApplicationRecord
-  Status = GraphQL::EnumType.define do
-    name "ActionStatus"
-    description "Status of a pending or performed action"
-
-    value("pending", "Action is not performed yet")
-    value("completed", "Action has been performed successfully")
-    value("failed", "Action failed even after retries")
-  end
-
   Type = GraphQL::ObjectType.define do
-    name "Action"
+    name "SubjectAction"
 
     field :id, !types.ID
 
@@ -19,7 +10,7 @@ class SubjectAction < ApplicationRecord
     field :workflowId, !types.ID, property: :workflow_id
     field :subjectId, !types.ID, property: :subject_id
     field :effectType, !types.String, property: :effect_type
-    field :status, !Status
+    field :status, !Types::ActionStatusType
 
     field :config, Types::JsonType
 

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -1,4 +1,25 @@
 class UserAction < ApplicationRecord
+  Type = GraphQL::ObjectType.define do
+    name "UserAction"
+
+    field :id, !types.ID
+
+    field :classificationId, types.String, property: :classification_id
+    field :classificationAt, Types::TimeType, property: :classification_at
+
+    field :workflowId, !types.ID, property: :workflow_id
+    field :userId, !types.ID, property: :subject_id
+    field :effectType, !types.String, property: :effect_type
+    field :status, !Types::ActionStatusType
+
+    field :config, Types::JsonType
+
+    field :createdAt, !Types::TimeType, property: :created_at
+    field :updatedAt, !Types::TimeType, property: :updated_at
+    field :attemptedAt, Types::TimeType, property: :attempted_at
+    field :completedAt, Types::TimeType, property: :completed_at
+  end
+
   enum status: [:pending, :completed, :failed]
   belongs_to :workflow, counter_cache: true
 

--- a/app/models/user_reduction.rb
+++ b/app/models/user_reduction.rb
@@ -2,7 +2,7 @@ class UserReduction < ApplicationRecord
   include BelongsToReducibleCached
 
   Type = GraphQL::ObjectType.define do
-    name "SubjectReduction"
+    name "UserReduction"
 
     field :projectId, types.ID, property: :project_id
     field :workflowId, !types.ID, property: :workflow_id

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -49,7 +49,7 @@ class Workflow < ApplicationRecord
       argument :subjectId, !types.ID, "Filter by specific subject"
 
       resolve -> (workflow, args, ctx) {
-        scope = Pundit.policy_scope!(ctx[:credential], Action)
+        scope = Pundit.policy_scope!(ctx[:credential], SubjectAction)
         scope = scope.where(workflow_id: workflow.id)
         scope = scope.where(subject_id: args[:subjectId])
         scope
@@ -73,7 +73,7 @@ class Workflow < ApplicationRecord
       argument :userId, !types.ID, "Filter by specific subject"
 
       resolve -> (workflow, args, ctx) {
-        scope = Pundit.policy_scope!(ctx[:credential], Action)
+        scope = Pundit.policy_scope!(ctx[:credential], UserAction)
         scope = scope.where(workflow_id: workflow.id)
         scope = scope.where(user_id: args[:userId])
         scope

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -56,6 +56,30 @@ class Workflow < ApplicationRecord
       }
     end
 
+    field :user_reductions, types[UserReduction::Type] do
+      argument :userId, !types.ID, "Filter by specific user"
+      argument :reducerKey, types.String, "Filter by specific reducer"
+
+      resolve -> (workflow, args, ctx) {
+        scope = Pundit.policy_scope!(ctx[:credential], UserReduction)
+        scope = scope.where(workflow_id: workflow.id)
+        scope = scope.where(user_id: args[:userId])
+        scope = scope.where(reducer_key: args[:reducerKey]) if args[:reducerKey]
+        scope
+      }
+    end
+
+    field :user_actions, types[UserAction::Type] do
+      argument :userId, !types.ID, "Filter by specific subject"
+
+      resolve -> (workflow, args, ctx) {
+        scope = Pundit.policy_scope!(ctx[:credential], Action)
+        scope = scope.where(workflow_id: workflow.id)
+        scope = scope.where(user_id: args[:userId])
+        scope
+      }
+    end
+
     field :dataRequests, types[DataRequest::Type] do
       resolve -> (workflow, args, ctx) {
         scope = Pundit.policy_scope!(ctx[:credential], DataRequest)

--- a/app/policies/subject_action_policy.rb
+++ b/app/policies/subject_action_policy.rb
@@ -1,4 +1,4 @@
-class ActionPolicy < ApplicationPolicy
+class SubjectActionPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)

--- a/app/policies/user_action_policy.rb
+++ b/app/policies/user_action_policy.rb
@@ -1,0 +1,23 @@
+class UserActionPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      workflow_ids = Pundit.policy_scope!(credential, Workflow).pluck(:id)
+
+      scope = self.scope.joins(:workflow).references(:workflows)
+      scope.where(workflow_id: workflow_ids)
+    end
+  end
+
+  def create?
+    update?
+  end
+
+  def update?
+    return true if credential.admin?
+    credential.project_ids.include?(record.workflow.project_id)
+  end
+
+  def destroy?
+    credential.admin?
+  end
+end


### PR DESCRIPTION
As found by @shaunanoordin , our GraphQL schema didn't support querying of the user-related reductions yet. The type existed, but it wasn't accessible through the workflow type.