### PR TITLE
Include different subjects' extractions in new reductions

### DIFF
--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -103,7 +103,7 @@ class ClassificationPipeline
     elsif reducible_class.to_s == "Project"
       filter[:project_id] = reducible_id
     end
-    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids + prior_extracts)
+    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids | prior_extracts)
 
     if prior_extracts.any?
       extract_fetcher.strategy! :fetch_additional

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -94,7 +94,9 @@ class ClassificationPipeline
     if subject_id
       subject = Subject.find(subject_id)
       prior_subject_ids = subject.additional_subject_ids_for_reduction
-      prior_extracts = Extract.where(subject_id: prior_subject_ids).pluck(:id)
+      if prior_subject_ids.any?
+        prior_extracts = Extract.where(subject_id: prior_subject_ids).pluck(:id)
+      end
     end
 
     filter = { subject_id: subject_id, user_id: user_id }

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -105,10 +105,6 @@ class ClassificationPipeline
     end
     extract_fetcher = ExtractFetcher.new(filter).including(extract_ids | prior_extracts)
 
-    if prior_extracts.any?
-      extract_fetcher.strategy! :fetch_additional
-    end
-
     reduction_filter = { reducible_id: reducible_id, reducible_type: reducible_class.to_s, subject_id: subject_id, user_id: user_id }
     reduction_fetcher = ReductionFetcher.new(reduction_filter)
 

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -90,13 +90,24 @@ class ClassificationPipeline
     return [] unless reducers&.present?
     retries ||= 2
 
+    prior_extracts = []
+    if subject_id
+      subject = Subject.find(subject_id)
+      prior_subject_ids = subject.additional_subject_ids_for_reduction
+      prior_extracts = Extract.where(subject_id: prior_subject_ids).pluck(:id)
+    end
+
     filter = { subject_id: subject_id, user_id: user_id }
     if reducible_class.to_s == "Workflow"
       filter[:workflow_id] = reducible_id
     elsif reducible_class.to_s == "Project"
       filter[:project_id] = reducible_id
     end
-    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids)
+    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids + prior_extracts)
+
+    if prior_extracts
+      extract_fetcher.strategy! :fetch_additional
+    end
 
     reduction_filter = { reducible_id: reducible_id, reducible_type: reducible_class.to_s, subject_id: subject_id, user_id: user_id }
     reduction_fetcher = ReductionFetcher.new(reduction_filter)

--- a/app/models/classification_pipeline.rb
+++ b/app/models/classification_pipeline.rb
@@ -105,7 +105,7 @@ class ClassificationPipeline
     end
     extract_fetcher = ExtractFetcher.new(filter).including(extract_ids + prior_extracts)
 
-    if prior_extracts
+    if prior_extracts.any?
       extract_fetcher.strategy! :fetch_additional
     end
 

--- a/app/models/extract_fetcher.rb
+++ b/app/models/extract_fetcher.rb
@@ -2,7 +2,7 @@ class ExtractFetcher
   attr_accessor :reduction_mode, :topic, :extract_ids, :strategy
   attr_reader :filter
 
-  @@strategies = [ :fetch_all, :fetch_minimal, :fetch_additional ]
+  @@strategies = [ :fetch_all, :fetch_minimal ]
   def self.strategies
     @@strategies
   end
@@ -41,12 +41,10 @@ class ExtractFetcher
   def extracts
     if fetch_minimal?
       specified_extracts
-    elsif fetch_additional?
-      subject_extracts + specified_extracts
     elsif fetch_subjects?
-      subject_extracts
+      subject_extracts | specified_extracts
     elsif fetch_users?
-      user_extracts
+      user_extracts | specified_extracts
     end
   end
 

--- a/app/models/extract_fetcher.rb
+++ b/app/models/extract_fetcher.rb
@@ -19,7 +19,7 @@ class ExtractFetcher
     @strategy = strategy.to_sym
     @user_extracts = nil
     @subject_extracts = nil
-    @exact_extracts = nil
+    @specified_extracts = nil
   end
 
   def for(topic)
@@ -40,9 +40,9 @@ class ExtractFetcher
 
   def extracts
     if fetch_minimal?
-      exact_extracts
+      specified_extracts
     elsif fetch_additional?
-      subject_extracts + exact_extracts
+      subject_extracts + specified_extracts
     elsif fetch_subjects?
       subject_extracts
     elsif fetch_users?
@@ -74,7 +74,7 @@ class ExtractFetcher
     @subject_extracts ||= Extract.where(filter.except(:user_id)).order(classification_at: :desc)
   end
 
-  def exact_extracts
-    @exact_extracts ||= Extract.find(@extract_ids).sort_by{ |e| e.classification_at }
+  def specified_extracts
+    @specified_extracts ||= Extract.find(@extract_ids).sort_by{ |e| e.classification_at }
   end
 end

--- a/app/models/extract_fetcher.rb
+++ b/app/models/extract_fetcher.rb
@@ -2,7 +2,7 @@ class ExtractFetcher
   attr_accessor :reduction_mode, :topic, :extract_ids, :strategy
   attr_reader :filter
 
-  @@strategies = [ :fetch_all, :fetch_minimal ]
+  @@strategies = [ :fetch_all, :fetch_minimal, :fetch_additional ]
   def self.strategies
     @@strategies
   end
@@ -41,6 +41,8 @@ class ExtractFetcher
   def extracts
     if fetch_minimal?
       exact_extracts
+    elsif fetch_additional?
+      subject_extracts + exact_extracts
     elsif fetch_subjects?
       subject_extracts
     elsif fetch_users?
@@ -50,6 +52,10 @@ class ExtractFetcher
 
   def fetch_minimal?
     @strategy == :fetch_minimal
+  end
+
+  def fetch_additional?
+    @strategy == :fetch_additional
   end
 
   def fetch_users?

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -14,4 +14,12 @@ class Subject < ApplicationRecord
     retry unless (tries-=1).zero?
     raise
   end
+
+  def additional_subject_ids_for_reduction
+    if metadata["previous_subject_ids"]
+      JSON.parse(metadata["previous_subject_ids"]) 
+    else
+      []
+    end
+  end
 end

--- a/spec/factories/subject_factory.rb
+++ b/spec/factories/subject_factory.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :subject do
+    metadata { {} }
   end
 end


### PR DESCRIPTION
Manifest files from MAST will come in to Panoptes that include in the metadata `{previous_subject_ids: "[1234]"`. These represent incidents in which TESS has already viewed the sector in question and we want to include those previous viewings (extracts) in the reduction of the new subject. This assumes that both subjects exist in Caesar and that the metadata value for `previous_subject_ids` is JSON parsable. 

To include all the extracts in the reduction, I added a new strategy to the ExtractFetcher that will concatenate the typical subject filtered extracts with the extract IDs you can pass it manually. Speccing this feels a little squirrelly, but because of the way that the ExtractFetcher creates new instances of itself, I had to go with `expect_any_instance_of` to make sure that at least one of them got the correct arg to `including`.  The final expect is probably enough on it's own, tbh.

Resolves https://github.com/zooniverse/caesar/issues/385