### PR TITLE
add extractors that fetch reductions' values

### DIFF
--- a/app/models/extractor.rb
+++ b/app/models/extractor.rb
@@ -3,20 +3,24 @@ class Extractor < ApplicationRecord
 
   def self.of_type(type)
     case type.to_s
-    when "blank"
+    when 'blank'
       Extractors::BlankExtractor
-    when "external"
+    when 'external'
       Extractors::ExternalExtractor
-    when "question"
+    when 'question'
       Extractors::QuestionExtractor
-    when "survey"
+    when 'survey'
       Extractors::SurveyExtractor
-    when "who"
+    when 'who'
       Extractors::WhoExtractor
-    when "pluck_field"
+    when 'pluck_field'
       Extractors::PluckFieldExtractor
+    when 'retrieve_user_reduction'
+      Extractors::RetrieveUserReductionExtractor
+    when 'retrieve_subject_reduction'
+      Extractors::RetrieveSubjectReductionExtractor
     else
-      raise "Unknown type #{type}"
+      raise "Unknown extractor type #{type}"
     end
   end
 

--- a/app/models/extractors/retrieve_subject_reduction_extractor.rb
+++ b/app/models/extractors/retrieve_subject_reduction_extractor.rb
@@ -1,0 +1,20 @@
+module Extractors
+  class RetrieveSubjectReductionExtractor < Extractor
+    config_field :reducer_key
+    config_field :default_value
+
+    def extract_data_for(classification)
+      query = SubjectReduction.where(
+        workflow_id: classification.workflow_id,
+        subject_id: classification.subject_id,
+        reducer_key: reducer_key
+      )
+
+      return default_value if query.empty?
+
+      raise StandardError.new('Multiple matching reductions') if query.count > 1
+
+      query.first.data
+    end
+  end
+end

--- a/app/models/extractors/retrieve_user_reduction_extractor.rb
+++ b/app/models/extractors/retrieve_user_reduction_extractor.rb
@@ -1,0 +1,20 @@
+module Extractors
+  class RetrieveUserReductionExtractor < Extractor
+    config_field :reducer_key
+    config_field :default_value
+
+    def extract_data_for(classification)
+      query = UserReduction.where(
+        workflow_id: classification.workflow_id,
+        user_id: classification.user_id,
+        reducer_key: reducer_key
+      )
+
+      return default_value if query.empty?
+
+      raise StandardError.new('Multiple matching extracts') if query.count > 1
+
+      query.first.data
+    end
+  end
+end

--- a/app/views/workflows/_extractors.html.erb
+++ b/app/views/workflows/_extractors.html.erb
@@ -77,6 +77,8 @@
         <li><%= link_to "Question", new_workflow_extractor_path(@workflow, type: 'question') %></li>
         <li><%= link_to "Survey", new_workflow_extractor_path(@workflow, type: 'survey') %></li>
         <li><%= link_to "Who", new_workflow_extractor_path(@workflow, type: 'who') %></li>
+        <li><%= link_to "Retrieve User Reduction", new_workflow_extractor_path(@workflow, type: 'retrieve_user_reduction') %></li>
+        <li><%= link_to "Retrieve Subject Reduction", new_workflow_extractor_path(@workflow, type: 'retrieve_subject_reduction') %></li>
       </ul>
     </div>
   <% end %>

--- a/spec/models/extractors/retrieve_subject_reduction_extractor_spec.rb
+++ b/spec/models/extractors/retrieve_subject_reduction_extractor_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Extractors::RetrieveSubjectReductionExtractor do
+  describe 'validation' do
+    let(:workflow){ build :workflow }
+
+    it 'requires the usual config fields' do
+      expect( described_class.new(workflow: workflow) ).not_to be_valid
+      expect( described_class.new(key: 's') ).not_to be_valid
+    end
+
+    it 'requires a reducer key' do
+      expect( described_class.new(key: 's', workflow: workflow, config: { default_value: 'foo' } ) ).not_to be_valid
+    end
+
+    it 'requires a default value' do
+      expect( described_class.new(key: 's', workflow: workflow, config: { reducer_key: 'blah' } ) ).not_to be_valid
+    end
+
+    it 'validates if everything is set' do
+      expect( described_class.new(key: 's', workflow: workflow, config: { reducer_key: 'blah', default_value: 'foo' } ) ).to be_valid
+    end
+  end
+
+  describe 'extraction' do
+    let(:workflow){ create :workflow }
+    let(:subject) { create :subject }
+
+    let(:classification) do
+      build :classification,
+        subject_id: subject.id,
+        workflow_id: workflow.id
+    end
+
+    let(:extractor) do
+      described_class.new(
+        key: 's',
+        workflow: workflow,
+        config: { reducer_key: 'subject_weight', default_value: { value: 0.5 }}
+      )
+    end
+
+    it 'returns a subject reduction if one exists' do
+      create :subject_reduction, subject_id: subject.id, reducible_type: 'Workflow', reducible_id: workflow.id, reducer_key: 'subject_weight', data: { value: 4 }
+      create :subject_reduction, subject_id: subject.id, reducible_type: 'Workflow', reducible_id: workflow.id, reducer_key: 'dummy', data: { value: 3 }
+
+      expect(extractor.process classification).to eq({ 'value' => 4 })
+    end
+
+    it 'returns the default if no subject reduction exists' do
+      expect(extractor.process classification).to eq({ 'value' => 0.5 })
+    end
+
+    it 'fails if there are multiple reductions' do
+      create :subject_reduction, subject_id: subject.id, reducible_type: 'Workflow', reducible_id: workflow.id, reducer_key: 'subject_weight', data: { value: 3 }
+      create :subject_reduction, subject_id: subject.id, reducible_type: 'Workflow', reducible_id: workflow.id, reducer_key: 'subject_weight', data: { value: 4 }, subgroup: 'blah'
+
+      expect do
+        extractor.process classification
+      end.to raise_error(StandardError)
+    end
+  end
+end

--- a/spec/models/extractors/retrieve_user_reduction_extractor_spec.rb
+++ b/spec/models/extractors/retrieve_user_reduction_extractor_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Extractors::RetrieveUserReductionExtractor do
+  describe 'validation' do
+    let(:workflow){ build :workflow }
+
+    it 'requires the usual config fields' do
+      expect( described_class.new(workflow: workflow) ).not_to be_valid
+      expect( described_class.new(key: 's') ).not_to be_valid
+    end
+
+    it 'requires a reducer key' do
+      expect( described_class.new(key: 's', workflow: workflow, config: { default_value: 'foo' } ) ).not_to be_valid
+    end
+
+    it 'requires a default value' do
+      expect( described_class.new(key: 's', workflow: workflow, config: { reducer_key: 'blah' } ) ).not_to be_valid
+    end
+
+    it 'validates if everything is set' do
+      expect( described_class.new(key: 's', workflow: workflow, config: { reducer_key: 'blah', default_value: 'foo' } ) ).to be_valid
+    end
+  end
+
+  describe 'extraction' do
+    let(:workflow){ create :workflow }
+
+    let(:classification) do
+      build :classification,
+        user_id: 1234,
+        workflow_id: workflow.id
+    end
+
+    let(:extractor) do
+      described_class.new(
+        key: 'u',
+        workflow: workflow,
+        config: { reducer_key: 'user_weight', default_value: { value: 0.5 }}
+      )
+    end
+
+    it 'returns a user reduction if one exists' do
+      create :user_reduction, user_id: 1234, reducible_type: 'Workflow', reducible_id: workflow.id, reducer_key: 'user_weight', data: { value: 4 }
+      create :user_reduction, user_id: 1234, reducible_type: 'Workflow', reducible_id: workflow.id, reducer_key: 'dummy', data: { value: 3 }
+
+      expect(extractor.process classification).to eq({ 'value' => 4 })
+    end
+
+    it 'returns the default if no user reduction exists' do
+      expect(extractor.process classification).to eq({ 'value' => 0.5 })
+    end
+
+    it 'fails if there are multiple reductions' do
+      create :user_reduction, user_id: 1234, reducible_type: 'Workflow', reducible_id: workflow.id, reducer_key: 'user_weight', data: { value: 3 }
+      create :user_reduction, user_id: 1234, reducible_type: 'Workflow', reducible_id: workflow.id, reducer_key: 'user_weight', data: { value: 4 }, subgroup: 'blah'
+
+      expect do
+        extractor.process classification
+      end.to raise_error(StandardError)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #499

adds `RetrieveUserReductionExtractor` and `RetrieveSubjectReductionExtractor`

These extractors will take the relevant id (`user_id` or `subject_id`) from a classification and then use that to find a relevant reduction (either `UserReduction` or `SubjectReduction`) to pass as a new extract.

Each extractor must be configured with a `reducer_key` and a `default_value` to be substituted if no reductions can be found.

An error will be thrown if there is more than one matching reduction.