### PR TITLE
unbreak rerun_reducers

### DIFF
--- a/app/models/is_reducible.rb
+++ b/app/models/is_reducible.rb
@@ -2,11 +2,11 @@ module IsReducible
   extend ActiveSupport::Concern
 
   def concerns_subjects?
-    subject_rules.present? or reducers.where(topic: 'reduce_by_subject').present?
+    reducers.where(topic: 'reduce_by_subject').present?
   end
 
   def concerns_users?
-    user_rules.present? or reducers.where(topic: 'reduce_by_user').present?
+    reducers.where(topic: 'reduce_by_user').present?
   end
 
   def reducers_runner

--- a/spec/controllers/subject_reductions_controller_spec.rb
+++ b/spec/controllers/subject_reductions_controller_spec.rb
@@ -24,7 +24,7 @@ describe SubjectReductionsController, :type => :controller do
       response = get :index, params: { workflow_id: workflow.id, reducer_key: 'r', subject_id: subject1.id }
       results = JSON.parse(response.body)
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(results.size).to be(1)
       expect(results[0]).to include("reducer_key" => "r", "subject_id" => subject1.id)
       expect(results[0]).not_to include("reducer_key" => "s")

--- a/spec/controllers/user_reductions_controller_spec.rb
+++ b/spec/controllers/user_reductions_controller_spec.rb
@@ -24,7 +24,7 @@ describe UserReductionsController, :type => :controller do
       response = get :index, params: { workflow_id: workflow.id, reducer_key: 'r', user_id: user1_id }
       results = JSON.parse(response.body)
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(results.size).to be(1)
       expect(results[0]).to include("reducer_key" => "r", "user_id" => user1_id)
       expect(results[0]).not_to include("reducer_key" => "s")

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe Project, type: :model do
       expect(Project.find(project.id).user_reductions_count).to eq(1)
     end
   end
+
+  describe 'IsReducible' do
+    it 'can re-run reducers' do
+      expect{project.rerun_reducers}.not_to raise_error
+    end
+  end
 end

--- a/spec/models/runs_extractors_spec.rb
+++ b/spec/models/runs_extractors_spec.rb
@@ -43,7 +43,7 @@ describe RunsExtractors do
   let(:workflow) do
     create(:workflow, project_id: 1,
                       extractors: [build(:survey_extractor, key: 's', config: {"task_key" => "T1"})]) do |w|
-      create :subject_rule, workflow: w, subject_rule_effects: [build(:subject_rule_effect, config: {reason: "consensus"})]
+      create :reducer, reducible: w, key: 'r', type: 'Reducers::PlaceholderReducer'
     end
   end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Workflow, type: :model do
 
   describe 'rerun_extractors', sidekiq: :fake do
     it 'enqueues jobs' do
-      extracts = create_list(:extract, 3, workflow: workflow)
+      create_list(:extract, 3, workflow: workflow)
       workflow.rerun_extractors
       expect(FetchClassificationsWorker.jobs.size).to eq(3)
     end
@@ -113,6 +113,11 @@ RSpec.describe Workflow, type: :model do
         expect(ReduceWorker).not_to receive(:perform_in).with(anything, workflow.id, 'Workflow', nil, nil, anything)
         workflow.rerun_reducers
       end
+    end
+  end
+  describe 'IsReducible' do
+    it 'can re-run reducers' do
+      expect{workflow.rerun_reducers}.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
There is no need for IsReducible to check whether a workflow or project has SubjectRules or UserRules configured, and adding that check breaks some code. I removed it, modified a spec so that it correctly tests based on which *reducers* are defined for that reducible, and tidied up some warnings.