### PR TITLE
Adding relevant reductions to active reducers

### DIFF
--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -48,7 +48,7 @@ class Reducer < ApplicationRecord
 
   NoData = Class.new
 
-  def process(extract_fetcher, reduction_fetcher, relevant_reductions)
+  def process(extract_fetcher, reduction_fetcher, relevant_reductions=[])
     light = Stoplight("reducer-#{id}") do
       # if any of the reductions that this reducer cares about have expired, we're
       # going to need to fetch all of the relevant extracts in order to rebuild them

--- a/app/models/reducers/consensus_reducer.rb
+++ b/app/models/reducers/consensus_reducer.rb
@@ -2,7 +2,7 @@ module Reducers
   class ConsensusReducer < Reducer
     config_field :ignore_empty_extracts, default: false
 
-    def reduce_into(extractions, reduction)
+    def reduce_into(extractions, reduction, _relevant_reductions=[])
       store_value = reduction.store || {}
       counter = CountingHash.new(store_value)
 

--- a/app/models/reducers/count_reducer.rb
+++ b/app/models/reducers/count_reducer.rb
@@ -7,7 +7,7 @@
 #
 module Reducers
   class CountReducer < Reducer
-    def reduce_into(extracts, reduction)
+    def reduce_into(extracts, reduction, _relevant_reductions=[])
       data = reduction.data || {}
 
       classifications_count = data.fetch("classifications", 0)

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -5,6 +5,7 @@ module Reducers
     class ExternalReducerFailed < StandardError; end
 
     config_field :url, default: nil
+    config_field :version, default: 1
 
     validate do
       if url.present?
@@ -21,12 +22,12 @@ module Reducers
       end
     end
 
-    def reduce_into(extractions, reduction)
+    def reduce_into(extractions, reduction, relevant_reductions)
       if url
         response = if default_reduction?
           RestClient.post(url, extractions.to_json, {content_type: :json, accept: :json})
         elsif running_reduction?
-          RestClient.post(url, { extracts: extractions, store: reduction.store }.to_json, {content_type: :json, accept: :json})
+          RestClient.post(url, { extracts: extractions, relevant_reductions: relevant_reductions, store: reduction.store }.to_json, {content_type: :json, accept: :json})
         else
           raise StandardError.new("Impossible reducer configuration #{id}")
         end

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -22,12 +22,12 @@ module Reducers
       end
     end
 
-    def reduce_into(extractions, reduction, relevant_reductions)
+    def reduce_into(extractions, reduction, relevant_reductions=[])
       if url
         response = if default_reduction?
           RestClient.post(url, extractions.to_json, {content_type: :json, accept: :json})
         elsif running_reduction?
-          RestClient.post(url, { extracts: extractions, relevant_reductions: relevant_reductions, store: reduction.store }.to_json, {content_type: :json, accept: :json})
+          RestClient.post(url, { extracts: extractions, store: reduction.store, relevant_reductions: relevant_reductions }.to_json, {content_type: :json, accept: :json})
         else
           raise StandardError.new("Impossible reducer configuration #{id}")
         end

--- a/app/models/reducers/first_extract_reducer.rb
+++ b/app/models/reducers/first_extract_reducer.rb
@@ -6,7 +6,7 @@
 #
 module Reducers
   class FirstExtractReducer < Reducer
-    def reduce_into(extractions, reduction)
+    def reduce_into(extractions, reduction, _relevant_reductions=[])
       reduction.tap do |r|
         r.data = if reduction.data.blank? then (extractions&.fetch(0, nil)&.data || {}) else reduction.data end
       end

--- a/app/models/reducers/placeholder_reducer.rb
+++ b/app/models/reducers/placeholder_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class PlaceholderReducer < Reducer
-    def reduce_into(extracts, reduction)
+    def reduce_into(extracts, reduction, _relevant_reductions=[])
       reduction.tap do |r|
         r.data = nil
       end

--- a/app/models/reducers/sqs_reducer.rb
+++ b/app/models/reducers/sqs_reducer.rb
@@ -9,7 +9,7 @@ module Reducers
       end
     end
 
-    def reduce_into(extracts, reduction)
+    def reduce_into(extracts, reduction, _relevant_reductions=[])
       extracts.map do |extract|
         {
           message_body: prepare_extract(extract).to_json,

--- a/app/models/reducers/stats_reducer.rb
+++ b/app/models/reducers/stats_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class StatsReducer < Reducer
-    def reduce_into(extractions, reduction)
+    def reduce_into(extractions, reduction, _relevant_reductions=[])
       data = reduction.data || {}
 
       reduction.tap do |r|

--- a/app/models/reducers/summary_statistics_reducer.rb
+++ b/app/models/reducers/summary_statistics_reducer.rb
@@ -68,7 +68,7 @@ module Reducers
     end
 
 
-    def reduce_into(extracts, reduction)
+    def reduce_into(extracts, reduction, _relevant_reductions=[])
       @old_store = reduction.store || {}
       @new_store = {}
 

--- a/app/models/reducers/unique_count_reducer.rb
+++ b/app/models/reducers/unique_count_reducer.rb
@@ -2,7 +2,7 @@ module Reducers
   class UniqueCountReducer < Reducer
     config_field :field
 
-    def reduce_into(extracts, reduction)
+    def reduce_into(extracts, reduction, _relevant_reductions=[])
       store = reduction.store || {}
       store["items"] = [] unless store.key? "items"
 

--- a/spec/models/reducer_spec.rb
+++ b/spec/models/reducer_spec.rb
@@ -114,6 +114,22 @@ RSpec.describe Reducer, type: :model do
     expect(reductions[1][:data].count).to eq(1)
   end
 
+  # it "passes on relevant reductions" do
+  #   workflow = create(:workflow)
+  #   reduction = create(:subject_reduction, reducible: workflow)
+  #   relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 1, reducible: workflow, reducer_key: 'skillz'
+  #   reducer = build :reducer, topic: :reduce_by_subject, config: {user_reducer_keys: ['skillz']}
+
+  #   allow(reducer).to receive(:get_reduction).and_return(reduction)
+
+  #   extract_fetcher = instance_double(ExtractFetcher, extracts: extracts)
+  #   reduction_fetcher = instance_double(ReductionFetcher, retrieve: SubjectReduction, has_expired?: false)
+
+  #   expect(reducer).to receive(:reduce_into).with(extract_fetcher.extracts, reduction, [relevant_reduction])
+
+  #   reducer.process(extract_fetcher, reduction_fetcher, relevant_reduction: [relevant_reduction])
+  # end
+
   describe 'validations' do
     it 'is not valid with invalid filters' do
       reducer = Reducer.new filters: {repeated_classifications: "something"}
@@ -232,7 +248,7 @@ RSpec.describe Reducer, type: :model do
       allow(subject_reduction_double).to receive(:expired=)
 
       running_reducer.process(extract_fetcher, reduction_fetcher)
-      expect(running_reducer).to have_received(:reduce_into).with([extract2], subject_reduction_double)
+      expect(running_reducer).to have_received(:reduce_into).with([extract2], subject_reduction_double, [])
     end
   end
 end

--- a/spec/models/reducer_spec.rb
+++ b/spec/models/reducer_spec.rb
@@ -114,22 +114,6 @@ RSpec.describe Reducer, type: :model do
     expect(reductions[1][:data].count).to eq(1)
   end
 
-  # it "passes on relevant reductions" do
-  #   workflow = create(:workflow)
-  #   reduction = create(:subject_reduction, reducible: workflow)
-  #   relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 1, reducible: workflow, reducer_key: 'skillz'
-  #   reducer = build :reducer, topic: :reduce_by_subject, config: {user_reducer_keys: ['skillz']}
-
-  #   allow(reducer).to receive(:get_reduction).and_return(reduction)
-
-  #   extract_fetcher = instance_double(ExtractFetcher, extracts: extracts)
-  #   reduction_fetcher = instance_double(ReductionFetcher, retrieve: SubjectReduction, has_expired?: false)
-
-  #   expect(reducer).to receive(:reduce_into).with(extract_fetcher.extracts, reduction, [relevant_reduction])
-
-  #   reducer.process(extract_fetcher, reduction_fetcher, relevant_reduction: [relevant_reduction])
-  # end
-
   describe 'validations' do
     it 'is not valid with invalid filters' do
       reducer = Reducer.new filters: {repeated_classifications: "something"}

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -57,6 +57,14 @@ describe Reducers::ExternalReducer do
     end.to raise_error(StandardError)
   end
 
+  it 'includes relevant reductions' do
+    reducer = described_class.new(reducible: workflow, config: {user_reducer_keys: "skillz", "url" => "http://foo.com"})
+    extract = create :extract, workflow_id: workflow.id, user_id: 111, data: { test: 1 }
+    relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 111, reducible: workflow, reducer_key: 'skillz'
+
+    result = reducer.reduce_into(extracts, build(:subject_reduction), [relevant_reduction])
+  end
+
   describe 'validations' do
     it 'is not valid with a non-https url' do
       reducer = described_class.new(config: {"url" => "http://foo.com"})

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -57,14 +57,6 @@ describe Reducers::ExternalReducer do
     end.to raise_error(StandardError)
   end
 
-  it 'includes relevant reductions' do
-    reducer = described_class.new(reducible: workflow, config: {user_reducer_keys: "skillz", "url" => "http://foo.com"})
-    extract = create :extract, workflow_id: workflow.id, user_id: 111, data: { test: 1 }
-    relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 111, reducible: workflow, reducer_key: 'skillz'
-
-    result = reducer.reduce_into(extracts, build(:subject_reduction), [relevant_reduction])
-  end
-
   describe 'validations' do
     it 'is not valid with a non-https url' do
       reducer = described_class.new(config: {"url" => "http://foo.com"})
@@ -91,7 +83,8 @@ describe Reducers::ExternalReducer do
 
     let(:request_data){{
       extracts: extracts,
-      store: running_reduction.store
+      store: running_reduction.store,
+      relevant_reductions: []
     }}
 
     it 'sends the extracts and the store' do
@@ -119,6 +112,24 @@ describe Reducers::ExternalReducer do
 
       reducer.reduce_into(extracts, running_reduction)
       expect(running_reduction.store).to have_key('bar')
+    end
+
+    it 'includes relevant reductions' do
+      relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 111, reducible: workflow, reducer_key: 'skillz'
+      running_reducer.user_reducer_keys = "skillz"
+
+      request_data[:relevant_reductions] = [relevant_reduction]
+
+      stub_request(:post, valid_url)
+        .with(:headers => {'Accept'=>'application/json',
+                          'Content-Type'=>'application/json',
+                          'Host'=>'example.org'})
+        .to_return(:status => 200, :body => request_data.to_json, :headers => {})
+
+      reducer.reduce_into(extracts, running_reduction, [relevant_reduction])
+      expect(a_request(:post, valid_url)
+              .with(body: request_data.to_json))
+        .to have_been_made.once
     end
   end
 end

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -114,9 +114,29 @@ describe Reducers::ExternalReducer do
       expect(running_reduction.store).to have_key('bar')
     end
 
-    it 'includes relevant reductions' do
+    it 'includes relevant user reductions' do
       relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 111, reducible: workflow, reducer_key: 'skillz'
       running_reducer.user_reducer_keys = "skillz"
+
+      request_data[:relevant_reductions] = [relevant_reduction]
+
+      stub_request(:post, valid_url)
+        .with(:headers => {'Accept'=>'application/json',
+                          'Content-Type'=>'application/json',
+                          'Host'=>'example.org'})
+        .to_return(:status => 200, :body => request_data.to_json, :headers => {})
+
+      reducer.reduce_into(extracts, running_reduction, [relevant_reduction])
+      expect(a_request(:post, valid_url)
+              .with(body: request_data.to_json))
+        .to have_been_made.once
+    end
+
+    it 'includes relevant subject reductions' do
+      subject = create(:subject)
+      relevant_reduction = create :subject_reduction, data: {probability: 0.94}, subject_id: subject.id, reducible: workflow, reducer_key: 'skillz'
+
+      running_reducer.subject_reducer_keys = "skillz"
 
       request_data[:relevant_reductions] = [relevant_reduction]
 

--- a/spec/models/runs_reducers_spec.rb
+++ b/spec/models/runs_reducers_spec.rb
@@ -145,6 +145,21 @@ describe RunsReducers do
     expect(UserReduction.first.data).to eq({"LN" => 2})
   end
 
+  it 'includes relevant reductions' do
+    subject = create(:subject)
+    workflow = create(:workflow)
+
+    extract = create :extract, workflow_id: workflow.id, user_id: 111, subject_id: subject.id, classification_id: 11111, data: { test: 1 }
+    relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 111, reducible: workflow, reducer_key: 'skillz'
+
+    reducer = create :stats_reducer, reducible: workflow, config: {user_reducer_keys: "skillz"}
+    runner = described_class.new(workflow, [reducer])
+
+    reductions = runner.reduce(subject.id, nil)
+    expect(reducer).to have_received(:reduce_into).with([extract], [reduction], [relevant_reduction]).and_call_original
+
+  end
+
   context "reducing by project" do
     let(:project) { create :project }
     let(:reducer) { create(:stats_reducer, key: 's', reducible: project) }

--- a/spec/models/runs_reducers_spec.rb
+++ b/spec/models/runs_reducers_spec.rb
@@ -145,21 +145,6 @@ describe RunsReducers do
     expect(UserReduction.first.data).to eq({"LN" => 2})
   end
 
-  it 'includes relevant reductions' do
-    subject = create(:subject)
-    workflow = create(:workflow)
-
-    extract = create :extract, workflow_id: workflow.id, user_id: 111, subject_id: subject.id, classification_id: 11111, data: { test: 1 }
-    relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 111, reducible: workflow, reducer_key: 'skillz'
-
-    reducer = create :stats_reducer, reducible: workflow, config: {user_reducer_keys: "skillz"}
-    runner = described_class.new(workflow, [reducer])
-
-    reductions = runner.reduce(subject.id, nil)
-    expect(reducer).to have_received(:reduce_into).with([extract], [reduction], [relevant_reduction]).and_call_original
-
-  end
-
   context "reducing by project" do
     let(:project) { create :project }
     let(:reducer) { create(:stats_reducer, key: 's', reducible: project) }


### PR DESCRIPTION
Pulls relevant reductions (that is, they have a matching `user_` or `subject_reducer_key` in its config) in RunsReducers. They're passed along to Reducer#process, and then on to the specific reducer#reduce_into. Only the external reducer model currently needs these, and the argument defaults to an empty array.

This allows the building of subject reducers for TESS that can include relevant user's skill reductions, to be sent to external reducers for probability calculation.