### PR TITLE
Serialize SubjectReductions for ExternalEffects

### DIFF
--- a/app/models/effects/external.rb
+++ b/app/models/effects/external.rb
@@ -7,13 +7,14 @@ module Effects
       raise InvalidConfiguration unless valid?
 
       reductions = SubjectReduction.where(
-        workflow_id: workflow_id, 
-        subject_id: subject_id, 
+        workflow_id: workflow_id,
+        subject_id: subject_id,
       )
       reductions = reductions.where(reducer_key: config[:reducer_key]) if config[:reducer_key]
 
       begin
-        response = RestClient.post(url, reductions.to_json, {content_type: :json, accept: :json})
+        body = reductions.map{|r| r.prepare}.to_json
+        response = RestClient.post(url, body, {content_type: :json, accept: :json})
       rescue RestClient::InternalServerError
         raise ExternalEffectFailed
       end
@@ -27,7 +28,7 @@ module Effects
       [:url, :reducer_key].freeze
     end
 
-    def url 
+    def url
       config[:url]
     end
 

--- a/app/models/effects/external.rb
+++ b/app/models/effects/external.rb
@@ -9,19 +9,22 @@ module Effects
       reductions = SubjectReduction.where(
         workflow_id: workflow_id,
         subject_id: subject_id,
+        reducer_key: reducer_key
       )
-      reductions = reductions.where(reducer_key: config[:reducer_key]) if config[:reducer_key]
+
+      if reductions.length != 1
+        raise ExternalEffectFailed, "Incorrect number of reductions found"
+      end
 
       begin
-        body = reductions.map{|r| r.prepare}.to_json
-        response = RestClient.post(url, body, {content_type: :json, accept: :json})
+        response = RestClient.post(url, reductions.first.prepare.to_json, {content_type: :json, accept: :json})
       rescue RestClient::InternalServerError
         raise ExternalEffectFailed
       end
     end
 
     def valid?
-      url.present? && valid_url?
+      reducer_key.present? && url.present? && valid_url?
     end
 
     def self.config_fields
@@ -30,6 +33,10 @@ module Effects
 
     def url
       config[:url]
+    end
+
+    def reducer_key
+      config[:reducer_key]
     end
 
     def valid_url?

--- a/app/models/subject_reduction.rb
+++ b/app/models/subject_reduction.rb
@@ -23,6 +23,7 @@ class SubjectReduction < ApplicationRecord
       id: id,
       reducible: { id: reducible_id, type: reducible_type },
       data: data,
+      user_ids: extracts.pluck(:user_id),
       subject: subject.attributes,
       created_at: created_at,
       updated_at: updated_at

--- a/app/models/subject_reduction.rb
+++ b/app/models/subject_reduction.rb
@@ -17,4 +17,15 @@ class SubjectReduction < ApplicationRecord
 
   belongs_to :subject
   has_and_belongs_to_many_with_deferred_save :extracts
+
+  def prepare
+    {
+      id: id,
+      reducible: { id: reducible_id, type: reducible_type },
+      data: data,
+      subject: subject.attributes,
+      created_at: created_at,
+      updated_at: updated_at
+    }.with_indifferent_access
+  end
 end

--- a/spec/models/effects/external_spec.rb
+++ b/spec/models/effects/external_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Effects::External do
-  let(:reduction) { create(:subject_reduction, reducer_key: "key") }
+  let(:subject) { create(:subject) }
+  let(:reduction) { create(:subject_reduction, reducer_key: "key", subject: subject, data: {}) }
   let(:url) { "https://example.org/post/reduction/here" }
   let(:effect) { described_class.new(url: url, reducer_key: "key") }
 
@@ -11,7 +12,8 @@ describe Effects::External do
 
   it 'sends the reductions to the external API' do
     effect.perform(reduction.workflow_id, reduction.subject_id)
-    expect(a_request(:post, url).with(body: [reduction].to_json))
+    # expect(a_request(:post, url).with(body: [reduction_json]))
+    expect(a_request(:post, url).with(body: [reduction.prepare].to_json))
       .to have_been_made.once
   end
 
@@ -27,7 +29,7 @@ describe Effects::External do
     effect = described_class.new(url: url)
     effect.perform(reduction.workflow_id, reduction.subject_id)
 
-    expect(a_request(:post, url).with(body: [reduction].to_json))
+    expect(a_request(:post, url).with(body: [reduction.prepare].to_json))
       .to have_been_made.once
   end
 

--- a/spec/models/effects/external_spec.rb
+++ b/spec/models/effects/external_spec.rb
@@ -12,33 +12,16 @@ describe Effects::External do
 
   it 'sends the reductions to the external API' do
     effect.perform(reduction.workflow_id, reduction.subject_id)
-    # expect(a_request(:post, url).with(body: [reduction_json]))
-    expect(a_request(:post, url).with(body: [reduction.prepare].to_json))
+    expect(a_request(:post, url).with(body: reduction.prepare.to_json))
       .to have_been_made.once
   end
 
-  it 'does not include reductions that do not match the reducer key' do
-    effect = described_class.new(url: url, reducer_key: "yarp")
-    effect.perform(reduction.workflow_id, reduction.subject_id)
-
-    expect(a_request(:post, url).with(body: [].to_json))
-      .to have_been_made.once
-  end
-
-  it 'includes all reductions if no key is specified' do
-    effect = described_class.new(url: url)
-    effect.perform(reduction.workflow_id, reduction.subject_id)
-
-    expect(a_request(:post, url).with(body: [reduction.prepare].to_json))
-      .to have_been_made.once
-  end
-
-  it 'does not post if no url is configured' do
-    effect = described_class.new(url: nil)
+  it 'raises an error if more than one reduction is matched' do
+    new_reduction = create(:subject_reduction, reducible: reduction.reducible, subgroup: "lol", reducer_key: "key", subject: subject, data: {})
 
     expect do
       effect.perform(reduction.workflow_id, reduction.subject_id)
-    end.to raise_error(Effects::External::InvalidConfiguration)
+    end.to raise_error(Effects::External::ExternalEffectFailed)
   end
 
   it 'raises an error if the post fails' do
@@ -58,6 +41,22 @@ describe Effects::External do
     it 'is not valid with some strange url' do
       effect = described_class.new(url: "https:\\foo+3")
       expect(effect).not_to be_valid
+    end
+
+    it 'raises an error if no key is specified' do
+      effect = described_class.new(url: url)
+
+      expect do
+        effect.perform(reduction.workflow_id, reduction.subject_id)
+      end.to raise_error(Effects::External::InvalidConfiguration)
+    end
+
+    it 'does not post if no url is configured' do
+      effect = described_class.new(url: nil)
+
+      expect do
+        effect.perform(reduction.workflow_id, reduction.subject_id)
+      end.to raise_error(Effects::External::InvalidConfiguration)
     end
   end
 end

--- a/spec/models/subject_reduction_spec.rb
+++ b/spec/models/subject_reduction_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe SubjectReduction, type: :model do
+
+  it "should not fail to build the factory" do
+    expect(build(:subject_reduction)).to be_valid
+  end
+
+  it "should prepare auxiliary attributes" do
+    extract1 = create(:extract, user_id: 1)
+    extract2 = create(:extract, user_id: 2)
+    extract3 = create(:extract, user_id: 3)
+    reduction = create(:subject_reduction, extracts: [extract1, extract2, extract3])
+
+    prepared = reduction.prepare
+    expect(prepared[:user_ids]).to include(extract1.user_id, extract2.user_id, extract3.user_id)
+    expect(prepared[:subject]).to eq(reduction.subject.attributes)
+  end
+end


### PR DESCRIPTION
SubjectReductions that are sent to external targets via an ExternalEffect shouldn't simply be `to_json`'d, as auxiliary attributes (subject, user_ids) are needed and there's a lot of stuff that only caesar cares about. The new method grabs all that makes it available to effects.

Also a new bit of logic that requires ExternalEffects to have a `config[:reducer_key]` defined and only ever send a single reduction out to the target.