### PR TITLE
Allow all users to access their own reductions

### DIFF
--- a/app/controllers/subject_reductions_controller.rb
+++ b/app/controllers/subject_reductions_controller.rb
@@ -1,6 +1,6 @@
 class SubjectReductionsController < ApplicationController
   def index
-    reductions = policy_scope(SubjectReduction).where(reducible_id: reducible.id, subject_id: params[:subject_id])
+    reductions = policy_scope(SubjectReduction).where(reducible_id: reducible.id, reducible_type: reducible_type, subject_id: params[:subject_id])
     reductions = reductions.where(reducer_key: params[:reducer_key]) if params.key?(:reducer_key)
 
     render json: reductions

--- a/app/controllers/user_reductions_controller.rb
+++ b/app/controllers/user_reductions_controller.rb
@@ -1,6 +1,6 @@
 class UserReductionsController < ApplicationController
   def index
-    reductions = policy_scope(UserReduction).where(reducible_id: reducible.id, user_id: params[:user_id])
+    reductions = policy_scope(UserReduction).where(reducible_id: reducible_id, reducible_type: reducible_type, user_id: params[:user_id])
     reductions = reductions.where(reducer_key: params[:reducer_key]) if params.key?(:reducer_key)
 
     render json: reductions
@@ -22,20 +22,6 @@ class UserReductionsController < ApplicationController
     render json: reduction
   end
 
-  def current_user_reductions
-    reducible_type = params[:reducible_type].titleize.singularize
-    reducible_id = params[:reducible_id]
-
-    reductions = UserReduction.where(
-      user_id: credential.user_id,
-      reducible_type: reducible_type,
-      reducible_id: reducible_id
-    )
-
-    authorize reductions
-    render json: reductions
-  end
-
   private
 
   def reducible
@@ -44,6 +30,10 @@ class UserReductionsController < ApplicationController
                     elsif params[:project_id]
                       policy_scope(Project).find(params[:project_id])
                     end
+  end
+
+  def reducible_id
+    params[:workflow_id] || params[:project_id]
   end
 
   def reducible_type

--- a/app/controllers/user_reductions_controller.rb
+++ b/app/controllers/user_reductions_controller.rb
@@ -22,6 +22,20 @@ class UserReductionsController < ApplicationController
     render json: reduction
   end
 
+  def current_user_reductions
+    reducible_type = params[:reducible_type].titleize.singularize
+    reducible_id = params[:reducible_id]
+
+    reductions = UserReduction.where(
+      user_id: credential.current_user_id,
+      reducible_type: reducible_type,
+      reducible_id: reducible_id
+    )
+
+    authorize reductions
+    render json: reductions
+  end
+
   private
 
   def reducible

--- a/app/controllers/user_reductions_controller.rb
+++ b/app/controllers/user_reductions_controller.rb
@@ -26,9 +26,9 @@ class UserReductionsController < ApplicationController
 
   def reducible
     @reducible ||=  if params[:workflow_id]
-                      policy_scope(Workflow).find(params[:workflow_id]) 
+                      policy_scope(Workflow).find(params[:workflow_id])
                     elsif params[:project_id]
-                      policy_scope(Project).find(params[:project_id]) 
+                      policy_scope(Project).find(params[:project_id])
                     end
   end
 

--- a/app/controllers/user_reductions_controller.rb
+++ b/app/controllers/user_reductions_controller.rb
@@ -27,7 +27,7 @@ class UserReductionsController < ApplicationController
     reducible_id = params[:reducible_id]
 
     reductions = UserReduction.where(
-      user_id: credential.current_user_id,
+      user_id: credential.user_id,
       reducible_type: reducible_type,
       reducible_id: reducible_id
     )

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -17,7 +17,7 @@ class Credential < ApplicationRecord
     jwt_payload.fetch("login")
   end
 
-  def current_user_id
+  def user_id
     jwt_payload["id"]
   end
 

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -17,6 +17,10 @@ class Credential < ApplicationRecord
     jwt_payload.fetch("login")
   end
 
+  def current_user_id
+    jwt_payload["id"]
+  end
+
   def admin?
     return true if Rails.env.development?
     jwt_payload.fetch("admin", false)

--- a/app/models/fake_credential.rb
+++ b/app/models/fake_credential.rb
@@ -3,6 +3,10 @@ class FakeCredential
     'dev'
   end
 
+  def current_user_id
+    3
+  end
+
   def ok?
     true
   end

--- a/app/models/fake_credential.rb
+++ b/app/models/fake_credential.rb
@@ -3,7 +3,7 @@ class FakeCredential
     'dev'
   end
 
-  def current_user_id
+  def user_id
     3
   end
 

--- a/app/policies/user_reduction_policy.rb
+++ b/app/policies/user_reduction_policy.rb
@@ -21,6 +21,11 @@ class UserReductionPolicy < ApplicationPolicy
     credential.project_ids.include?(record.reducible.project_id)
   end
 
+  def current_user_reductions?
+    return true if credential.admin?
+    record.all? { |reduction| credential.current_user_id == reduction.user_id }
+  end
+
   def destroy?
     credential.admin?
   end

--- a/app/policies/user_reduction_policy.rb
+++ b/app/policies/user_reduction_policy.rb
@@ -9,6 +9,7 @@ class UserReductionPolicy < ApplicationPolicy
 
       self.scope.where(reducible_type: 'Workflow', reducible_id: workflow_ids)
         .or(self.scope.where(reducible_type: 'Project', reducible_id: project_ids))
+        .or(self.scope.where(user_id: credential.user_id))
     end
   end
 
@@ -19,11 +20,6 @@ class UserReductionPolicy < ApplicationPolicy
   def update?
     return true if credential.admin?
     credential.project_ids.include?(record.reducible.project_id)
-  end
-
-  def current_user_reductions?
-    return true if credential.admin?
-    record.all? { |reduction| credential.user_id == reduction.user_id }
   end
 
   def destroy?

--- a/app/policies/user_reduction_policy.rb
+++ b/app/policies/user_reduction_policy.rb
@@ -23,7 +23,7 @@ class UserReductionPolicy < ApplicationPolicy
 
   def current_user_reductions?
     return true if credential.admin?
-    record.all? { |reduction| credential.current_user_id == reduction.user_id }
+    record.all? { |reduction| credential.user_id == reduction.user_id }
   end
 
   def destroy?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,4 @@ Rails.application.routes.draw do
     end
     resources :data_requests
   end
-
-  get 'my/user_reductions/:reducible_type/:reducible_id', to: 'user_reductions#current_user_reductions', format: :json
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,4 +68,6 @@ Rails.application.routes.draw do
     end
     resources :data_requests
   end
+
+  get 'my/user_reductions/:reducible_type/:reducible_id', to: 'user_reductions#current_user_reductions', format: :json
 end

--- a/spec/controllers/user_reductions_controller_spec.rb
+++ b/spec/controllers/user_reductions_controller_spec.rb
@@ -15,91 +15,110 @@ describe UserReductionsController, :type => :controller do
     ]
   }
 
-  before { fake_session(admin: true) }
+  describe 'as user' do
+    before { fake_session(admin: false, current_user_id: user1_id) }
+    let(:workflow2) { create :workflow }
 
-  describe '#index' do
-    it 'returns only the requested reductions' do
+    it 'returns user reductions for the user' do
       reductions
+      create(:user_reduction, reducible: workflow2, user_id: user1_id, reducer_key: reducer2.key, data: {'2' => 1})
 
-      response = get :index, params: { workflow_id: workflow.id, reducer_key: 'r', user_id: user1_id }
+      response = get :current_user_reductions, params: { reducible_type: 'Workflow', reducible_id: workflow.id }, format: :json
       results = JSON.parse(response.body)
 
+      # there are four total reductions but only two belong to this user in this workflow
       expect(response).to be_successful
-      expect(results.size).to be(1)
-      expect(results[0]).to include("reducer_key" => "r", "user_id" => user1_id)
-      expect(results[0]).not_to include("reducer_key" => "s")
-      expect(results[0]).not_to include("user_id" => user2_id)
+      expect(results.size).to be(2)
     end
   end
 
-  describe '#update' do
-    before { allow(CheckRulesWorker).to receive(:perform_async) }
+  describe 'as admin' do
+    before { fake_session(admin: true) }
 
-    it 'updates an existing reduction' do
-      reductions
+    describe '#index' do
+      it 'returns only the requested reductions' do
+        reductions
 
-      post :update, params: {
-        workflow_id: workflow.id,
-        reducer_key: reducer1.key,
-        reduction: {
-          user_id: user1_id,
-          subgroup: '_default',
-          data: { blah: 10 }
-        }
-      }, as: :json
+        response = get :index, params: { workflow_id: workflow.id, reducer_key: 'r', user_id: user1_id }
+        results = JSON.parse(response.body)
 
-      updated = UserReduction.find_by(
-        reducible_id: workflow.id,
-        reducible_type: "Workflow",
-        reducer_key: reducer1.key,
-        user_id: user1_id
-      )
-
-      expect(UserReduction.count).to eq(3)
-      expect(updated.id).to eq(reductions[0].id)
-      expect(updated.data).to eq("blah" => 10)
-      expect(CheckRulesWorker).to have_received(:perform_async).with(workflow.id, "Workflow", user1_id).once
+        expect(response).to be_successful
+        expect(results.size).to be(1)
+        expect(results[0]).to include("reducer_key" => "r", "user_id" => user1_id)
+        expect(results[0]).not_to include("reducer_key" => "s")
+        expect(results[0]).not_to include("user_id" => user2_id)
+      end
     end
 
-    it 'creates new reductions if needed' do
-      reductions
+    describe '#update' do
+      before { allow(CheckRulesWorker).to receive(:perform_async) }
 
-      post :update, params: {
-        workflow_id: workflow.id,
-        reducer_key: reducer2.key,
-        reduction: {
-          user_id: user2_id,
-          subgroup: '_default',
-          data: { blah: 10 }
-        }
-      }, as: :json
+      it 'updates an existing reduction' do
+        reductions
 
-      updated = UserReduction.find_by(
-        reducible_id: workflow.id,
-        reducible_type: "Workflow",
-        reducer_key: reducer2.key,
-        user_id: user2_id
-      )
+        post :update, params: {
+          workflow_id: workflow.id,
+          reducer_key: reducer1.key,
+          reduction: {
+            user_id: user1_id,
+            subgroup: '_default',
+            data: { blah: 10 }
+          }
+        }, as: :json
 
-      expect(UserReduction.count).to eq(4)
-      expect(updated.data).to eq("blah" => 10)
-      expect(CheckRulesWorker).to have_received(:perform_async).with(workflow.id, "Workflow", user2_id).once
-    end
+        updated = UserReduction.find_by(
+          reducible_id: workflow.id,
+          reducible_type: "Workflow",
+          reducer_key: reducer1.key,
+          user_id: user1_id
+        )
 
-    it 'does not check rules if nothing changed' do
-      reductions
+        expect(UserReduction.count).to eq(3)
+        expect(updated.id).to eq(reductions[0].id)
+        expect(updated.data).to eq("blah" => 10)
+        expect(CheckRulesWorker).to have_received(:perform_async).with(workflow.id, "Workflow", user1_id).once
+      end
 
-      post :update, params: {
-        workflow_id: workflow.id,
-        reducer_key: reducer1.key,
-        reduction: {
-          user_id: user1_id,
-          subgroup: '_default',
-          data: reductions[0].data
-        }
-      }, as: :json
+      it 'creates new reductions if needed' do
+        reductions
 
-      expect(CheckRulesWorker).not_to have_received(:perform_async)
+        post :update, params: {
+          workflow_id: workflow.id,
+          reducer_key: reducer2.key,
+          reduction: {
+            user_id: user2_id,
+            subgroup: '_default',
+            data: { blah: 10 }
+          }
+        }, as: :json
+
+        updated = UserReduction.find_by(
+          reducible_id: workflow.id,
+          reducible_type: "Workflow",
+          reducer_key: reducer2.key,
+          user_id: user2_id
+        )
+
+        expect(UserReduction.count).to eq(4)
+        expect(updated.data).to eq("blah" => 10)
+        expect(CheckRulesWorker).to have_received(:perform_async).with(workflow.id, "Workflow", user2_id).once
+      end
+
+      it 'does not check rules if nothing changed' do
+        reductions
+
+        post :update, params: {
+          workflow_id: workflow.id,
+          reducer_key: reducer1.key,
+          reduction: {
+            user_id: user1_id,
+            subgroup: '_default',
+            data: reductions[0].data
+          }
+        }, as: :json
+
+        expect(CheckRulesWorker).not_to have_received(:perform_async)
+      end
     end
   end
 end

--- a/spec/controllers/user_reductions_controller_spec.rb
+++ b/spec/controllers/user_reductions_controller_spec.rb
@@ -23,8 +23,10 @@ describe UserReductionsController, :type => :controller do
       reductions
       create(:user_reduction, reducible: workflow2, user_id: user1_id, reducer_key: reducer2.key, data: {'2' => 1})
 
-      response = get :current_user_reductions, params: { reducible_type: 'Workflow', reducible_id: workflow.id }, format: :json
+      response = get :index, params: { workflow_id: workflow.id, user_id: user1_id }
       results = JSON.parse(response.body)
+
+      # binding.pry
 
       # there are four total reductions but only two belong to this user in this workflow
       expect(response).to be_successful

--- a/spec/controllers/user_reductions_controller_spec.rb
+++ b/spec/controllers/user_reductions_controller_spec.rb
@@ -16,7 +16,7 @@ describe UserReductionsController, :type => :controller do
   }
 
   describe 'as user' do
-    before { fake_session(admin: false, current_user_id: user1_id) }
+    before { fake_session(admin: false, user_id: user1_id) }
     let(:workflow2) { create :workflow }
 
     it 'returns user reductions for the user' do

--- a/spec/models/credential_spec.rb
+++ b/spec/models/credential_spec.rb
@@ -28,7 +28,7 @@ describe Credential, type: :model do
     allow_any_instance_of(Panoptes::Client).to receive(:jwt_signing_public_key).and_return(rsa_public)
 
     credential = Credential.create!(token: token)
-    expect(credential.current_user_id).to eq(3)
+    expect(credential.user_id).to eq(3)
   end
 
   it 'defaults expires_at to the date in the token' do

--- a/spec/models/credential_spec.rb
+++ b/spec/models/credential_spec.rb
@@ -15,6 +15,22 @@ describe Credential, type: :model do
     credential
   end
 
+  it 'gets the user id from a JWT' do
+    # generate a keypair to build a sample JWT
+    rsa_private = OpenSSL::PKey::RSA.generate 2048
+    rsa_public = rsa_private.public_key
+
+    # encode a fake app state
+    contents = { data: {id: 3}, exp: (Time.now + 1.minute).to_i }
+    token = JWT.encode contents, rsa_private, 'RS512'
+
+    # use our public key for decryption instead of the default one
+    allow_any_instance_of(Panoptes::Client).to receive(:jwt_signing_public_key).and_return(rsa_public)
+
+    credential = Credential.create!(token: token)
+    expect(credential.current_user_id).to eq(3)
+  end
+
   it 'defaults expires_at to the date in the token' do
     pending
     token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzUxMiJ9.eyJkYXRhIjp7ImlkIjoxMzIzODY5LCJsb2dpbiI6Im1hcnRlbnpvb25pdmVyc2UiLCJkbmFtZSI6Im1hcnRlbnpvb25pdmVyc2UiLCJzY29wZSI6WyJ1c2VyIiwicHJvamVjdCIsImdyb3VwIiwiY29sbGVjdGlvbiIsImNsYXNzaWZpY2F0aW9uIiwic3ViamVjdCIsIm1lZGl1bSIsIm9yZ2FuaXphdGlvbiIsInB1YmxpYyJdLCJhZG1pbiI6dHJ1ZX0sImV4cCI6MTQ5OTY4ODM1NCwiaXNzIjoicGFuLXN0YWciLCJybmciOiJiNmZkIn0.OSKeTRiS_ITbQhqYNbmFzIFc8zZ8nuSEjnlR1GGZtgPCQ3x9BoTq-NATN-fnFm9BQm5fseK2k4HMRixedtY2KFi0-Wq7gXBylzKQBc0He9nrnYX3e8TfXjq7X6RhllWVY7XpQRSyJKyq8Rc6gqro2bLSP2faaTDOV8kfsZYGNhWtXB28zLrkt2v_EEfikm3-i3PjFhr06le8mQDZPYt28cKan8KXr_cLV2lbSHVADE6ogpOQhYMbWUOLFqh1zgzgRRQFJY8byvv8HsVdh2KQlG1P0F2NOn5CfhbM5huUG0ktxmQosmVLmpEk_gafmhYn2GMA3JWHy4B_HoM437wk9s5voosfMXeZ6KY8R2d03VyXPIqlNnk5Mtqa0W_POSsx2mgI2QnfAJBLjU1bJU3LXRuaFe2asMfZ2rwji44DlfDefo5Fclh4_ZVSivcrktPx3WPJQShTQnxXkz6F5KoioEoPmDGCONieNGRKOFYsE9OYUn8Zr_Tk6QpuEUZ4tdnoRil9pJEzk18klEXRSCjsIs-CEdFJ3zCIO_anOyy7I2_njLPA_GfJLWVvVBhTCfVUkViPIKCNZgAUu57uhTVv1tk8vz943s_G-lw7TF5E-X_8qbae_L0vFeLvLpOI2xkgMXEB24OrISv8tYYjbUyPx4uwnWT4WCiSIMRHrsPFMHk"

--- a/spec/policies/user_reduction_policy_spec.rb
+++ b/spec/policies/user_reduction_policy_spec.rb
@@ -105,4 +105,21 @@ RSpec.describe UserReductionPolicy do
       expect(subject).to permit(credential, reduction)
     end
   end
+
+  permissions :current_user_reductions? do
+    let(:credential){ build :credential }
+    let(:reduction1){ create :user_reduction, user_id: 55555 }
+
+    it 'allows the current user to get their own reductions' do
+      reduction2 = create :user_reduction, user_id: 55555
+      allow_any_instance_of(Credential).to receive(:current_user_id).and_return(55555)
+      expect(subject).to permit(credential, [reduction1, reduction2])
+    end
+
+    it 'only allows the current user to get their own reductions' do
+      reduction2 = create :user_reduction, user_id: 55556
+      allow_any_instance_of(Credential).to receive(:current_user_id).and_return(55555)
+      expect(subject).not_to permit(credential, [reduction1, reduction2])
+    end
+  end
 end

--- a/spec/policies/user_reduction_policy_spec.rb
+++ b/spec/policies/user_reduction_policy_spec.rb
@@ -112,13 +112,13 @@ RSpec.describe UserReductionPolicy do
 
     it 'allows the current user to get their own reductions' do
       reduction2 = create :user_reduction, user_id: 55555
-      allow_any_instance_of(Credential).to receive(:current_user_id).and_return(55555)
+      allow_any_instance_of(Credential).to receive(:user_id).and_return(55555)
       expect(subject).to permit(credential, [reduction1, reduction2])
     end
 
     it 'only allows the current user to get their own reductions' do
       reduction2 = create :user_reduction, user_id: 55556
-      allow_any_instance_of(Credential).to receive(:current_user_id).and_return(55555)
+      allow_any_instance_of(Credential).to receive(:user_id).and_return(55555)
       expect(subject).not_to permit(credential, [reduction1, reduction2])
     end
   end

--- a/spec/policies/user_reduction_policy_spec.rb
+++ b/spec/policies/user_reduction_policy_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe UserReductionPolicy do
   permissions ".scope" do
     let!(:reductions) { create_list :user_reduction, 4 }
 
+    it 'allows any authenticated user to get their own reductions' do
+      credential = build(:credential)
+      reduction2 = create :user_reduction, user_id: 55555
+
+      allow_any_instance_of(Credential).to receive(:user_id).and_return(55555)
+      expect(records_for(credential)).to match_array([reduction2])
+    end
+
     it 'returns no records when not logged in' do
       credential = build(:credential, :not_logged_in)
       expect(records_for(credential)).to match_array(UserReduction.none)
@@ -103,23 +111,6 @@ RSpec.describe UserReductionPolicy do
       reduction = create :user_reduction
       credential = build(:credential, :admin)
       expect(subject).to permit(credential, reduction)
-    end
-  end
-
-  permissions :current_user_reductions? do
-    let(:credential){ build :credential }
-    let(:reduction1){ create :user_reduction, user_id: 55555 }
-
-    it 'allows the current user to get their own reductions' do
-      reduction2 = create :user_reduction, user_id: 55555
-      allow_any_instance_of(Credential).to receive(:user_id).and_return(55555)
-      expect(subject).to permit(credential, [reduction1, reduction2])
-    end
-
-    it 'only allows the current user to get their own reductions' do
-      reduction2 = create :user_reduction, user_id: 55556
-      allow_any_instance_of(Credential).to receive(:user_id).and_return(55555)
-      expect(subject).not_to permit(credential, [reduction1, reduction2])
     end
   end
 end

--- a/spec/support/fake_session.rb
+++ b/spec/support/fake_session.rb
@@ -1,11 +1,11 @@
 module FakeSession
-  def fake_session(admin: false, logged_in: true, project_ids: [], current_user_id: nil)
+  def fake_session(admin: false, logged_in: true, project_ids: [], user_id: nil)
     @credential = instance_double(Credential,
                                   logged_in?: logged_in,
                                   admin?: admin,
                                   ok?: true,
                                   expired?: false,
-                                  current_user_id: current_user_id,
+                                  user_id: user_id,
                                   project_ids: project_ids)
 
     allow(controller).to receive(:credential).and_return(@credential)

--- a/spec/support/fake_session.rb
+++ b/spec/support/fake_session.rb
@@ -1,10 +1,11 @@
 module FakeSession
-  def fake_session(admin: false, logged_in: true, project_ids: [])
+  def fake_session(admin: false, logged_in: true, project_ids: [], current_user_id: nil)
     @credential = instance_double(Credential,
                                   logged_in?: logged_in,
                                   admin?: admin,
                                   ok?: true,
                                   expired?: false,
+                                  current_user_id: current_user_id,
                                   project_ids: project_ids)
 
     allow(controller).to receive(:credential).and_return(@credential)


### PR DESCRIPTION
Resolves #592 

Users who are authenticated with Panoptes but not project owners or collaborators may access their own user reductions at:

`/workflows/1234/user_reductions?user_id=5678`

and

`/projects/1234/user_reductions?user_id=5678`

Supports the NfN use case.