### PR TITLE
Move relevant reductions to extract attr_accessor

### DIFF
--- a/app/models/extract.rb
+++ b/app/models/extract.rb
@@ -16,6 +16,8 @@ class Extract < ApplicationRecord
     field :updatedAt, !Types::TimeType, property: :updated_at
   end
 
+  attr_accessor :relevant_reduction
+
   belongs_to :workflow, counter_cache: true
   belongs_to :subject
   has_and_belongs_to_many_with_deferred_save :subject_reduction

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -62,7 +62,7 @@ class Reducer < ApplicationRecord
         reduction = get_reduction(reduction_fetcher, group_key)
         extracts = filter_extracts(grouped, reduction)
 
-        # ADD CORRESPONDING RELEVANT REDUCTION TO EACH EXTRACT FOR ALL
+        # Set relevant reduction on each extract if required by external reducer
         augmented_extracts = add_relevant_reductions(extracts, relevant_reductions)
 
         # relevant_reductions are any previously reduced user or subject reductions

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -62,9 +62,12 @@ class Reducer < ApplicationRecord
         reduction = get_reduction(reduction_fetcher, group_key)
         extracts = filter_extracts(grouped, reduction)
 
+        # ADD CORRESPONDING RELEVANT REDUCTION TO EACH EXTRACT FOR ALL
+        augmented_extracts = add_relevant_reductions(extracts, relevant_reductions)
+
         # relevant_reductions are any previously reduced user or subject reductions
         # that are required by this reducer to properly calculate
-        reduce_into(extracts, reduction, relevant_reductions).tap do |r|
+        reduce_into(augmented_extracts, reduction).tap do |r|
           r.expired = false
 
           # note that because we use deferred associations, this won't actually hit the database
@@ -95,7 +98,7 @@ class Reducer < ApplicationRecord
     end
   end
 
-  def reduce_into(extracts, reduction, relevant_reductions)
+  def reduce_into(extracts, reduction)
     raise NotImplementedError
   end
 
@@ -120,5 +123,17 @@ class Reducer < ApplicationRecord
   end
 
   def nilify_empty_fields
+  end
+
+  def add_relevant_reductions(extracts, relevant_reductions)
+    extracts.map do |ex|
+      ex.relevant_reduction = case topic
+                              when 0, "reduce_by_subject"
+                                relevant_reductions.find { |rr| rr.user_id == ex.user_id }
+                              when 1, "reduce_by_user"
+                                relevant_reductions.find { |rr| rr.subject_id == ex.subject_id }
+                              end
+    end
+    extracts
   end
 end

--- a/app/models/reducers/consensus_reducer.rb
+++ b/app/models/reducers/consensus_reducer.rb
@@ -2,7 +2,7 @@ module Reducers
   class ConsensusReducer < Reducer
     config_field :ignore_empty_extracts, default: false
 
-    def reduce_into(extractions, reduction, _relevant_reductions=[])
+    def reduce_into(extractions, reduction)
       store_value = reduction.store || {}
       counter = CountingHash.new(store_value)
 

--- a/app/models/reducers/count_reducer.rb
+++ b/app/models/reducers/count_reducer.rb
@@ -7,7 +7,7 @@
 #
 module Reducers
   class CountReducer < Reducer
-    def reduce_into(extracts, reduction, _relevant_reductions=[])
+    def reduce_into(extracts, reduction)
       data = reduction.data || {}
 
       classifications_count = data.fetch("classifications", 0)

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -22,12 +22,12 @@ module Reducers
       end
     end
 
-    def reduce_into(extractions, reduction, relevant_reductions=[])
+    def reduce_into(extractions, reduction)
       if url
         response = if default_reduction?
           RestClient.post(url, extractions.to_json, {content_type: :json, accept: :json})
         elsif running_reduction?
-          RestClient.post(url, { extracts: extractions, store: reduction.store, relevant_reductions: relevant_reductions }.to_json, {content_type: :json, accept: :json})
+          RestClient.post(url, { extracts: extractions, store: reduction.store }.to_json, {content_type: :json, accept: :json})
         else
           raise StandardError.new("Impossible reducer configuration #{id}")
         end

--- a/app/models/reducers/first_extract_reducer.rb
+++ b/app/models/reducers/first_extract_reducer.rb
@@ -6,7 +6,7 @@
 #
 module Reducers
   class FirstExtractReducer < Reducer
-    def reduce_into(extractions, reduction, _relevant_reductions=[])
+    def reduce_into(extractions, reduction)
       reduction.tap do |r|
         r.data = if reduction.data.blank? then (extractions&.fetch(0, nil)&.data || {}) else reduction.data end
       end

--- a/app/models/reducers/placeholder_reducer.rb
+++ b/app/models/reducers/placeholder_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class PlaceholderReducer < Reducer
-    def reduce_into(extracts, reduction, _relevant_reductions=[])
+    def reduce_into(extracts, reduction)
       reduction.tap do |r|
         r.data = nil
       end

--- a/app/models/reducers/sqs_reducer.rb
+++ b/app/models/reducers/sqs_reducer.rb
@@ -9,7 +9,7 @@ module Reducers
       end
     end
 
-    def reduce_into(extracts, reduction, _relevant_reductions=[])
+    def reduce_into(extracts, reduction)
       extracts.map do |extract|
         {
           message_body: prepare_extract(extract).to_json,

--- a/app/models/reducers/stats_reducer.rb
+++ b/app/models/reducers/stats_reducer.rb
@@ -1,6 +1,6 @@
 module Reducers
   class StatsReducer < Reducer
-    def reduce_into(extractions, reduction, _relevant_reductions=[])
+    def reduce_into(extractions, reduction)
       data = reduction.data || {}
 
       reduction.tap do |r|

--- a/app/models/reducers/summary_statistics_reducer.rb
+++ b/app/models/reducers/summary_statistics_reducer.rb
@@ -68,7 +68,7 @@ module Reducers
     end
 
 
-    def reduce_into(extracts, reduction, _relevant_reductions=[])
+    def reduce_into(extracts, reduction)
       @old_store = reduction.store || {}
       @new_store = {}
 

--- a/app/models/reducers/unique_count_reducer.rb
+++ b/app/models/reducers/unique_count_reducer.rb
@@ -2,7 +2,7 @@ module Reducers
   class UniqueCountReducer < Reducer
     config_field :field
 
-    def reduce_into(extracts, reduction, _relevant_reductions=[])
+    def reduce_into(extracts, reduction)
       store = reduction.store || {}
       store["items"] = [] unless store.key? "items"
 

--- a/app/models/subject_reduction.rb
+++ b/app/models/subject_reduction.rb
@@ -23,7 +23,6 @@ class SubjectReduction < ApplicationRecord
       id: id,
       reducible: { id: reducible_id, type: reducible_type },
       data: data,
-      user_ids: extracts.pluck(:user_id),
       subject: subject.attributes,
       created_at: created_at,
       updated_at: updated_at

--- a/spec/controllers/user_reductions_controller_spec.rb
+++ b/spec/controllers/user_reductions_controller_spec.rb
@@ -26,8 +26,6 @@ describe UserReductionsController, :type => :controller do
       response = get :index, params: { workflow_id: workflow.id, user_id: user1_id }
       results = JSON.parse(response.body)
 
-      # binding.pry
-
       # there are four total reductions but only two belong to this user in this workflow
       expect(response).to be_successful
       expect(results.size).to be(2)

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Reducers::ExternalReducer do
   let(:valid_url){ "https://example.org/post/extracts/here" }
   let(:workflow) { create :workflow }
+  let(:subject) { create :subject}
   let(:reducer) { described_class.new(
     key: 'external',
     reducible_id: workflow.id,
@@ -12,8 +13,8 @@ describe Reducers::ExternalReducer do
 
   let(:extracts) {
     [
-      Extract.new(data: {"foo" => "bar"}, workflow: workflow),
-      Extract.new(data: {"foo" => "baz"}, workflow: workflow)
+      Extract.new(data: {"foo" => "bar"}, workflow: workflow, subject: subject, user_id: 123),
+      Extract.new(data: {"foo" => "baz"}, workflow: workflow, subject: subject, user_id: 123)
     ]
   }
 
@@ -83,8 +84,7 @@ describe Reducers::ExternalReducer do
 
     let(:request_data){{
       extracts: extracts,
-      store: running_reduction.store,
-      relevant_reductions: []
+      store: running_reduction.store
     }}
 
     it 'sends the extracts and the store' do
@@ -112,44 +112,6 @@ describe Reducers::ExternalReducer do
 
       reducer.reduce_into(extracts, running_reduction)
       expect(running_reduction.store).to have_key('bar')
-    end
-
-    it 'includes relevant user reductions' do
-      relevant_reduction = create :user_reduction, data: {skill: 15}, user_id: 111, reducible: workflow, reducer_key: 'skillz'
-      running_reducer.user_reducer_keys = "skillz"
-
-      request_data[:relevant_reductions] = [relevant_reduction]
-
-      stub_request(:post, valid_url)
-        .with(:headers => {'Accept'=>'application/json',
-                          'Content-Type'=>'application/json',
-                          'Host'=>'example.org'})
-        .to_return(:status => 200, :body => request_data.to_json, :headers => {})
-
-      reducer.reduce_into(extracts, running_reduction, [relevant_reduction])
-      expect(a_request(:post, valid_url)
-              .with(body: request_data.to_json))
-        .to have_been_made.once
-    end
-
-    it 'includes relevant subject reductions' do
-      subject = create(:subject)
-      relevant_reduction = create :subject_reduction, data: {probability: 0.94}, subject_id: subject.id, reducible: workflow, reducer_key: 'skillz'
-
-      running_reducer.subject_reducer_keys = "skillz"
-
-      request_data[:relevant_reductions] = [relevant_reduction]
-
-      stub_request(:post, valid_url)
-        .with(:headers => {'Accept'=>'application/json',
-                          'Content-Type'=>'application/json',
-                          'Host'=>'example.org'})
-        .to_return(:status => 200, :body => request_data.to_json, :headers => {})
-
-      reducer.reduce_into(extracts, running_reduction, [relevant_reduction])
-      expect(a_request(:post, valid_url)
-              .with(body: request_data.to_json))
-        .to have_been_made.once
     end
   end
 end

--- a/spec/models/subject_reduction_spec.rb
+++ b/spec/models/subject_reduction_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe SubjectReduction, type: :model do
     reduction = create(:subject_reduction, extracts: [extract1, extract2, extract3])
 
     prepared = reduction.prepare
-    expect(prepared[:user_ids]).to include(extract1.user_id, extract2.user_id, extract3.user_id)
     expect(prepared[:subject]).to eq(reduction.subject.attributes)
   end
 end


### PR DESCRIPTION
Re: TESS and aggregation. Relevant reductions are now included as an accessible attribute on the individual extract that they pertain to. This prevents needing to match them up in the aggregator by user/subject id. I refactored the specs for this feature a bit as well. 

A lot of the file changes are where I removed the `relevant_reductions` argument being passed around to every reducer type because it's now just set on each individual extract during processing.