### PR TITLE
Workflow index fix

### DIFF
--- a/app/models/extractor.rb
+++ b/app/models/extractor.rb
@@ -20,7 +20,7 @@ class Extractor < ApplicationRecord
     end
   end
 
-  belongs_to :workflow
+  belongs_to :workflow, counter_cache: true
 
   validates :workflow, presence: true
   validates :key, presence: true, uniqueness: {scope: [:workflow_id]}

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -1,6 +1,6 @@
 class Reducer < ApplicationRecord
   include Configurable
-  include BelongsToReducible
+  include BelongsToReducibleCached
 
   enum topic: {
     reduce_by_subject: 0,

--- a/app/models/subject_rule.rb
+++ b/app/models/subject_rule.rb
@@ -2,7 +2,7 @@ class SubjectRule < ApplicationRecord
   include RankedModel
   ranks :row_order, with_same: :workflow_id
 
-  belongs_to :workflow
+  belongs_to :workflow, counter_cache: true
   has_many :subject_rule_effects, dependent: :destroy
 
   validate :valid_condition?

--- a/app/models/user_rule.rb
+++ b/app/models/user_rule.rb
@@ -2,7 +2,7 @@ class UserRule < ApplicationRecord
   include RankedModel
   ranks :row_order, with_same: :workflow_id
 
-  belongs_to :workflow
+  belongs_to :workflow, counter_cache: true
   has_many :user_rule_effects, dependent: :destroy
 
   validate :valid_condition?

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,5 +1,11 @@
 <div class="row">
 <div class="col-md-12">
+<div class="pull-right" style="margin-top: 1em;">
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#myModal">
+    <i class="glyphicon glyphicon-plus"></i> Add</span>
+  </button>
+</div>
+
 <h2>Projects</h2>
 
 <table class="table table-striped">
@@ -28,19 +34,13 @@
         <td><%= project.id %></td>
         <td><%= link_to project.display_name || "No Name", project_path(project) %></td>
         <td class="text-muted">N/A</td>
-        <td><%= project.reducers.count %></td>
+        <td><%= project.reducers_count %></td>
         <td class="text-muted">N/A</td>
         <td><%= project.updated_at %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
-
-<div class="btn-group pull-right">
-  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#myModal">
-    <i class="glyphicon glyphicon-plus"></i> Add</span>
-  </button>
-</div>
 
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
   <div class="modal-dialog" role="document">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -4,7 +4,7 @@
 <ul class="nav nav-pills">
     <li class="active"><a href="#summary" data-toggle="tab">Summary</a></li>
     <li class="disabled"><a href="#extractors" data-toggle="tab">Extractors</a></li>
-    <li><a href="#reducers" data-toggle="tab">Reducers <span class="badge"><%= @project.reducers.count %></span></a></li>
+    <li><a href="#reducers" data-toggle="tab">Reducers <span class="badge"><%= @project.reducers_count %></span></a></li>
     <li class="disabled"><a href="#rules" data-toggle="tab">Rules</a></li>
     <li class="disabled"><a href="#requests" data-toggle="tab">Data Requests</a></li>
 </ul>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -1,5 +1,10 @@
 <div class="row">
 <div class="col-md-12">
+<div class="pull-right" style="margin-top: 1em;">
+  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#myModal">
+    <i class="glyphicon glyphicon-plus"></i> Add</span>
+  </button>
+</div>
 <h2>Workflows</h2>
 <table class="table table-striped table-sm">
   <colgroup>
@@ -38,20 +43,14 @@
         <td><%= link_to workflow.name || "[Name unknown]", workflow_path([workflow]) %></td>
         <td><%= workflow.project_id %></td>
         <td><%= workflow.project_name || "[Name unknown]" %></td>
-        <td><%= workflow.extractors.count %></td>
-        <td><%= workflow.reducers.count %></td>
-        <td><%= workflow.subject_rules.count + workflow.user_rules.count %></td>
+        <td><%= workflow.extractors_count %></td>
+        <td><%= workflow.reducers_count %></td>
+        <td><%= (workflow.subject_rules_count||0) + (workflow.user_rules_count||0) %></td>
         <td><%= workflow.updated_at %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
-
-<div class="btn-group pull-right">
-  <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#myModal">
-    <i class="glyphicon glyphicon-plus"></i> Add</span>
-  </button>
-</div>
 
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
   <div class="modal-dialog" role="document">

--- a/app/views/workflows/show.html.erb
+++ b/app/views/workflows/show.html.erb
@@ -8,9 +8,9 @@
 </h2>
 <ul class="nav nav-pills">
     <li class="active"><a href="#summary" data-toggle="tab">Summary</a></li>
-    <li><a href="#extractors" data-toggle="tab">Extractors <span class="badge"><%= @workflow.extractors.count %></span></a></li>
-    <li><a href="#reducers" data-toggle="tab">Reducers <span class="badge"><%= @workflow.reducers.count %></span></a></li>
-    <li><a href="#rules" data-toggle="tab">Rules <span class="badge"><%= @workflow.subject_rules.count + @workflow.user_rules.count %></span></a></li>
+    <li><a href="#extractors" data-toggle="tab">Extractors <span class="badge"><%= @workflow.extractors_count %></span></a></li>
+    <li><a href="#reducers" data-toggle="tab">Reducers <span class="badge"><%= @workflow.reducers_count %></span></a></li>
+    <li><a href="#rules" data-toggle="tab">Rules <span class="badge"><%= @workflow.subject_rules_count + @workflow.user_rules_count %></span></a></li>
     <li><a href="#requests" data-toggle="tab">Data Requests <span class="badge"><%= @workflow.data_requests.count %></span></a></li>
     <li><a href="#subjects" data-toggle="tab">Subjects</a></li>
 </ul>

--- a/db/migrate/20190228155041_add_extractors_count_to_workflows.rb
+++ b/db/migrate/20190228155041_add_extractors_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddExtractorsCountToWorkflows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :workflows, :extractors_count, :int
+  end
+end

--- a/db/migrate/20190228155344_add_reducers_count_to_workflows.rb
+++ b/db/migrate/20190228155344_add_reducers_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddReducersCountToWorkflows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :workflows, :reducers_count, :int
+  end
+end

--- a/db/migrate/20190228155359_add_subject_rules_count_to_workflows.rb
+++ b/db/migrate/20190228155359_add_subject_rules_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddSubjectRulesCountToWorkflows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :workflows, :subject_rules_count, :int
+  end
+end

--- a/db/migrate/20190228155430_add_user_rules_count_to_workflows.rb
+++ b/db/migrate/20190228155430_add_user_rules_count_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddUserRulesCountToWorkflows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :workflows, :user_rules_count, :int
+  end
+end

--- a/db/migrate/20190228155456_add_reducers_count_to_projects.rb
+++ b/db/migrate/20190228155456_add_reducers_count_to_projects.rb
@@ -1,0 +1,5 @@
+class AddReducersCountToProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :reducers_count, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_17_191627) do
+ActiveRecord::Schema.define(version: 2019_02_28_155456) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2018_12_17_191627) do
     t.string "display_name"
     t.integer "subject_reductions_count"
     t.integer "user_reductions_count"
+    t.integer "reducers_count"
   end
 
   create_table "reducers", force: :cascade do |t|
@@ -261,6 +262,10 @@ ActiveRecord::Schema.define(version: 2018_12_17_191627) do
     t.integer "user_reductions_count"
     t.integer "subject_actions_count"
     t.integer "user_actions_count"
+    t.integer "extractors_count"
+    t.integer "reducers_count"
+    t.integer "subject_rules_count"
+    t.integer "user_rules_count"
   end
 
   add_foreign_key "classifications", "subjects"

--- a/lib/tasks/project_counters.rake
+++ b/lib/tasks/project_counters.rake
@@ -5,7 +5,7 @@ namespace :counters do
     task projects: :environment do
       Project.reset_column_information
       Project.pluck(:id).each do |id|
-        Project.reset_counters id, :subject_reductions, :user_reductions
+        Project.reset_counters id, :subject_reductions, :user_reductions, :reducers
       end
     end
   end

--- a/lib/tasks/workflow_counters.rake
+++ b/lib/tasks/workflow_counters.rake
@@ -4,7 +4,7 @@ namespace :counters do
     task workflows: :environment do
       Workflow.reset_column_information
       Workflow.pluck(:id).each do |id|
-        Workflow.reset_counters id, :extracts, :subject_reductions, :user_reductions, :subject_actions, :user_actions
+        Workflow.reset_counters id, :extracts, :subject_reductions, :user_reductions, :subject_actions, :user_actions, :extractors, :reducers, :subject_rules, :user_rules
       end
     end
   end


### PR DESCRIPTION
the `Workflow#index` view was super slow, probably because it was fetching all of the extractors, reducers, and rules for every workflow in order to count them. i added counter_cache stuff to make that work better. after this is deployed, we'll need to run:

```console
$ rake counters:update:projects
$ rake counters:update:workflows
```

Until this is done the columns will just show up empty in the UI.