### PR TITLE
Wrapper around aggregation-for-caesar

### DIFF
--- a/app/models/configurable.rb
+++ b/app/models/configurable.rb
@@ -29,6 +29,14 @@ module Configurable
       end
     end
 
+    def merge_configuration_fields
+      if self.superclass.respond_to? :merge_configuration_fields
+        self.configuration_fields.merge self.superclass.merge_configuration_fields
+      else
+        self.configuration_fields
+      end
+    end
+
     def configuration_fields
       @configuration_fields ||= {}
     end

--- a/app/models/extractor.rb
+++ b/app/models/extractor.rb
@@ -15,6 +15,8 @@ class Extractor < ApplicationRecord
       Extractors::WhoExtractor
     when "pluck_field"
       Extractors::PluckFieldExtractor
+    when "shape"
+      Extractors::AggregationExtractors::ShapeExtractor
     else
       raise "Unknown type #{type}"
     end

--- a/app/models/extractors/aggregation_extractor.rb
+++ b/app/models/extractors/aggregation_extractor.rb
@@ -1,0 +1,48 @@
+module Extractors
+  class AggregationExtractor < Extractor
+    include Extractors::HttpExtraction
+    config_field :task_key, default: 'T0'
+
+    def extract_data_for(classification)
+      http_extract(classification)
+    end
+
+    def base_url
+      'https://aggregation-caesar.zooniverse.org/extractors'
+    end
+
+    def collect_parameters
+      blacklist_fields = [:url]
+
+      self.class.merge_configuration_fields.map do |field, options|
+        if (blacklist_fields.include? field) || (self.send(field).blank?)
+          nil
+        else
+          "#{field}=#{self.send field}"
+        end
+      end.compact.join("&")
+    end
+
+    def url
+      "#{base_url}/#{extractor_name}?" + collect_parameters
+    end
+
+    @@valid_shapes = [
+      'circle',
+      'column',
+      'ellipse',
+      'fullWidthLine',
+      'fullHeightLine',
+      'line',
+      'point',
+      'rectangle',
+      'rotateRectangle',
+      'triangle',
+      'fan'
+    ]
+
+    def self.valid_shapes
+      @@valid_shapes
+    end
+  end
+end

--- a/app/models/extractors/aggregation_extractor.rb
+++ b/app/models/extractors/aggregation_extractor.rb
@@ -12,10 +12,8 @@ module Extractors
     end
 
     def collect_parameters
-      blacklist_fields = [:url]
-
       self.class.merge_configuration_fields.map do |field, options|
-        if (blacklist_fields.include? field) || (self.send(field).blank?)
+        if (AggregationExtractor::BLACKLIST_FIELDS.include? field) || (self.send(field).blank?)
           nil
         else
           "#{field}=#{self.send field}"
@@ -27,22 +25,7 @@ module Extractors
       "#{base_url}/#{extractor_name}?" + collect_parameters
     end
 
-    @@valid_shapes = [
-      'circle',
-      'column',
-      'ellipse',
-      'fullWidthLine',
-      'fullHeightLine',
-      'line',
-      'point',
-      'rectangle',
-      'rotateRectangle',
-      'triangle',
-      'fan'
-    ]
-
-    def self.valid_shapes
-      @@valid_shapes
-    end
+    BLACKLIST_FIELDS = [:url].freeze
+    VALID_SHAPES = %w(circle column ellipse fullWidthLine fullHeightLine line point rectangle rotateRectangle triangle fan).freeze
   end
 end

--- a/app/models/extractors/aggregation_extractors/shape_extractor.rb
+++ b/app/models/extractors/aggregation_extractors/shape_extractor.rb
@@ -1,0 +1,12 @@
+module Extractors
+  module AggregationExtractors
+    class ShapeExtractor < Extractors::AggregationExtractor
+      config_field :shape
+      validates :shape, inclusion: { in: AggregationExtractor.valid_shapes }
+
+      def extractor_name
+        'shape_extractor'
+      end
+    end
+  end
+end

--- a/app/models/extractors/aggregation_extractors/shape_extractor.rb
+++ b/app/models/extractors/aggregation_extractors/shape_extractor.rb
@@ -2,7 +2,7 @@ module Extractors
   module AggregationExtractors
     class ShapeExtractor < Extractors::AggregationExtractor
       config_field :shape
-      validates :shape, inclusion: { in: AggregationExtractor.valid_shapes }
+      validates :shape, inclusion: { in: AggregationExtractor::VALID_SHAPES }
 
       def extractor_name
         'shape_extractor'

--- a/app/models/extractors/external_extractor.rb
+++ b/app/models/extractors/external_extractor.rb
@@ -1,42 +1,15 @@
-require 'uri'
-
 module Extractors
   class ExternalExtractor < Extractor
+    include Extractors::HttpExtraction
+
     class ExternalExtractorFailed < StandardError; end
 
     config_field :url, default: nil
 
-    validate do
-      if url.present?
-        schemes = ['https']
-
-        begin
-          uri = URI.parse(url)
-          unless uri && uri.host && schemes.include?(uri.scheme)
-            errors.add(:url, "URL must be one of: #{schemes.join(",")}")
-          end
-        rescue URI::InvalidURIError
-          errors.add(:url, "URL could not be parsed")
-        end
-      end
-    end
-
     def extract_data_for(classification)
-      if url
-        response = RestClient.post(url, classification.to_json, {content_type: :json, accept: :json})
-
-        if response.code == 204
-          Extractor::NoData
-        elsif ([200, 201, 202].include? response.code) and response.body.present?
-          JSON.parse(response.body)
-        else
-          raise StandardError.new 'Remote extractor failed'
-        end
-      else
-        raise StandardError.new "External extractor improperly configured: no URL"
-      end
-    rescue RestClient::InternalServerError
-      raise ExternalExtractorFailed
+      http_extract(classification)
+    rescue StandardError => e
+      raise ExternalExtractorFailed.new e.to_s
     end
   end
 end

--- a/app/models/extractors/http_extraction.rb
+++ b/app/models/extractors/http_extraction.rb
@@ -1,0 +1,22 @@
+module Extractors
+  module HttpExtraction
+    include HttpOperation
+    def self.included(base)
+      HttpOperation.configure_validation(base)
+    end
+
+    class ExtractionFailed < HttpOperation::HttpOperationException; end
+
+    def no_data
+      Extractor::NoData
+    end
+
+    def operation_failed_type
+      ExtractionFailed
+    end
+
+    def http_extract(classification)
+      http_post(classification)
+    end
+  end
+end

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -30,6 +30,8 @@ class Reducer < ApplicationRecord
       Reducers::SummaryStatisticsReducer
     when 'unique_count'
       Reducers::UniqueCountReducer
+    when 'rectangle'
+      Reducers::AggregationReducers::RectangleReducer
     when 'sqs'
       Reducers::SqsReducer
     else

--- a/app/models/reducers/aggregation_reducer.rb
+++ b/app/models/reducers/aggregation_reducer.rb
@@ -1,0 +1,52 @@
+
+module Reducers
+  class AggregationReducer < Reducer
+    include Reducers::HttpReduction
+
+    def reduce_into(extracts, reduction, relevant_reductions=[])
+      if default_reduction?
+        http_reduce(reduction, extracts)
+      elsif running_reduction?
+        http_reduce(reduction, {
+          extracts: extracts,
+          store: reduction.store,
+          relevant_reductions: relevant_reductions
+        })
+      else
+        raise ExternalReducerFailed.new 'Impossible configuration, select default_reduction or running_reduction'
+      end
+    rescue StandardError => e
+      raise ExternalReducerFailed.new e.to_s
+    end
+
+    def base_url
+      'https://aggregation-caesar.zooniverse.org/reducers'
+    end
+
+    def collect_parameters
+      blacklist_fields = [:url, :user_reducer_keys, :subject_reducer_keys]
+
+      self.class.merge_configuration_fields.map do |field, options|
+        if (blacklist_fields.include? field) || (self.send(field).blank?)
+          nil
+        else
+          "#{field}=#{self.send field}"
+        end
+      end.compact.join("&")
+    end
+
+    def url
+      "#{base_url}/#{reducer_name}?" + collect_parameters
+    end
+
+    # refer to https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html#sklearn.metrics.pairwise_distances
+    @@metric_names = [
+      'cityblock', 'cosine', 'euclidean', 'l1', 'l2', 'manhattan',
+      'braycurtis', 'canberra', 'chebyshev', 'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski', 'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean', 'yule'
+    ]
+
+    def self.metric_names
+      @@metric_names
+    end
+  end
+end

--- a/app/models/reducers/aggregation_reducer.rb
+++ b/app/models/reducers/aggregation_reducer.rb
@@ -24,10 +24,8 @@ module Reducers
     end
 
     def collect_parameters
-      blacklist_fields = [:url, :user_reducer_keys, :subject_reducer_keys]
-
       self.class.merge_configuration_fields.map do |field, options|
-        if (blacklist_fields.include? field) || (self.send(field).blank?)
+        if (AggregationReducer::BLACKLIST_FIELDS.include? field) || (self.send(field).blank?)
           nil
         else
           "#{field}=#{self.send field}"
@@ -39,14 +37,11 @@ module Reducers
       "#{base_url}/#{reducer_name}?" + collect_parameters
     end
 
+    BLACKLIST_FIELDS = [:url, :user_reducer_keys, :subject_reducer_keys].freeze
     # refer to https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html#sklearn.metrics.pairwise_distances
-    @@metric_names = [
-      'cityblock', 'cosine', 'euclidean', 'l1', 'l2', 'manhattan',
-      'braycurtis', 'canberra', 'chebyshev', 'correlation', 'dice', 'hamming', 'jaccard', 'kulsinski', 'mahalanobis', 'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean', 'yule'
-    ]
-
-    def self.metric_names
-      @@metric_names
-    end
+    METRIC_NAMES = %w(
+      cityblock cosine euclidean l1 l2 manhattan
+      braycurtis, canberra, chebyshev, correlation, dice, hamming, jaccard, kulsinski, mahalanobis, minkowski, rogerstanimoto, russellrao, seuclidean, sokalmichener, sokalsneath, sqeuclidean, yule
+    ).freeze
   end
 end

--- a/app/models/reducers/aggregation_reducers/rectangle_reducer.rb
+++ b/app/models/reducers/aggregation_reducers/rectangle_reducer.rb
@@ -2,11 +2,7 @@ module Reducers
   module AggregationReducers
     class RectangleReducer < Reducers::AggregationReducer
       # refer to https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html
-      @@algorithm_names = ['auto', 'ball_tree', 'kd_tree', 'brute']
-
-      def self.algorithm_names
-        @@algorithm_names
-      end
+      ALGORITHM_NAMES = %w(auto ball_tree kd_tree brute).freeze
 
       config_field :eps, default: 5.0
       config_field :min_samples, default: 3
@@ -17,8 +13,8 @@ module Reducers
 
       validates :eps, numericality: true
       validates :min_samples, numericality: true
-      validates :metric, inclusion: { in: AggregationReducer.metric_names }
-      validates :algorithm, inclusion: { in: algorithm_names }
+      validates :metric, inclusion: { in: AggregationReducer::METRIC_NAMES }
+      validates :algorithm, inclusion: { in: RectangleReducer::ALGORITHM_NAMES }
       validates :leaf_size, numericality: true
       validates :p, numericality: true, allow_blank: true
 

--- a/app/models/reducers/aggregation_reducers/rectangle_reducer.rb
+++ b/app/models/reducers/aggregation_reducers/rectangle_reducer.rb
@@ -1,0 +1,30 @@
+module Reducers
+  module AggregationReducers
+    class RectangleReducer < Reducers::AggregationReducer
+      # refer to https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html
+      @@algorithm_names = ['auto', 'ball_tree', 'kd_tree', 'brute']
+
+      def self.algorithm_names
+        @@algorithm_names
+      end
+
+      config_field :eps, default: 5.0
+      config_field :min_samples, default: 3
+      config_field :metric, default: 'euclidean'
+      config_field :algorithm, default: 'auto'
+      config_field :leaf_size, default: 30
+      config_field :p, default: nil
+
+      validates :eps, numericality: true
+      validates :min_samples, numericality: true
+      validates :metric, inclusion: { in: AggregationReducer.metric_names }
+      validates :algorithm, inclusion: { in: algorithm_names }
+      validates :leaf_size, numericality: true
+      validates :p, numericality: true, allow_blank: true
+
+      def reducer_name
+        'rectangle_reducer'
+      end
+    end
+  end
+end

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -2,55 +2,27 @@ require 'uri'
 
 module Reducers
   class ExternalReducer < Reducer
+    include Reducers::HttpReduction
+
     class ExternalReducerFailed < StandardError; end
 
     config_field :url, default: nil
     config_field :version, default: 1
 
-    validate do
-      if url.present?
-        schemes = ['https']
-
-        begin
-          uri = URI.parse(url)
-          unless uri && uri.host && schemes.include?(uri.scheme)
-            errors.add(:url, "URL must be one of: #{schemes.join(",")}")
-          end
-        rescue URI::InvalidURIError
-          errors.add(:url, "URL could not be parsed")
-        end
-      end
-    end
-
-    def reduce_into(extractions, reduction)
-      if url
-        response = if default_reduction?
-          RestClient.post(url, extractions.to_json, {content_type: :json, accept: :json})
-        elsif running_reduction?
-          RestClient.post(url, { extracts: extractions, store: reduction.store }.to_json, {content_type: :json, accept: :json})
-        else
-          raise StandardError.new("Impossible reducer configuration #{id}")
-        end
-
-        reduction.tap do |r|
-          r.data = (if response.code == 204
-            nil
-          elsif ([200, 201, 202].include? response.code) and response.body.present?
-            JSON.parse(response.body)
-          else
-            raise StandardError.new 'Remote reducer failed'
-          end)
-
-          if r&.data&.key? '_store'
-            r.store = r.data['_store']
-            r.data = r.data.except '_store'
-          end
-        end
+    def reduce_into(extracts, reduction, relevant_reductions=[])
+      if default_reduction?
+        http_reduce(reduction, extracts)
+      elsif running_reduction?
+        http_reduce(reduction, {
+          extracts: extracts,
+          store: reduction.store,
+          relevant_reductions: relevant_reductions
+        })
       else
-        raise StandardError.new "External extractor improperly configured: no URL"
+        raise ExternalReducerFailed.new "Impossible configuration, select default_reduction or running_reduction"
       end
-    rescue RestClient::InternalServerError
-      raise ExternalReducerFailed
+    rescue StandardError => e
+      raise ExternalReducerFailed.new e.to_s
     end
   end
 end

--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -9,14 +9,13 @@ module Reducers
     config_field :url, default: nil
     config_field :version, default: 1
 
-    def reduce_into(extracts, reduction, relevant_reductions=[])
+    def reduce_into(extracts, reduction)
       if default_reduction?
         http_reduce(reduction, extracts)
       elsif running_reduction?
         http_reduce(reduction, {
           extracts: extracts,
           store: reduction.store,
-          relevant_reductions: relevant_reductions
         })
       else
         raise ExternalReducerFailed.new "Impossible configuration, select default_reduction or running_reduction"

--- a/app/models/reducers/http_reduction.rb
+++ b/app/models/reducers/http_reduction.rb
@@ -1,0 +1,33 @@
+module Reducers
+  module HttpReduction
+    include HttpOperation
+    def self.included(base)
+      HttpOperation.configure_validation(base)
+    end
+
+    class ReductionFailed < HttpOperation::HttpOperationException; end
+
+    def no_data
+      nil
+    end
+
+    def operation_failed_type
+      ReductionFailed
+    end
+
+    def http_reduce(reduction, reducer_inputs)
+      result = http_post(reducer_inputs)
+      unpack(reduction, result)
+    end
+
+    def unpack(reduction, result)
+      reduction.tap do |r|
+        r.data = result
+        if r&.data&.key? '_store'
+          r.store = r.data['_store']
+          r.data = r.data.except '_store'
+        end
+      end
+    end
+  end
+end

--- a/app/models/workflow/convert_legacy_reducers_config.rb
+++ b/app/models/workflow/convert_legacy_reducers_config.rb
@@ -38,6 +38,8 @@ class Workflow::ConvertLegacyReducersConfig
       Reducers::PlaceholderReducer
     when "summary_stats"
       Reducers::SummaryStatisticsReducer
+    when "rectangle"
+      Reducers::AggregationReducers::RectangleReducer
     when "sqs"
       Reducers::SqsReducer
     else

--- a/app/views/workflows/_extractors.html.erb
+++ b/app/views/workflows/_extractors.html.erb
@@ -70,13 +70,14 @@
       <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="glyphicon glyphicon-plus"></i> Create Extractor <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu">
+      <ul class="dropdown-menu dropdown-menu-right">
         <li><%= link_to "Blank", new_workflow_extractor_path(@workflow, type: 'blank') %></li>
         <li><%= link_to "External", new_workflow_extractor_path(@workflow, type: 'external') %></li>
         <li><%= link_to "Pluck field", new_workflow_extractor_path(@workflow, type: 'pluck_field') %></li>
         <li><%= link_to "Question", new_workflow_extractor_path(@workflow, type: 'question') %></li>
         <li><%= link_to "Survey", new_workflow_extractor_path(@workflow, type: 'survey') %></li>
         <li><%= link_to "Who", new_workflow_extractor_path(@workflow, type: 'who') %></li>
+        <li><%= link_to "Shape", new_workflow_extractor_path(@workflow, type: 'shape') %></li>
       </ul>
     </div>
   <% end %>

--- a/app/views/workflows/_reducers.html.erb
+++ b/app/views/workflows/_reducers.html.erb
@@ -80,7 +80,7 @@
         <i class="glyphicon glyphicon-plus"></i> Create <span class="caret"></span>
       </button>
 
-      <ul class="dropdown-menu">
+      <ul class="dropdown-menu dropdown-menu-right">
         <li><%= link_to "Consensus", new_workflow_reducer_path(@workflow, type: 'consensus') %></li>
         <li><%= link_to "Count", new_workflow_reducer_path(@workflow, type: 'count') %></li>
         <li><%= link_to "Placeholder", new_workflow_reducer_path(@workflow, type: 'placeholder') %></li>
@@ -90,6 +90,7 @@
         <li><%= link_to "Summary Stats", new_workflow_reducer_path(@workflow, type: 'summary_stats') %></li>
         <li><%= link_to "Unique Count", new_workflow_reducer_path(@workflow, type: 'unique_count') %></li>
         <li><%= link_to "SQS", new_workflow_reducer_path(@workflow, type: 'sqs') %></li>
+        <li><%= link_to "Rectangle", new_workflow_reducer_path(@workflow, type: 'rectangle') %></li>
       </ul>
     </div>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module Caesar
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+    # Eagerly load all modules of common code from ~/lib
+    # https://stackoverflow.com/a/44985745/7410891
+    config.eager_load_paths << Rails.root.join('lib')
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/lib/http_operation.rb
+++ b/lib/http_operation.rb
@@ -1,0 +1,55 @@
+require 'uri'
+
+module HttpOperation
+  class HttpOperationException < StandardError; end
+  class ConfigurationError < HttpOperationException;  end
+  class NotFound < HttpOperationException; end
+  class UnexpectedResponse < HttpOperationException; end
+
+  def self.included(base)
+    configure_validation(base)
+  end
+
+  def self.configure_validation(base)
+    if base.is_a? Class
+      base.include ActiveModel::Validations
+      base.validates_with HttpOperation::UrlValidator
+    end
+  end
+
+  class UrlValidator < ActiveModel::Validator
+    def validate(record)
+      schemes = ['https']
+      return true if record.url.blank? # make old tests pass
+
+      begin
+        uri = URI.parse(record.url)
+        unless uri && uri.host && schemes.include?(uri.scheme)
+          record.errors.add(:url, "URL must be one of: #{schemes.join(",")}")
+        end
+      rescue URI::InvalidURIError
+        record.errors.add(:url, "URL could not be parsed")
+      end
+    end
+  end
+
+  def http_post(payload)
+    if url.present? && valid?
+      response = RestClient.post(url, payload.to_json, {content_type: :json, accept: :json})
+
+      if ([200, 201, 202].include? response.code) and response.body.present?
+        JSON.parse(response.body)
+      elsif(response.code == 204)
+        no_data
+      else
+        raise UnexpectedResponse.new "Endpoint failed with HTTP #{response.code}"
+      end
+    else
+      raise ConfigurationError.new "Improperly configured endpoint #{errors.full_messages}"
+    end
+  rescue RestClient::NotFound => e
+    raise NotFound.new e.to_s
+  rescue RestClient::Exception => e
+    raise operation_failed_type.new(e.to_s)
+  end
+end

--- a/spec/lib/http_operation_spec.rb
+++ b/spec/lib/http_operation_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+class DummyException < StandardError; end
+
+class DummyHttpOperationHost
+  include HttpOperation
+
+  attr_reader :url
+
+  def initialize(url: 'https://example.org/post/here')
+    @url = url
+  end
+
+  def no_data
+    "no data"
+  end
+
+  def operation_failed_type
+    DummyException
+  end
+end
+
+describe HttpOperation do
+  let(:default_host){ DummyHttpOperationHost.new }
+  let(:sample_url){ 'https://example.org/post/here' }
+
+  describe 'validates urls' do
+    it 'accepts valid, secure urls' do
+      expect(default_host).to be_valid
+    end
+
+    it 'rejects insecure urls' do
+      mixin_host = DummyHttpOperationHost.new url: 'http://example.org/post/here'
+      expect(mixin_host).not_to be_valid
+    end
+  end
+
+  describe 'response handling' do
+    it 'does not post if the url is empty' do
+      mixin_host = DummyHttpOperationHost.new url: nil
+
+      expect do
+        mixin_host.http_post(nil)
+      end.to raise_error(HttpOperation::ConfigurationError)
+    end
+
+    it 'serializes the payload' do
+      sample_hash = { foo: 'bar' }
+      stub_request(:post, sample_url).
+        to_return(status: 204, body: sample_hash.to_json, headers: {})
+
+      default_host.http_post(sample_hash)
+
+      expect(a_request(:post, sample_url)
+              .with(body: sample_hash.to_json))
+        .to have_been_made.once
+    end
+
+    it 'unpacks the response if successful' do
+      sample_hash = { foo: 'bar' }.with_indifferent_access
+      stub_request(:post, sample_url).
+        to_return(status: 200, body: sample_hash.to_json, headers: {})
+
+      expect(default_host.http_post(nil)).to eq(sample_hash)
+    end
+
+    it 'handles 204s by returning no_data' do
+      stub_request(:post, sample_url).
+        to_return(status: 204, body: "", headers: {})
+
+      expect(default_host.http_post(nil)).to eq("no data")
+    end
+
+    it 'handles missing endpoints' do
+      stub_request(:post, sample_url).
+        to_return(status: 404, body: "", headers: {})
+
+      expect do
+        default_host.http_post(nil)
+      end.to raise_error(HttpOperation::NotFound)
+    end
+
+    it 'handles 500s' do
+      stub_request(:post, sample_url).
+        to_return(status: 500, body: "", headers: {})
+
+      expect do
+        default_host.http_post(nil)
+      end.to raise_error(DummyException)
+    end
+
+    it 'handles weird response codes' do
+      stub_request(:post, sample_url).
+        to_return(status: 999, body: "", headers: {})
+
+      expect do
+        default_host.http_post(nil)
+      end.to raise_error(DummyException)
+    end
+  end
+end

--- a/spec/models/extractors/aggregation_extractors/shape_extractor_spec.rb
+++ b/spec/models/extractors/aggregation_extractors/shape_extractor_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+describe Extractors::AggregationExtractors::ShapeExtractor do
+  let(:subject){ create :subject }
+  let(:workflow){ create :workflow }
+  let(:classification) do
+    Classification.new(
+      "id" => "12329",
+      "annotations" => [{"task" => "T0", "value" => "foo"}],
+      "metadata" => {},
+      "created_at" => "",
+      "updated_at" => "",
+      "links" => {"project" => "1232", "workflow" => workflow.id.to_s, "subjects" => [subject.id], "user" => nil}
+    )
+  end
+
+  it 'accepts a valid shape' do
+    extractor = described_class.new(
+      key: 'ext',
+      workflow: workflow,
+      config: {
+        shape: 'circle'
+      }
+    )
+
+    expect(extractor).to be_valid
+  end
+
+  it 'rejects a bad shape' do
+    extractor = described_class.new(
+      key: 'ext',
+      workflow: workflow,
+      config: {
+        shape: 'blah'
+      }
+    )
+
+    expect(extractor).not_to be_valid
+  end
+
+  it 'require a shape' do
+    extractor = described_class.new(
+      key: 'ext',
+      workflow: workflow,
+      config: {
+      }
+    )
+
+    expect(extractor).not_to be_valid
+  end
+
+  it 'builds the url correctly' do
+    extractor = described_class.new(
+      key: 'ext',
+      workflow: workflow,
+      config: {
+        shape: 'circle'
+      }
+    )
+
+    expect(extractor.url).to eq(
+      'https://aggregation-caesar.zooniverse.org/extractors/shape_extractor?shape=circle&task_key=T0'
+    )
+  end
+
+  it 'extracts correctly' do
+    stub_request(:post, 'https://aggregation-caesar.zooniverse.org/extractors/shape_extractor?shape=circle&task_key=T0').
+      to_return(status: 204, body: "", headers: {})
+
+    extractor = described_class.new(
+      key: 'ext',
+      workflow: workflow,
+      config: {
+        shape: 'circle'
+      }
+    )
+
+    result = extractor.process(classification)
+    expect(a_request(:post, 'https://aggregation-caesar.zooniverse.org/extractors/shape_extractor?shape=circle&task_key=T0'))
+      .to have_been_made.once
+    expect(result).to eq(Extractor::NoData)
+  end
+end

--- a/spec/models/extractors/external_extractor_spec.rb
+++ b/spec/models/extractors/external_extractor_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Extractors::ExternalExtractor do
   let(:subject){ create :subject }
+  let(:workflow){ create :workflow }
   let(:classification) do
     Classification.new(
       "id" => "12329",
@@ -9,14 +10,14 @@ describe Extractors::ExternalExtractor do
       "metadata" => {},
       "created_at" => "",
       "updated_at" => "",
-      "links" => {"project" => "1232", "workflow" => "1021", "subjects" => [subject.id], "user" => nil}
+      "links" => {"project" => "1232", "workflow" => workflow.id.to_s, "subjects" => [subject.id], "user" => nil}
     )
   end
 
   let(:response_data) { {"foo" => "bar"} }
 
   before do
-    stub_request(:post, "http://example.org/post/classification/here").
+    stub_request(:post, "https://example.org/post/classification/here").
       with(:body => classification.to_json,
            :headers => {'Accept'=>'application/json',
                         'Content-Type'=>'application/json',
@@ -25,34 +26,34 @@ describe Extractors::ExternalExtractor do
   end
 
   it 'posts the classification to a foreign API' do
-    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"})
+    extractor = described_class.new(key: "ext", config: {"url" => "https://example.org/post/classification/here"}, workflow: workflow)
     extractor.process(classification)
 
-    expect(a_request(:post, "example.org/post/classification/here")
+    expect(a_request(:post, "https://example.org/post/classification/here")
              .with(body: classification.to_json))
       .to have_been_made.once
   end
 
   it 'stores the returned data as an extract' do
-    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"})
+    extractor = described_class.new(key: "ext", config: {"url" => "https://example.org/post/classification/here"}, workflow: workflow)
     result = extractor.process(classification)
     expect(result).to eq(response_data)
   end
 
   it 'handles 204s' do
-    stub_request(:post, "http://example.org/post/classification/here").
+    stub_request(:post, "https://example.org/post/classification/here").
       to_return(status: 204, body: "", headers: {})
 
-    extractor = described_class.new(key: "ext", config: {"url" => "http://example.org/post/classification/here"})
+    extractor = described_class.new(key: "ext", config: {"url" => "https://example.org/post/classification/here"}, workflow: workflow)
     result = extractor.process(classification)
     expect(result).to eq(Extractor::NoData)
   end
 
-  it 'does not post if no url is configured' do
-    extractor = described_class.new(key: "ext")
+  it 'handles 500s' do
+    stub_request(:post, "https://example.org/post/classification/here").
+      to_return(status: 500, body: "", headers: {})
 
-    expect do
-      extractor.process(classification)
-    end.to raise_error(StandardError)
+    extractor = described_class.new(key: "ext", config: {"url" => "https://example.org/post/classification/here"}, workflow: workflow)
+    expect{extractor.process(classification)}.to raise_error(Extractors::ExternalExtractor::ExternalExtractorFailed)
   end
 end

--- a/spec/models/extractors/http_extraction_spec.rb
+++ b/spec/models/extractors/http_extraction_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+class DummyExtractor
+  include Extractors::HttpExtraction
+
+  attr_reader :url
+
+  def initialize(url: 'https://example.org/post/here')
+    @url = url
+  end
+end
+
+describe Extractors::HttpExtraction do
+  let(:default_extractor){ DummyExtractor.new }
+  let(:sample_url){ 'https://example.org/post/here' }
+
+  it 'still validates the url' do
+    broken_extractor = DummyExtractor.new url: 'http://www.google.com'
+    expect(broken_extractor).not_to be_valid
+  end
+
+  it 'calls http_post correctly' do
+    expect(default_extractor).to receive(:http_post).with("test").once
+    default_extractor.http_extract("test")
+  end
+
+  it 'returns the correct value for no data' do
+    stub_request(:post, sample_url).
+      to_return(status: 204, body: "", headers: {})
+
+    expect(default_extractor.http_extract(nil)).to eq(Extractor::NoData)
+  end
+
+  it 'configures HttpOperation with the correct exception type' do
+    allow(RestClient).to receive(:post).and_raise(RestClient::Exception)
+
+    expect do
+      default_extractor.http_extract(nil)
+    end.to raise_error(Extractors::HttpExtraction::ExtractionFailed)
+  end
+end

--- a/spec/models/reducers/aggregation_reducers/rectangle_reducer_spec.rb
+++ b/spec/models/reducers/aggregation_reducers/rectangle_reducer_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe Reducers::AggregationReducers::RectangleReducer do
+  let(:workflow){ create :workflow }
+  let(:subject_reduction){ create :subject_reduction, reducible_type: 'Workflow', reducible_id: workflow.id }
+
+  it 'is valid by default' do
+    expect(described_class.new(key: 'ext')).to be_valid
+  end
+
+  describe 'validates the shapes of parameters' do
+    it 'validates eps' do
+      expect(described_class.new(key: 'ext', eps: 'foo')).not_to be_valid
+      expect(described_class.new(key: 'ext', eps: 7)).to be_valid
+      expect(described_class.new(key: 'ext', eps: nil).eps).to eq(5.0)
+    end
+
+    it 'validates min_samples' do
+      expect(described_class.new(key: 'ext', min_samples: 'foo')).not_to be_valid
+      expect(described_class.new(key: 'ext', min_samples: 7)).to be_valid
+      expect(described_class.new(key: 'ext', min_samples: nil).min_samples).to eq(3)
+    end
+
+    it 'validates metric' do
+      expect(described_class.new(key: 'ext', metric: 'blah')).not_to be_valid
+      expect(described_class.new(key: 'ext', metric: 7)).not_to be_valid
+      expect(described_class.new(key: 'ext', metric: 'cosine')).to be_valid
+      expect(described_class.new(key: 'ext', metric: nil).metric).to eq('euclidean')
+    end
+
+    it 'validates algorithms' do
+      expect(described_class.new(key: 'ext', algorithm: 'blah')).not_to be_valid
+      expect(described_class.new(key: 'ext', algorithm: 7)).not_to be_valid
+      expect(described_class.new(key: 'ext', algorithm: 'kd_tree')).to be_valid
+      expect(described_class.new(key: 'ext', algorithm: nil).algorithm).to eq('auto')
+    end
+
+    it 'validates leaf_size' do
+      expect(described_class.new(key: 'ext', leaf_size: 'blah')).not_to be_valid
+      expect(described_class.new(key: 'ext', leaf_size: 7)).to be_valid
+      expect(described_class.new(key: 'ext', leaf_size: nil).leaf_size).to eq(30)
+    end
+
+    it 'validates p' do
+      expect(described_class.new(key: 'ext', p: 'blah')).not_to be_valid
+      expect(described_class.new(key: 'ext', p: 7)).to be_valid
+      expect(described_class.new(key: 'ext', p: nil).p).to be_nil
+    end
+  end
+
+  describe 'builds urls correctly' do
+    it 'builds the default URL' do
+      expect(described_class.new(key: 'ext', reducible: workflow).url).to eq(
+        'https://aggregation-caesar.zooniverse.org/reducers/rectangle_reducer?eps=5.0&min_samples=3&metric=euclidean&algorithm=auto&leaf_size=30'
+      )
+    end
+
+    it 'uses all custom values' do
+      reducer = described_class.new(
+        key: 'ext',
+        reducible: workflow,
+        config: {
+          eps: 8.0,
+          min_samples: 4,
+          metric: 'minkowski',
+          leaf_size: 25,
+          p: 2
+        }
+      )
+
+      expect(reducer.url).to eq(
+        'https://aggregation-caesar.zooniverse.org/reducers/rectangle_reducer?eps=8.0&min_samples=4&metric=minkowski&algorithm=auto&leaf_size=25&p=2'
+      )
+    end
+  end
+
+  it 'sends the request correctly' do
+    stub_request(:post, 'https://aggregation-caesar.zooniverse.org/reducers/rectangle_reducer?eps=5.0&min_samples=3&metric=euclidean&algorithm=auto&leaf_size=30').
+      to_return(status: 204, body: "", headers: {})
+
+    reducer = described_class.new(key: 'r')
+    reducer.reduce_into([], subject_reduction, [])
+
+    expect(a_request(:post, "https://aggregation-caesar.zooniverse.org/reducers/rectangle_reducer?eps=5.0&min_samples=3&metric=euclidean&algorithm=auto&leaf_size=30"))
+      .to have_been_made.once
+  end
+end

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -63,7 +63,6 @@ describe Reducers::ExternalReducer do
     let(:request_data){{
       extracts: extracts,
       store: running_reduction.store,
-      relevant_reductions: []
     }}
 
     it 'sends the extracts and the store' do

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -50,28 +50,6 @@ describe Reducers::ExternalReducer do
     expect(result.data).to be(nil)
   end
 
-  it 'does not post if no url is configured' do
-    reducer = described_class.new(config: {"url" => nil})
-
-    expect do
-      reducer.reduce_into(extracts, build(:subject_reduction))
-    end.to raise_error(StandardError)
-  end
-
-  describe 'validations' do
-    it 'is not valid with a non-https url' do
-      reducer = described_class.new(config: {"url" => "http://foo.com"})
-      expect(reducer).not_to be_valid
-      expect(reducer.errors[:url]).to be_present
-    end
-
-    it 'is not valid with some strange url' do
-      reducer = described_class.new(config: {"url" => "https:\\foo+3"})
-      expect(reducer).not_to be_valid
-      expect(reducer.errors[:url]).to include("URL could not be parsed")
-    end
-  end
-
   describe 'running_reduction' do
     let(:running_reducer){ reducer.tap{ |r| r.running_reduction! } }
     let(:store){ {"foo" => "bar"} }
@@ -84,7 +62,8 @@ describe Reducers::ExternalReducer do
 
     let(:request_data){{
       extracts: extracts,
-      store: running_reduction.store
+      store: running_reduction.store,
+      relevant_reductions: []
     }}
 
     it 'sends the extracts and the store' do

--- a/spec/models/reducers/http_reduction_spec.rb
+++ b/spec/models/reducers/http_reduction_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+class DummyReducer
+  include Reducers::HttpReduction
+
+  attr_reader :url
+
+  def initialize(url: 'https://example.org/post/here')
+    @url = url
+  end
+end
+
+describe Reducers::HttpReduction do
+  let(:default_reducer){ DummyReducer.new }
+  let(:sample_url){ 'https://example.org/post/here' }
+  let(:workflow){ build :workflow }
+  let(:subject){ build :subject }
+  let(:reduction){ build :subject_reduction, reducible: workflow, subject: subject }
+
+  it 'still validates the url' do
+    broken_reducer = DummyReducer.new url: 'http://www.google.com'
+    expect(broken_reducer).not_to be_valid
+  end
+
+  it 'calls http_post correctly' do
+    expect(default_reducer).to receive(:http_post).with("test").once
+    default_reducer.http_reduce(reduction, "test")
+  end
+
+  it 'returns the correct value for no data' do
+    stub_request(:post, sample_url).
+      to_return(status: 204, body: "", headers: {})
+
+    expect(default_reducer.http_reduce(reduction, nil).data).to eq(nil)
+  end
+
+  it 'configures HttpOperation with the correct exception type' do
+    allow(RestClient).to receive(:post).and_raise(RestClient::Exception)
+
+    expect do
+      default_reducer.http_reduce(reduction, nil)
+    end.to raise_error(Reducers::HttpReduction::ReductionFailed)
+  end
+end


### PR DESCRIPTION
This PR extracts some of the common code from External Extractors and External Reducers into a common base and then uses that to provide sample wrappers for Coleman's aggregation-for-caesar external reducers. This way the reducers can be configured as normal reducers and they do the work of building the querystring for a user.