### PR TITLE
upgrade factory-girl to factory-bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :development, :test do
   gem 'webmock'
   gem 'spring-commands-rspec'
   gem 'rubocop'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'rails-controller-testing'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,11 +105,11 @@ GEM
     erubi (1.8.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
-      railties (>= 3.0.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.1)
+      factory_bot (~> 5.0.0)
+      railties (>= 4.2.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-panoptes (0.3.0)
@@ -137,7 +137,7 @@ GEM
     hashie (3.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.5.3)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
     jmespath (1.4.0)
@@ -392,7 +392,7 @@ DEPENDENCIES
   capybara (~> 3.14)
   deferred_associations
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   flipper
   flipper-active_record
   flipper-ui

--- a/spec/factories/classification_factory.rb
+++ b/spec/factories/classification_factory.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification do
     id { generate :classification_id }
     project_id { workflow&.project_id || 1 }
-    workflow_version "1.1"
+    workflow_version { "1.1" }
   end
 end

--- a/spec/factories/credential_factory.rb
+++ b/spec/factories/credential_factory.rb
@@ -1,13 +1,13 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :credential do
     transient do
-      login "tester"
-      admin false
+      login { "tester" }
+      admin { false }
       workflows { [] }
     end
 
-    token "fake"
-    expires_at 1.day.from_now
+    token { "fake" }
+    expires_at { 1.day.from_now }
     project_ids { workflows.map(&:project_id).uniq }
 
     after(:build) do |credential, evaluator|
@@ -15,7 +15,7 @@ FactoryGirl.define do
     end
 
     trait :not_logged_in do
-      login nil
+      login { nil }
     end
 
     trait :expired do
@@ -23,7 +23,7 @@ FactoryGirl.define do
     end
 
     trait :admin do
-      admin true
+      admin { true }
     end
   end
 end

--- a/spec/factories/data_request_factory.rb
+++ b/spec/factories/data_request_factory.rb
@@ -1,7 +1,7 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :data_request do
     exportable { create :workflow }
     workflow_id { exportable.id }
-    requested_data :extracts
+    requested_data { :extracts }
   end
 end

--- a/spec/factories/extract_factory.rb
+++ b/spec/factories/extract_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence(:classification_id) { |n| n }
 
   factory :extract do
@@ -6,8 +6,8 @@ FactoryGirl.define do
     subject
 
     classification_id { generate :classification_id }
-    classification_at Time.zone.now
+    classification_at { Time.zone.now }
 
-    extractor_key "foo"
+    extractor_key { "foo" }
   end
 end

--- a/spec/factories/extractor_factory.rb
+++ b/spec/factories/extractor_factory.rb
@@ -1,9 +1,9 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :extractor do
-    workflow nil
+    workflow { nil }
     key { generate(:key) }
     config { {} }
-    minimum_workflow_version nil
+    minimum_workflow_version { nil }
 
     factory :survey_extractor, class: Extractors::SurveyExtractor
     factory :external_extractor, class: Extractors::ExternalExtractor

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :project do
   end
 end

--- a/spec/factories/reducer_factory.rb
+++ b/spec/factories/reducer_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   sequence :key do |n|
     "key#{n}"
   end
@@ -13,11 +13,11 @@ FactoryGirl.define do
     factory :external_reducer, class: Reducers::ExternalReducer
 
     trait :reduce_by_subject do
-      topic 'reduce_by_subject'
+      topic { 'reduce_by_subject' }
     end
 
     trait :reduce_by_user do
-      topic 'reduce_by_user'
+      topic { 'reduce_by_user' }
     end
   end
 end

--- a/spec/factories/stream_factory.rb
+++ b/spec/factories/stream_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :classification_event, class: Hash do
     transient do
       workflow

--- a/spec/factories/subject_action_factory.rb
+++ b/spec/factories/subject_action_factory.rb
@@ -1,9 +1,9 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :subject_action do
     workflow
     subject
 
-    effect_type "retire_subject"
-    status "completed"
+    effect_type { "retire_subject" }
+    status { "completed" }
   end
 end

--- a/spec/factories/subject_factory.rb
+++ b/spec/factories/subject_factory.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :subject do
     metadata { {} }
   end

--- a/spec/factories/subject_reduction_factory.rb
+++ b/spec/factories/subject_reduction_factory.rb
@@ -1,8 +1,8 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :subject_reduction do
     reducible { create :workflow }
     subject
 
-    reducer_key "foo"
+    reducer_key { "foo" }
   end
 end

--- a/spec/factories/subject_rule_effect_factory.rb
+++ b/spec/factories/subject_rule_effect_factory.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :subject_rule_effect do
-    action :retire_subject
+    action { :retire_subject }
     config { {} }
   end
 end

--- a/spec/factories/subject_rule_factory.rb
+++ b/spec/factories/subject_rule_factory.rb
@@ -1,5 +1,5 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :subject_rule do
-    condition [:const, true]
+    condition { [:const, true] }
   end
 end

--- a/spec/factories/user_actions.rb
+++ b/spec/factories/user_actions.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_action do
     
   end

--- a/spec/factories/user_reduction_factory.rb
+++ b/spec/factories/user_reduction_factory.rb
@@ -1,8 +1,8 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_reduction do
     reducible { create :workflow }
-    user_id 1234
+    user_id { 1234 }
 
-    reducer_key "foo"
+    reducer_key { "foo" }
   end
 end

--- a/spec/factories/user_rule_effect_factory.rb
+++ b/spec/factories/user_rule_effect_factory.rb
@@ -1,6 +1,6 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_rule_effect do
-    action :promote_user
+    action { :promote_user }
     config { {workflow_id: 1} }
   end
 end

--- a/spec/factories/user_rule_factory.rb
+++ b/spec/factories/user_rule_factory.rb
@@ -1,5 +1,5 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_rule do
-    condition [:const, true]
+    condition { [:const, true] }
   end
 end

--- a/spec/factories/workflow_factory.rb
+++ b/spec/factories/workflow_factory.rb
@@ -1,5 +1,5 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :workflow do
-    project_id 123
+    project_id { 123 }
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end


### PR DESCRIPTION
Resolves #629

I'm still really weirded out by the apparent syntax change. We used to be able to say:

```ruby
FactoryBot.define do
  factory :classification do
    id { generate :classification_id }
    project_id { workflow&.project_id || 1 }
    workflow_version "1.1"
  end
end
```

but that must be changed to

```ruby
FactoryBot.define do
  factory :classification do
    id { generate :classification_id }
    project_id { workflow&.project_id || 1 }
    workflow_version { "1.1" }
  end
end
```

(note the curly braces added after `workflow_version`)

This PR works correctly but we might want to figure out why the system is acting this way. It makes me suspicious.