### PR TITLE
Include relevant reduction in jsonified extracts

### DIFF
--- a/app/models/extract.rb
+++ b/app/models/extract.rb
@@ -22,4 +22,8 @@ class Extract < ApplicationRecord
   belongs_to :subject
   has_and_belongs_to_many_with_deferred_save :subject_reduction
   has_and_belongs_to_many_with_deferred_save :user_reduction
+
+  def as_json(*)
+    super(methods: :relevant_reduction)
+  end
 end

--- a/spec/models/extract_spec.rb
+++ b/spec/models/extract_spec.rb
@@ -5,4 +5,19 @@ RSpec.describe Extract, type: :model do
   it "should not fail to build the factory" do
     expect(build(:extract)).to be_valid
   end
+
+  describe "a relevant reduction" do
+    let(:extract) { create(:extract, user_id: 1) }
+    let(:rr) { create(:user_reduction, data: {skill: 15}, user_id: 1, reducer_key: 'skillz') }
+    let(:parsed) { JSON.parse(extract.to_json) }
+
+    it 'serializes a relevant reduction' do
+      extract.relevant_reduction = rr
+      expect(parsed).to include("relevant_reduction" => hash_including("id" => rr.id, "data" => rr.data))
+    end
+
+    it 'serializes nil if not associated' do
+     expect(parsed).to include("relevant_reduction" => nil)
+    end
+  end
 end


### PR DESCRIPTION
Includes specs to test the new `as_json` override. I don't think anything else is needed as the HTTP methods all use and are specced with `to_json`.