### PR TITLE
add approved label github action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,13 @@
+workflow "Label approved pull requests" {
+  on = "pull_request_review"
+  resolves = ["Label when approved"]
+}
+
+action "Label when approved" {
+  uses = "zooniverse/label-when-approved-action@master"
+  secrets = ["GITHUB_TOKEN"]
+  env = {
+    LABEL_NAME = "approved"
+    APPROVALS  = "1"
+  }
+}


### PR DESCRIPTION
Add an approved label on 1 PR approval from a reviewer. This is done with a github action and is used by the pullreminders app to decide which PR's to ignore (i.e. don't remind folks about approved PRs).