### PR TITLE
Ported docs, new docs

### DIFF
--- a/docs/source/includes/_reducer_configuration.md
+++ b/docs/source/includes/_reducer_configuration.md
@@ -1,0 +1,38 @@
+# Reducer Configuration
+
+Configuring reducers can be tricky because they are flexible in so many different ways.
+
+## Extractor Keys
+
+Sometimes multiple extractors will be defined but a particular reducer only cares about or can only work with a particular type of extract. In this case, you can use the extractor keys property to restrict the extracts that are sent to this reducer. The format of this value is either a string (for a single extractor key) or an array of strings (for multiple extractors). The default, a blank string or a nil, sends all extracts.
+
+## Topic
+
+Extracts are always implicitly grouped before being combined. There are two different ways of doing this, whose names are hopefully self-explanatory. The default is `reduce_by_subject`
+
+* `reduce_by_subject`
+* `reduce_by_user`
+
+## Grouping
+
+This is a confusing setting because extracts are already obviously grouped according to the [topic](#topic). This allows an additional grouping pass, which, crucially, can be done on the basis of the *value* of a specified field. So to configure this, you need to set the name of the field to group by (in format `extractor_key.field_name`) and then a flag indicating how to handle when the extracts for a given classification are missing that field. The value of the grouping field will be reflected in the name of the group, stored in the `subgroup` field. The default behavior is not to perform this secondary grouping.
+
+## Reduction Mode
+
+This is probably the least understood part of configuring reducers. Briefly, the system offers two very different modes of performing reduction. These are:
+
+* `default_reduction`
+* `running_reduction`
+
+### Default Reduction
+
+In "default reduction" mode, each time a new extract is created, we fetch all of the other extracts for that subject (or user) and send them all to the reducer for processing. In cases where extracts are coming in very quickly, this can create some extra work fetching extracts, but is guaranteed to be free of race conditions because each new reduction will get a chance to reduce across all relevant extracts. This mode is much simpler and is preferred in almost every case. However, in the case where a given subject (or user) is likely to have thousands of associated extracts, it is recommended to use "running reduction" mode.
+
+### Running Reduction
+
+"Running reduction" mode was created to support the Notes for Nature use case, where we are reducing across a user's entire classification history within a given project, which could run to tens of thousands of items for power users. In this use case, fetching all 10,000 extracts each time a new extract is created is impractical and the operations we want to perform are relatively simple to perform using only the new extracts created in a given extraction pass.
+
+When a reducer is configured for running reduction, each time a new classification produces new extracts, the reducer is invoked with only those new extracts. Any additional information it would need in order to correctly compute the reduction should be present in a field *on* the reduction, called a `store`. With the new extracts and the store, the reducer will compute an updated value and update its store appropriately. However, this can't be done in a multithreaded way or else the object might be available while in an inconsistent state (example: its store has been updated but its value has not). Accordingly, we use optimistic locking semantics, so that we prefetch all possible relevant extracts and reductions before reducing and throw a sync error if the object versions don't match when we try to save. Further, we need to avoid updating the reduction multiple times with the same extract, which is not a concern with running reduction. Therefore, this mode populates a relation tracking which extracts have been incorporated into which reductions. Between this and the synchronization retries, there is considerable added complexity and overhead compared to default reduction mode. It's not recommended to use running reduction mode with external reducers, because the added complexity of writing reducers that reduce from a `store`.
+
+### Reduction Mode Example
+See [Reduction Mode Example](Reduction-Mode-Example)

--- a/docs/source/includes/_reduction_mode.md
+++ b/docs/source/includes/_reduction_mode.md
@@ -1,0 +1,30 @@
+# Reduction Mode Examples
+
+This example is to clarify the difference between how default reduction and running reduction work. Imagine the extract from each classification produces a number from 0 to 10 and the reducer computes the average of these numbers.
+
+The same extracts are processed by each reducer in the same order and we illustrate the changing values in the system as they arrive. For clarity, the values of extracts are indicated in bold.
+
+## Default Reduction
+
+| Extract ID | Extract Value | Extracts to reducer | Store Value In | Calculation | Store Value | Items in Association |
+|------------|---------------|---------------------|----------------|-------------|-------------|----------------------|
+| 1 | **5** | 1 | nil | **5**/1 | nil | 0 |
+| 2 | **3** | 1, 2 | nil | (**5**+**3**)/2 | nil | 0 |
+| 2 | **3** | 1, 2 | nil | (**5**+**3**)/2 | nil | 0 |
+| 3 | **4** | 1, 2, 3 | nil | (**5**+**3**+**4**)/3 | nil | 0 |
+
+
+## Running Reduction
+
+| Extract ID | Extract Value | Extracts to reducer | Store Value In | Calculation | Store Value | Items in Association |
+|------------|---------------|---------------------|----------------|-------------|-------------|----------------------|
+| 1 | **5** | 1 | nil | (0*0+**5**)/(0+1) | 1 | 1 |
+| 2 | **3** | 2 | 1 | (5*1+**3**)/(1+1) | 2 | 2 |
+| 2 | **3** | nil | N/A | N/A | 2 | 2 |
+| 3 | **4** | 3 | 2 | (4*2+**4**)/(2+1) | 3 | 3 |
+
+## Points of Note
+
+Note that in default reduction mode, re-reduction is always triggered, regardless of whether an extract is being processed twice. Also notice that each computation in default reduction consumes all of the extracts. We calculate an average by summing together the values of all of the extracts and then dividing by the number of extracts.
+
+In running reduction, on the other hand, the store keeps a running count of how many items the reducer has seen. This store, with the previous value of the reduction, can be used to compute the new average using only the new value by using the formula `((old average * previous count) + new value)/(old count + 1)` and the store can be updated with the new count `(old count + 1)`.

--- a/docs/source/includes/_subject_metadata.md
+++ b/docs/source/includes/_subject_metadata.md
@@ -1,0 +1,20 @@
+# Subject Metadata
+
+### Caesar can reflect on several attributes in a subject's metadata to know how to perform certain actions.
+
+## `#training_subject`:
+* Boolean. If true, subject is a training subject.
+* Used to funnel training subjects to a separate reduction pathway.
+* Example: TESS user weighting
+* ExtractFilter allows filtering by training behavior.
+* To use: set a filter on reducer to include:
+  `training_behavior: training_only` or `experiment_only`
+* See Subject#training_subject? and Filters::FilterByTrainingBehavior for use.
+
+## `#previous_subject_ids`:
+* Array of Zooniverse subject ids
+* Subjects whose ids are included in array will be passed by RunsReducers to ExtractFetcher
+* Used to indicate that one or more prior subjects' extracts should be included when reducing a new subject.
+* Example: TESS takes a new image of the same piece of the sky as a previous subject on a subsequent pass. The previous subject's Zooniverse id is included in the subject metadata and all extracts for both subjects are included in the new subject's reduction.
+* See Subject#additional_subject_ids_for_reduction for use.
+

--- a/docs/source/index.html.md
+++ b/docs/source/index.html.md
@@ -9,9 +9,12 @@ toc_footers:
   - <a href='https://github.com/tripit/slate'>Documentation Powered by Slate</a>
 
 includes:
-  - how_to_swap
   - extracts
+  - reducer_configuration
+  - reduction_mode
+  - subject_metadata
   - rules
+  - how_to_swap
   - errors
 
 search: true
@@ -21,7 +24,7 @@ search: true
 
 Caesar is an evolution of the Nero codebase, which is made more generic. In
 essence, Caesar receives classifications from the event stream (a Lambda script
-sends them to Caesars HTTP API). 
+sends them to Caesars HTTP API).
 
 For each classification, it runs zero or more extractors defined in the
 workflow to generate "extracts". These extracts specify information summarized


### PR DESCRIPTION
Moved the docs from the Github wiki to their own markdown in the repo and added them to the index. 

This should build the new github.io docs page automatically on merge.