### PR TITLE
fix rollbar spam from extractors

### DIFF
--- a/app/models/runs_extractors.rb
+++ b/app/models/runs_extractors.rb
@@ -24,7 +24,7 @@ class RunsExtractors
         data = extractor.process(classification)
         extract_ok = true
       rescue Exception => e
-        Rollbar.log('error', e)
+        Rollbar.error(e, use_exception_level_filters: true)
         has_errors = true
       end
 

--- a/spec/models/runs_extractors_spec.rb
+++ b/spec/models/runs_extractors_spec.rb
@@ -124,8 +124,8 @@ describe RunsExtractors do
         allow(blank_extractor).to receive(:process).and_raise(DummyException.new('boo'))
         expect(question_extractor).to receive(:process).and_raise(StandardError.new('boo'))
 
-        expect(Rollbar).to receive(:log).with('error', instance_of(DummyException))
-        expect(Rollbar).to receive(:log).with('error', instance_of(StandardError))
+        expect(Rollbar).to receive(:error).with(instance_of(DummyException), use_exception_level_filters: true)
+        expect(Rollbar).to receive(:error).with(instance_of(StandardError), use_exception_level_filters: true)
         begin
           runner.extract(classification)
         rescue


### PR DESCRIPTION
If Rollbar is explicitly invoked then by default it doesn't apply the exception filters we defined. This is why there are a ton of errors in Rollbar from failing extractions. None of them matter.