### PR TITLE
Don't save NoData extractions

### DIFF
--- a/app/models/extractors/pluck_field_extractor.rb
+++ b/app/models/extractors/pluck_field_extractor.rb
@@ -3,15 +3,22 @@ require 'jsonpath'
 module Extractors
   class PluckFieldExtractor < Extractor
     class FailedMatch < StandardError; end
+    class NoMatches < StandardError; end
 
     config_field :field_map
-    config_field :if_missing, default: 'error', enum: ['error', 'ignore']
+    config_field :if_missing, default: 'error', enum: ['error', 'ignore', "reject"]
 
     def extract_data_for(classification)
       Hash.new.tap do |hash|
         field_map.each do |name, path|
           hash[name] = extract_one(classification, path)
         end
+      end
+    rescue FailedMatch
+      if if_missing == "reject"
+        Extractor::NoData
+      else
+        raise
       end
     end
 
@@ -21,10 +28,10 @@ module Extractors
 
       case result.size
       when 0
-        if if_missing == "error"
-          raise FailedMatch
-        else
+        if if_missing == "ignore"
           nil
+        else
+          raise FailedMatch
         end
       when 1
         result[0]

--- a/app/models/runs_extractors.rb
+++ b/app/models/runs_extractors.rb
@@ -29,6 +29,7 @@ class RunsExtractors
       end
 
       next unless extract_ok
+      return data if data == Extractor::NoData
 
       extract = Extract.where(
         workflow_id: classification.workflow_id,

--- a/spec/models/extractors/pluck_field_extractor_spec.rb
+++ b/spec/models/extractors/pluck_field_extractor_spec.rb
@@ -69,5 +69,11 @@ describe Extractors::PluckFieldExtractor do
       expect(result).to be_a(Hash)
       expect(result).to eq({"cantfind" => nil})
     end
+
+    it 'does not create an extract if no matches and reject' do
+      reject = described_class.new(key: "e", config: {"field_map" => {"nothin" => "$.busted"}, "if_missing" => "reject"})
+      result = reject.process(classification)
+      expect(result).to be(Extractor::NoData)
+    end
   end
 end

--- a/spec/models/runs_extractors_spec.rb
+++ b/spec/models/runs_extractors_spec.rb
@@ -96,6 +96,13 @@ describe RunsExtractors do
       runner.extract(classification)
     end
 
+    it 'does not save the extract if there is no data' do
+      plucker = instance_double(Extractors::PluckFieldExtractor, key: 'pluck', config: {if_missing: 'reject'}, process: nil)
+      allow(plucker).to receive(:process).and_return(Extractor::NoData)
+      expect do
+        RunsExtractors.new([plucker]).extract(classification)
+      end.to_not change{Extract.count}
+    end
 
     describe 'error handling' do
       class DummyException < StandardError; end


### PR DESCRIPTION
PluckFieldExtractor has a new option to "reject" extractions that did not match any fields. This causes the extract to become a Extractor::NoData (instead of a hash), which are filtered out in the ExtractWorker.