### PR TITLE
refactor extract fetcher to locate prior subjects

### DIFF
--- a/app/models/extract_fetcher.rb
+++ b/app/models/extract_fetcher.rb
@@ -2,10 +2,7 @@ class ExtractFetcher
   attr_accessor :reduction_mode, :topic, :extract_ids, :strategy
   attr_reader :filter
 
-  @@strategies = [ :fetch_all, :fetch_minimal ]
-  def self.strategies
-    @@strategies
-  end
+  STRATEGIES = [ :fetch_all, :fetch_minimal ]
 
   def initialize(filter)
     @filter = filter
@@ -17,43 +14,31 @@ class ExtractFetcher
 
   def strategy!(strategy)
     @strategy = strategy.to_sym
-    @user_extracts = nil
-    @subject_extracts = nil
-    @specified_extracts = nil
+    self
   end
 
   def for(topic)
-    ExtractFetcher.new(filter).tap do |fetcher|
-      fetcher.topic = topic.to_sym
-      fetcher.extract_ids = @extract_ids
-      fetcher.strategy = @strategy
-    end
+    @topic = topic.to_sym
+    self
   end
 
   def including(extract_ids)
-    ExtractFetcher.new(filter).tap do |fetcher|
-      fetcher.extract_ids = (@extract_ids + extract_ids).uniq
-      fetcher.topic = @topic
-      fetcher.strategy = @strategy
-    end
+    @extract_ids = (extract_ids + @extract_ids).uniq
+    self
   end
 
   def extracts
-    if fetch_minimal?
-      specified_extracts
-    elsif fetch_subjects?
-      subject_extracts | specified_extracts
+    if fetch_subjects?
+      subject_extracts
     elsif fetch_users?
-      user_extracts | specified_extracts
+      user_extracts
+    else
+      raise StandardError.new 'No fetch configured'
     end
   end
 
   def fetch_minimal?
     @strategy == :fetch_minimal
-  end
-
-  def fetch_additional?
-    @strategy == :fetch_additional
   end
 
   def fetch_users?
@@ -65,14 +50,36 @@ class ExtractFetcher
   end
 
   def user_extracts
-    @user_extracts ||= Extract.where(filter.except(:subject_id)).order(classification_at: :desc)
+    corrected_filter = filter.except(:subject_id)
+    if fetch_minimal?
+      Extract.where(corrected_filter.merge(id: @extract_ids))
+    else
+      Extract.where(corrected_filter)
+    end
   end
 
   def subject_extracts
-    @subject_extracts ||= Extract.where(filter.except(:user_id)).order(classification_at: :desc)
+    extract_subject_ids = Extract.find(@extract_ids).pluck(:subject_id)
+    exact_subject_ids = extract_subject_ids.append(filter[:subject_id]).uniq
+    augmented_subject_ids = augment_subject_ids(exact_subject_ids)
+
+    corrected_filter = filter.except(:user_id)
+
+    if fetch_minimal?
+      # is an extract exactly in the list of extracts with the specified subject
+      # or is an extract for one of those prior subjects but not the specified subjects
+      Extract.where(corrected_filter.merge(id: @extract_ids))
+        .or(Extract.where(
+          corrected_filter.except(:subject_id).merge(subject_id: augmented_subject_ids-exact_subject_ids)
+        )
+      )
+    else
+      # is an extract for any of the subjects that were mentioned or any of their parents
+      Extract.where(corrected_filter.except(:subject_id).merge(subject_id: augmented_subject_ids))
+    end
   end
 
-  def specified_extracts
-    @specified_extracts ||= Extract.find(@extract_ids).sort_by{ |e| e.classification_at }
+  def augment_subject_ids(id_list)
+    (id_list + id_list.map{ |subject_id| Subject.find(subject_id).additional_subject_ids_for_reduction }.flatten).uniq
   end
 end

--- a/app/models/runs_reducers.rb
+++ b/app/models/runs_reducers.rb
@@ -12,15 +12,6 @@ class RunsReducers
     return [] unless reducers&.present?
     retries ||= 2
 
-    prior_extracts = []
-    if subject_id
-      subject = Subject.find(subject_id)
-      prior_subject_ids = subject.additional_subject_ids_for_reduction
-      if prior_subject_ids.any?
-        prior_extracts = Extract.where(subject_id: prior_subject_ids).pluck(:id)
-      end
-    end
-
     filter = { subject_id: subject_id, user_id: user_id }
     case reducible
     when Workflow
@@ -29,8 +20,7 @@ class RunsReducers
       filter[:project_id] = reducible.id
     end
 
-    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids | prior_extracts)
-
+    extract_fetcher = ExtractFetcher.new(filter).including(extract_ids)
     reduction_filter = { reducible_id: reducible.id, reducible_type: reducible.class.to_s, subject_id: subject_id, user_id: user_id }
     reduction_fetcher = ReductionFetcher.new(reduction_filter)
 

--- a/spec/models/extract_fetcher_spec.rb
+++ b/spec/models/extract_fetcher_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+describe ExtractFetcher do
+  let(:wf){ create :workflow }
+  let(:s1){ create :subject }
+  let(:s2){ create :subject }
+  let(:user1_id){ 12345 }
+  let(:user2_id){ 23456 }
+
+  describe 'applies filters correctly' do
+    it 'by workflow id' do
+      wf2 = create :workflow
+
+      e1 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e2 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e2', workflow: wf
+      e3 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e3', workflow: wf2
+
+      fetcher = ExtractFetcher.new(subject_id: s1.id, workflow_id: wf.id).for(:reduce_by_subject)
+      expect(fetcher.extracts).to contain_exactly(e1, e2)
+      expect(fetcher.extracts).not_to include(e3)
+
+      fetcher = ExtractFetcher.new(user_id: user1_id, workflow_id: wf.id).for(:reduce_by_user)
+      expect(fetcher.extracts).to contain_exactly(e1, e2)
+      expect(fetcher.extracts).not_to include(e3)
+    end
+
+    it 'by subject' do
+      e1 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e2 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e2', workflow: wf
+      e3 = create :extract, subject_id: s2.id, user_id: user2_id, extractor_key: 'e1', workflow: wf
+
+      fetcher = ExtractFetcher.new(subject_id: s1.id, workflow_id: wf.id).for(:reduce_by_subject)
+      expect(fetcher.extracts).to contain_exactly(e1, e2)
+      expect(fetcher.extracts).not_to include(e3)
+    end
+
+    it 'by user' do
+      e1 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e2 = create :extract, subject_id: s2.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e3 = create :extract, subject_id: s1.id, user_id: user2_id, extractor_key: 'e2', workflow: wf
+
+      fetcher = ExtractFetcher.new(user_id: user1_id, workflow_id: wf.id).for(:reduce_by_user)
+      expect(fetcher.extracts).to contain_exactly(e1, e2)
+      expect(fetcher.extracts).not_to include(e3)
+    end
+  end
+
+  describe 'in minimal mode' do
+    it 'selects exact subject extracts' do
+      e1 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e2 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e2', workflow: wf
+      e3 = create :extract, subject_id: s2.id, user_id: user2_id, extractor_key: 'e1', workflow: wf
+
+      fetcher = ExtractFetcher.new(subject_id: s1.id, workflow_id: wf.id)
+        .including([e1.id])
+        .for(:reduce_by_subject)
+
+      fetcher.strategy! :fetch_minimal
+
+      expect(fetcher.extracts).to contain_exactly(e1)
+      expect(fetcher.extracts).not_to include(e2)
+      expect(fetcher.extracts).not_to include(e3)
+    end
+
+    it 'selects exact user extracts' do
+      e1 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e2 = create :extract, subject_id: s2.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e3 = create :extract, subject_id: s1.id, user_id: user2_id, extractor_key: 'e2', workflow: wf
+
+      fetcher = ExtractFetcher.new(user_id: user1_id, workflow_id: wf.id)
+        .including([e1.id])
+        .for(:reduce_by_user)
+
+      fetcher.strategy! :fetch_minimal
+
+      expect(fetcher.extracts).to contain_exactly(e1)
+      expect(fetcher.extracts).not_to include(e2)
+      expect(fetcher.extracts).not_to include(e3)
+    end
+
+    it 'can find prior reductions' do
+      s3 = create :subject
+
+      e1 = create :extract, subject_id: s1.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e2 = create :extract, subject_id: s2.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+      e3 = create :extract, subject_id: s3.id, user_id: user1_id, extractor_key: 'e1', workflow: wf
+
+      allow_any_instance_of(Subject)
+        .to receive(:additional_subject_ids_for_reduction) do |instance|
+          if instance.id==s1.id then [s2.id] else [] end
+        end
+
+      fetcher = ExtractFetcher.new(subject_id: s1.id, workflow_id: wf.id)
+        .including([e1.id])
+        .for(:reduce_by_subject)
+
+      fetcher.strategy! :fetch_minimal
+
+      expect(fetcher.extracts).to contain_exactly(e1,e2)
+      expect(fetcher.extracts).not_to include(e3)
+    end
+  end
+
+  describe 'figures out prior subject ids' do
+    it 'when no prior subjects exist' do
+      fetch = ExtractFetcher.new @subject_id = s1.id
+
+      expect(fetch.augment_subject_ids([])).to eq([])
+      expect(fetch.augment_subject_ids([s1.id])).to eq([s1.id])
+      expect(fetch.augment_subject_ids([s1.id, s1.id])).to eq([s1.id])
+      expect(fetch.augment_subject_ids([s1.id, s2.id])).to contain_exactly(s1.id, s2.id)
+    end
+
+    it 'when a prior subject exists' do
+      fetch = ExtractFetcher.new @subject_id = s1.id
+
+      allow_any_instance_of(Subject)
+        .to receive(:additional_subject_ids_for_reduction) do |instance|
+          if instance.id==s1.id then [s2.id] else [] end
+        end
+
+      expect(fetch.augment_subject_ids([s1.id])).to contain_exactly(s1.id, s2.id)
+    end
+  end
+end

--- a/spec/models/runs_reducers_spec.rb
+++ b/spec/models/runs_reducers_spec.rb
@@ -117,8 +117,6 @@ describe RunsReducers do
 
     reducer = create(:stats_reducer, key: 's', reducible: workflow)
 
-    expect_any_instance_of(ExtractFetcher).to receive(:including).at_least(:once).with([99999]).and_call_original
-
     runner = described_class.new(workflow, [reducer])
     runner.reduce(subject.id, nil)
 


### PR DESCRIPTION
We should only locate prior subjects when we are reducing by subject.