### PR TITLE
Move asset copy to deployment template.

### DIFF
--- a/docker/start-puma.sh
+++ b/docker/start-puma.sh
@@ -11,9 +11,6 @@ rm -f tmp/pids/*.pid
 if [ "$RAILS_ENV" != "development" ]; then
   USER_DATA=$(curl --fail http://169.254.169.254/latest/user-data || echo "")
 
-  # Links static assets for nginx webserver
- cp -R /app/public/* /static-assets/
-
   if [ "$USER_DATA" == "EMERGENCY_MODE" ]
   then
     git pull

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -33,6 +33,10 @@ spec:
               readOnly: true
             - name: static-assets
               mountPath: "/static-assets"
+          lifecycle:
+            postStart:
+             exec:
+              command: ["/bin/bash", "-c", "cp -R /app/public/* /static-assets"]
         - name: caesar-staging-nginx
           image: zooniverse/apps-nginx:xenial
           ports:

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -35,8 +35,8 @@ spec:
               mountPath: "/static-assets"
           lifecycle:
             postStart:
-             exec:
-              command: ["/bin/bash", "-c", "cp -R /app/public/* /static-assets"]
+              exec:
+                command: ["/bin/bash", "-c", "cp -R /app/public/* /static-assets"]
         - name: caesar-staging-nginx
           image: zooniverse/apps-nginx:xenial
           ports:

--- a/kubernetes/nginx.yaml
+++ b/kubernetes/nginx.yaml
@@ -10,10 +10,6 @@ data:
       include /etc/nginx/ssl.default.conf;
       gzip_types *;
 
-      proxy_buffer_size 8k;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Real-IP $remote_addr;
-
       location = /commit_id.txt {
         root /static-assets/;
         expires off;
@@ -43,6 +39,13 @@ data:
 
       location / {
         proxy_pass http://docker-caesar;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_buffer_size   128k;
+        proxy_buffers   4 256k;
+        proxy_busy_buffers_size   256k;
       }
     }
 


### PR DESCRIPTION
Puma script doesn't need to know and this way there are no issues with production deployment.

Also updates nginx config to unbreak Sidekiq.