### PR TITLE
fix error, make tests actually enter loop

### DIFF
--- a/app/workers/data_request_worker.rb
+++ b/app/workers/data_request_worker.rb
@@ -37,7 +37,7 @@ class DataRequestWorker
       actual_count = 0
 
       exporter.dump(path, estimated_count: estimated_count) do |progress, total|
-        actual_count++
+        actual_count += 1
         if progress % 1000 == 0
           request.records_count = total
           request.records_exported = progress

--- a/spec/workers/data_request_worker_spec.rb
+++ b/spec/workers/data_request_worker_spec.rb
@@ -12,7 +12,7 @@ describe DataRequestWorker do
   describe 'for workflows' do
     let(:workflow_request) do
       DataRequest.new(
-        user_id: 1234,
+        user_id: nil,
         exportable: workflow,
         subgroup: nil,
         requested_data: DataRequest.requested_data[:extracts]
@@ -31,6 +31,8 @@ describe DataRequestWorker do
 
     describe '#perform' do
       it 'performs the export' do
+        create :extract, workflow_id: workflow.id
+
         worker.perform(workflow_request_id)
         expect(DataRequest.find(workflow_request_id).complete?).to be(true)
       end
@@ -77,6 +79,8 @@ describe DataRequestWorker do
 
     describe '#perform' do
       it 'performs the export' do
+        create :subject_reduction, reducible: project
+
         worker.perform(project_request_id)
         expect(DataRequest.find(project_request_id).complete?).to be(true)
       end
@@ -123,6 +127,8 @@ describe DataRequestWorker do
 
     describe '#perform' do
       it 'performs the export' do
+        create :user_reduction, reducible: workflow
+
         worker.perform(workflow_request_id)
         expect(DataRequest.find(workflow_request_id).complete?).to be(true)
       end


### PR DESCRIPTION
The tests didn't notice that i was saying `actual_count++` instead of `actual_count += 1` because there were no items actually being exported. Fix the code that was making exports fail and make sure the tests at least try to invoke the block.

Resolves #755 