### PR TITLE
Correct handling of nil in reduction data

### DIFF
--- a/app/models/conditions/any.rb
+++ b/app/models/conditions/any.rb
@@ -10,7 +10,8 @@ module Conditions
     end
 
     def apply(bindings)
-      dict = bindings.fetch(@dict_name).data
+      dict = bindings&.fetch(@dict_name)&.data
+      raise KeyError.new if dict.nil?
       dict.keys.any? { |key| @operation.apply({"key" => key, "value" => dict.fetch(key)}) }
     end
   end

--- a/app/models/rule_bindings.rb
+++ b/app/models/rule_bindings.rb
@@ -19,9 +19,14 @@ class RuleBindings
 
   def fetch(key, default=nil)
     reducer_key, data_key = key.split(".")
-    return (@reductions.fetch(reducer_key, default) || default) if data_key.nil?
+
     return default unless @reductions.key?(reducer_key)
-    (@reductions.fetch(reducer_key).data.fetch(data_key, default) || default)
+
+    if data_key.nil?
+      isnull(@reductions.fetch(reducer_key, default), default)
+    else
+      isnull(@reductions.fetch(reducer_key).data.fetch(data_key, default), default)
+    end
   end
 
   def keys
@@ -37,5 +42,12 @@ class RuleBindings
 
   def self.overlap?(a, b)
     (a.keys & b.keys != [])
+  end
+
+  private
+
+  def isnull(value, default)
+    return default if value.nil?
+    value
   end
 end

--- a/app/models/rule_bindings.rb
+++ b/app/models/rule_bindings.rb
@@ -19,9 +19,9 @@ class RuleBindings
 
   def fetch(key, default=nil)
     reducer_key, data_key = key.split(".")
-    return @reductions.fetch(reducer_key) if data_key.nil?
+    return (@reductions.fetch(reducer_key, default) || default) if data_key.nil?
     return default unless @reductions.key?(reducer_key)
-    @reductions.fetch(reducer_key).data.fetch(data_key, default)
+    (@reductions.fetch(reducer_key).data.fetch(data_key, default) || default)
   end
 
   def keys

--- a/spec/models/conditions/any_spec.rb
+++ b/spec/models/conditions/any_spec.rb
@@ -29,7 +29,7 @@ describe Conditions::Any do
     rule = make_rule('friends', 'gte', 5)
     expect {
       rule.apply(nil)
-    }.to raise_error(NoMethodError)
+    }.to raise_error(KeyError)
   end
 
   it('throws an error on bindings that lack the requested dictionary') do

--- a/spec/models/conditions/lookup_spec.rb
+++ b/spec/models/conditions/lookup_spec.rb
@@ -11,4 +11,16 @@ describe Conditions::Lookup do
     default = double
     expect(described_class.new("b", default).apply("a" => expected)).to eq(default)
   end
+
+  it 'returns default if the stored value is nil' do
+    default = double
+    expect(described_class.new("a.b", default).apply({
+      "a" => {
+        "data" => {
+          "b" => nil
+        }
+      }
+    })).to eq(default)
+
+  end
 end

--- a/spec/models/conditions/lookup_spec.rb
+++ b/spec/models/conditions/lookup_spec.rb
@@ -11,16 +11,4 @@ describe Conditions::Lookup do
     default = double
     expect(described_class.new("b", default).apply("a" => expected)).to eq(default)
   end
-
-  it 'returns default if the stored value is nil' do
-    default = double
-    expect(described_class.new("a.b", default).apply({
-      "a" => {
-        "data" => {
-          "b" => nil
-        }
-      }
-    })).to eq(default)
-
-  end
 end

--- a/spec/models/rule_bindings_spec.rb
+++ b/spec/models/rule_bindings_spec.rb
@@ -59,4 +59,14 @@ describe RuleBindings do
     expect(rule_bindings.fetch("count.a")).to eq(1)
     expect(rule_bindings.fetch("other.a")).to eq(2)
   end
+
+  it 'returns the default if the resolved value is nil' do
+    default = double
+    reductions = [
+      SubjectReduction.new(reducer_key: 'a', data: {"b" => nil})
+    ]
+
+    rule_bindings = described_class.new(reductions, nil)
+    expect(rule_bindings.fetch('a.b', default)).to eq(default)
+  end
 end

--- a/spec/models/rule_bindings_spec.rb
+++ b/spec/models/rule_bindings_spec.rb
@@ -28,27 +28,6 @@ describe RuleBindings do
     expect(rule_bindings.fetch("subject.region")).to eq("oxford")
   end
 
-  it 'returns default when reducer has not produced reduction yet' do
-    reductions = []
-    rule_bindings = described_class.new(reductions, subject)
-    default_value = double
-    expect(rule_bindings.fetch("count.a", default_value)).to eq(default_value)
-  end
-
-  it 'handles absent keys' do
-    reductions = [
-      SubjectReduction.new(reducer_key: 'count', data: {"a" => 1}),
-      SubjectReduction.new(reducer_key: 'other', data: {"b" => 2})
-    ]
-
-    unexpected = double
-
-    rule_bindings = described_class.new(reductions, subject)
-    expect(rule_bindings.fetch("count.a")).to eq(1)
-    expect(rule_bindings.fetch("count.b")).to be(nil)
-    expect(rule_bindings.fetch("count.b",unexpected)).to eq(unexpected)
-  end
-
   it 'works with overlapping data keys' do
     reductions = [
       SubjectReduction.new(reducer_key: 'count', data: {"a" => 1}),
@@ -60,13 +39,46 @@ describe RuleBindings do
     expect(rule_bindings.fetch("other.a")).to eq(2)
   end
 
-  it 'returns the default if the resolved value is nil' do
-    default = double
-    reductions = [
-      SubjectReduction.new(reducer_key: 'a', data: {"b" => nil})
-    ]
+  describe 'default handling' do
+    it 'returns default when reducer has not produced reduction yet' do
+      reductions = []
+      rule_bindings = described_class.new(reductions, subject)
+      default_value = double
+      expect(rule_bindings.fetch("count.a", default_value)).to eq(default_value)
+    end
 
-    rule_bindings = described_class.new(reductions, nil)
-    expect(rule_bindings.fetch('a.b', default)).to eq(default)
+    it 'handles absent keys' do
+      reductions = [
+        SubjectReduction.new(reducer_key: 'count', data: {"a" => 1}),
+        SubjectReduction.new(reducer_key: 'other', data: {"b" => 2})
+      ]
+
+      unexpected = double
+
+      rule_bindings = described_class.new(reductions, subject)
+      expect(rule_bindings.fetch("count.a")).to eq(1)
+      expect(rule_bindings.fetch("count.b")).to be(nil)
+      expect(rule_bindings.fetch("count.b",unexpected)).to eq(unexpected)
+    end
+
+    it 'does not return the default if the resolved value is 0' do
+      default = double
+      reductions = [
+        SubjectReduction.new(reducer_key: 'a', data: {"b" => 0})
+      ]
+
+      rule_bindings = described_class.new(reductions, nil)
+      expect(rule_bindings.fetch('a.b', default)).to eq(0)
+    end
+
+    it 'returns the default if the resolved value is nil' do
+      default = double
+      reductions = [
+        SubjectReduction.new(reducer_key: 'a', data: {"b" => nil})
+      ]
+
+      rule_bindings = described_class.new(reductions, nil)
+      expect(rule_bindings.fetch('a.b', default)).to eq(default)
+    end
   end
 end


### PR DESCRIPTION
Hash#fetch will prefer a nil value present in the hash to the default, so we have to enforce that default manually (see new test case in spec for clarification)

Resolves #790 