### PR TITLE
randomize execution of extract workers

### DIFF
--- a/app/models/deferred_queue.rb
+++ b/app/models/deferred_queue.rb
@@ -5,7 +5,9 @@ class DeferredQueue
 
   def commit
     @jobs.each do |worker, args|
-      worker.perform_async(*args)
+      delay = rand(5).seconds
+      args.unshift(delay)
+      worker.perform_in(*args)
     end
   end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,2 +1,6 @@
 require 'sidekiq/web'
 Sidekiq::Logstash.setup
+
+Sidekiq.configure_server do |config|
+  config.average_scheduled_poll_interval = 1
+end

--- a/spec/models/deferred_queue_spec.rb
+++ b/spec/models/deferred_queue_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe DeferredQueue do
-  let(:worker) { double(perform_async: true) }
+  let(:worker) { double(perform_in: true) }
 
   it 'commits added jobs' do
     queue = described_class.new
@@ -9,7 +9,6 @@ RSpec.describe DeferredQueue do
     queue.add(worker, 2)
     queue.commit
 
-    expect(worker).to have_received(:perform_async).with(1).ordered
-    expect(worker).to have_received(:perform_async).with(2).ordered
+    expect(worker).to have_received(:perform_in).twice
   end
 end


### PR DESCRIPTION
Resolves #819 

Note that in order to make this randomness actually matter I have decreased the poll interval from 5s to 1s. I don't think this will impose an unreasonable amount of load in the majority of circumstances, but this is a change we should watch.