### PR TITLE
Disable transaction to add index concurrently

### DIFF
--- a/db/migrate/20190530163752_add_lock_version_index_to_reductions.rb
+++ b/db/migrate/20190530163752_add_lock_version_index_to_reductions.rb
@@ -1,4 +1,6 @@
 class AddLockVersionIndexToReductions < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
     add_index :user_reductions, [:id, :lock_version], unique: true, algorithm: :concurrently
     add_index :subject_reductions, [:id, :lock_version], unique: true, algorithm: :concurrently


### PR DESCRIPTION
Adding the new index concurrently requires the `disable_ddl_transaction!` flag in the migration. 