### PR TITLE
Add strong migrations gem and initializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ group :development, :test do
   gem 'rubocop'
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
+  gem 'strong_migrations'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,8 +134,8 @@ GEM
     graphiql-rails (1.5.0)
       railties
       sprockets-rails
-    hashdiff (0.4.0)
     graphql (1.9.6)
+    hashdiff (0.4.0)
     hashie (3.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -353,6 +353,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stoplight (2.1.3)
+    strong_migrations (0.3.1)
+      activerecord (>= 3.2.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -433,6 +435,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   stoplight
+  strong_migrations
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,1 +1,3 @@
-StrongMigrations.start_after = 20190710204342
+if Rails.env.development? || Rails.env.test?
+  StrongMigrations.start_after = 20190710204342
+end

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,1 @@
+StrongMigrations.start_after = 20190710204342


### PR DESCRIPTION
Ignoring all previous migrations. Couldn't test the last migration (https://github.com/zooniverse/caesar/pull/883) as it wasn't made reversible before merging, but the gem's only in dev/test so from new migrations should benefit.

For reference: https://github.com/ankane/strong_migrations