### PR TITLE
it never makes sense to reduce by user for nil userid

### DIFF
--- a/app/models/extract_fetcher.rb
+++ b/app/models/extract_fetcher.rb
@@ -45,6 +45,8 @@ class ExtractFetcher
   end
 
   def user_extracts
+    return Extract.none if filter.fetch(:user_id, nil).blank?
+
     corrected_filter = filter.except(:subject_id)
     if fetch_minimal?
       Extract.where(corrected_filter.merge(id: @extract_ids))

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -52,8 +52,7 @@ class Reducer < ApplicationRecord
 
   def process(extract_fetcher, reduction_fetcher, relevant_reductions=[])
     light = Stoplight("reducer-#{id}") do
-      fetcher_strategy = running_reduction?  ? :fetch_minimal : :fetch_all
-      extract_fetcher.strategy = fetcher_strategy
+      extract_fetcher.strategy = running_reduction?  ? :fetch_minimal : :fetch_all
       grouped_extracts = ExtractGrouping.new(extract_fetcher.extracts, grouping).to_h
 
       grouped_extracts.map do |group_key, grouped|

--- a/app/models/runs_reducers.rb
+++ b/app/models/runs_reducers.rb
@@ -30,6 +30,8 @@ class RunsReducers
     end
 
     new_reductions = reducers.map do |reducer|
+      next UserReduction.none if (reducer.reduce_by_user? && user_id.nil?)
+
       fetcher = extract_fetcher.for(reducer.topic)
 
       relevant_reductions = case reducer.topic

--- a/spec/models/extract_fetcher_spec.rb
+++ b/spec/models/extract_fetcher_spec.rb
@@ -119,4 +119,17 @@ describe ExtractFetcher do
       expect(fetch.augment_subject_ids([s1.id])).to contain_exactly(s1.id, s2.id)
     end
   end
+
+  it 'skips getting user extracts if user id is nil' do
+    create :extract, workflow: wf, user_id: user1_id
+    nil_extract = create :extract, workflow: wf, user_id: nil
+
+    allow(Extract).to receive(:where).and_return([nil_extract])
+
+    fetch = ExtractFetcher.new({user_id: nil}, []).for(:reduce_by_user)
+    extracts = fetch.extracts
+
+    expect(Extract).not_to have_received(:where)
+    expect(extracts).to be_empty
+  end
 end

--- a/spec/models/runs_reducers_spec.rb
+++ b/spec/models/runs_reducers_spec.rb
@@ -208,5 +208,21 @@ describe RunsReducers do
       expect(u1).not_to have_received(:save!)
       expect(u2).to have_received(:save!)
     end
+
+    it 'short-circuits the user reducers if there is no user id' do
+      fetcher = instance_double(ExtractFetcher, for: nil)
+
+      reducible = create :workflow
+      reducer = create(:placeholder_reducer,
+                        topic: Reducer.topics[:reduce_by_user],
+                        reducible: reducible,
+                        config: {user_reducer_keys: "testing"}
+                      )
+      runner = described_class.new(reducible, [reducer])
+
+      allow(ExtractFetcher).to receive(:new).and_return(fetcher)
+      runner.reduce(1234, nil, [])
+      expect(fetcher).not_to have_received(:for)
+    end
   end
 end


### PR DESCRIPTION
The sooner we bail out of reducing by nil user id, the better. This is one possible reason for slow running reducer times in TESS.