### PR TITLE
Switch staging to env variable secrets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ gem 'pundit', "~> 2.0.1"
 gem 'graphql'
 gem 'graphiql-rails'
 gem 'stoplight'
-gem 'dotenv-rails'
 gem 'ranked-model'
 gem 'deferred_associations'
 gem 'aws-sdk-s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,10 +100,6 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.4)
-    dotenv-rails (2.7.4)
-      dotenv (= 2.7.4)
-      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -393,7 +389,6 @@ DEPENDENCIES
   byebug
   capybara (~> 3.25)
   deferred_associations
-  dotenv-rails
   factory_bot_rails
   flipper
   flipper-active_record

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,2 +1,0 @@
-require 'dotenv'
-Dotenv.load(ENV["DOTENV_FILE"] || '.env')

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+mkdir -p tmp/pids/
+rm -f tmp/pids/*.pid
+
+if [ "$RAILS_ENV" != "development" ]; then
+  USER_DATA=$(curl --fail http://169.254.169.254/latest/user-data || echo "")
+
+  if [ "$USER_DATA" == "EMERGENCY_MODE" ]
+  then
+    git pull
+  fi
+
+  bin/rails db:migrate
+
+  if [ -f "commit_id.txt" ]
+  then
+    cp commit_id.txt public/
+  fi
+fi

--- a/docker/start-puma.sh
+++ b/docker/start-puma.sh
@@ -1,32 +1,5 @@
 #!/bin/bash -e
 
-if [ -d "/rails_conf/" ]
-then
-    ln -sf /rails_conf/* ./config/
-fi
-
-mkdir -p tmp/pids/
-rm -f tmp/pids/*.pid
-
-if [ "$RAILS_ENV" != "development" ]; then
-  USER_DATA=$(curl --fail http://169.254.169.254/latest/user-data || echo "")
-
-  if [ "$USER_DATA" == "EMERGENCY_MODE" ]
-  then
-    git pull
-  fi
-
-  if [ -f /run/secrets/environment ]
-  then
-      source /run/secrets/environment
-  fi
-
-  bin/rails db:migrate
-
-  if [ -f "commit_id.txt" ]
-  then
-    cp commit_id.txt public/
-  fi
-fi
+./start_app.sh
 
 exec bundle exec puma -C config/puma.rb

--- a/docker/start-sidekiq.sh
+++ b/docker/start-sidekiq.sh
@@ -1,32 +1,5 @@
 #!/bin/bash -e
 
-if [ -d "/rails_conf/" ]
-then
-    ln -sf /rails_conf/* ./config/
-fi
-
-mkdir -p tmp/pids/
-rm -f tmp/pids/*.pid
-
-if [ "$RAILS_ENV" != "development" ]; then
-  USER_DATA=$(curl --fail http://169.254.169.254/latest/user-data || echo "")
-
-  if [ "$USER_DATA" == "EMERGENCY_MODE" ]
-  then
-    git pull
-  fi
-
-  if [ -f /run/secrets/environment ]
-  then
-      source /run/secrets/environment
-  fi
-
-  bin/rails db:migrate
-
-  if [ -f "commit_id.txt" ]
-  then
-    cp commit_id.txt public/
-  fi
-fi
+./start_app.sh
 
 exec bundle exec sidekiq

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -241,8 +241,6 @@ spec:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: SIDEKIQ_WEB_USERNAME
-          ports:
-            - containerPort: 80
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -30,15 +30,14 @@ spec:
                   name: caesar-staging-env-vars
                   key: SECRET_KEY_BASE
             - name: RAILS_SERVE_STATIC_FILES
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: RAILS_SERVE_STATIC_FILES
+              value: true
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: DATABASE_URL
+            - name: AWS_REGION
+              value: us-east-1
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -49,31 +48,17 @@ spec:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: AWS_SECRET_ACCESS_KEY
-            - name: KINESIS_STREAM_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: KINESIS_STREAM_PASSWORD
-            - name: KINESIS_STREAM_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: KINESIS_STREAM_USERNAME
             - name: NEW_RELIC_APP_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: NEW_RELIC_APP_NAME
+              value: Caesar (staging)
+            - name: NEW_RELIC_MONITOR_MODE
+              value: true
             - name: NEW_RELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: NEW_RELIC_LICENSE_KEY
-            - name: NEW_RELIC_MONITOR_MODE
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: NEW_RELIC_MONITOR_MODE
+            - name: PANOPTES_URL
+              value: https://panoptes-staging.zooniverse.org
             - name: PANOPTES_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -84,11 +69,6 @@ spec:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: PANOPTES_CLIENT_SECRET
-            - name: PANOPTES_URL
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: PANOPTES_URL
             - name: ROLLBAR_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -162,15 +142,14 @@ spec:
                   name: caesar-staging-env-vars
                   key: SECRET_KEY_BASE
             - name: RAILS_SERVE_STATIC_FILES
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: RAILS_SERVE_STATIC_FILES
+              value: true
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: DATABASE_URL
+            - name: AWS_REGION
+              value: us-east-1
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -181,31 +160,17 @@ spec:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: AWS_SECRET_ACCESS_KEY
-            - name: KINESIS_STREAM_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: KINESIS_STREAM_PASSWORD
-            - name: KINESIS_STREAM_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: KINESIS_STREAM_USERNAME
             - name: NEW_RELIC_APP_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: NEW_RELIC_APP_NAME
+              value: Caesar (staging)
+            - name: NEW_RELIC_MONITOR_MODE
+              value: true
             - name: NEW_RELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: NEW_RELIC_LICENSE_KEY
-            - name: NEW_RELIC_MONITOR_MODE
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: NEW_RELIC_MONITOR_MODE
+            - name: PANOPTES_URL
+              value: https://panoptes-staging.zooniverse.org
             - name: PANOPTES_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -216,11 +181,6 @@ spec:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: PANOPTES_CLIENT_SECRET
-            - name: PANOPTES_URL
-              valueFrom:
-                secretKeyRef:
-                  name: caesar-staging-env-vars
-                  key: PANOPTES_URL
             - name: ROLLBAR_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -22,15 +22,93 @@ spec:
               value: staging
             - name: REDIS_URL
               value: redis://caesar-staging-redis:6379
-            - name: DOTENV_FILE
-              value: /run/secrets/environment
             - name: PORT
               value: "81"
-          volumeMounts:
-            - name: caesar-staging-environment
-              mountPath: "/run/secrets/environment"
-              subPath: "environment"
-              readOnly: true
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: SECRET_KEY_BASE
+            - name: RAILS_SERVE_STATIC_FILES
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: RAILS_SERVE_STATIC_FILES
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: DATABASE_URL
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: KINESIS_STREAM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: KINESIS_STREAM_PASSWORD
+            - name: KINESIS_STREAM_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: KINESIS_STREAM_USERNAME
+            - name: NEW_RELIC_APP_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: NEW_RELIC_APP_NAME
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: NEW_RELIC_LICENSE_KEY
+            - name: NEW_RELIC_MONITOR_MODE
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: NEW_RELIC_MONITOR_MODE
+            - name: PANOPTES_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: PANOPTES_CLIENT_ID
+            - name: PANOPTES_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: PANOPTES_CLIENT_SECRET
+            - name: PANOPTES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: PANOPTES_URL
+            - name: ROLLBAR_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: ROLLBAR_ACCESS_TOKEN
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: SENTRY_DSN
+            - name: SIDEKIQ_WEB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: SIDEKIQ_WEB_PASSWORD
+            - name: SIDEKIQ_WEB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: SIDEKIQ_WEB_USERNAME
             - name: static-assets
               mountPath: "/static-assets"
           lifecycle:
@@ -47,9 +125,6 @@ spec:
             - name: caesar-nginx-config
               mountPath: "/etc/nginx-sites"
       volumes:
-        - name: caesar-staging-environment
-          secret:
-            secretName: caesar-staging-environment
         - name: static-assets
           emptyDir: {}
         - name: caesar-nginx-config
@@ -81,19 +156,93 @@ spec:
               value: staging
             - name: REDIS_URL
               value: redis://caesar-staging-redis:6379
-            - name: DOTENV_FILE
-              value: /run/secrets/environment
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: SECRET_KEY_BASE
+            - name: RAILS_SERVE_STATIC_FILES
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: RAILS_SERVE_STATIC_FILES
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: DATABASE_URL
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: KINESIS_STREAM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: KINESIS_STREAM_PASSWORD
+            - name: KINESIS_STREAM_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: KINESIS_STREAM_USERNAME
+            - name: NEW_RELIC_APP_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: NEW_RELIC_APP_NAME
+            - name: NEW_RELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: NEW_RELIC_LICENSE_KEY
+            - name: NEW_RELIC_MONITOR_MODE
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: NEW_RELIC_MONITOR_MODE
+            - name: PANOPTES_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: PANOPTES_CLIENT_ID
+            - name: PANOPTES_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: PANOPTES_CLIENT_SECRET
+            - name: PANOPTES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: PANOPTES_URL
+            - name: ROLLBAR_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: ROLLBAR_ACCESS_TOKEN
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: SENTRY_DSN
+            - name: SIDEKIQ_WEB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: SIDEKIQ_WEB_PASSWORD
+            - name: SIDEKIQ_WEB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: caesar-staging-env-vars
+                  key: SIDEKIQ_WEB_USERNAME
           ports:
             - containerPort: 80
-          volumeMounts:
-          - name: caesar-staging-environment
-            mountPath: "/run/secrets/environment"
-            subPath: "environment"
-            readOnly: true
-      volumes:
-        - name: caesar-staging-environment
-          secret:
-            secretName: caesar-staging-environment
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Staging setup only right now, will test in deployment and then update the production deployment.

Switch to using k8 env variables from secrets.
Remove dotenv and other env var sourcing strategies.
Consolidate the cmds in start scripts and remove the unused cmds (sourcing and config setups)