### PR TITLE
re add volumeMounts directive

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -89,6 +89,7 @@ spec:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: SIDEKIQ_WEB_USERNAME
+          volumeMounts:
             - name: static-assets
               mountPath: "/static-assets"
           lifecycle:


### PR DESCRIPTION
incorrectly removed the volumemounts directive for static assets on the staging deployment template

look at adding linting tools, https://github.com/kubernetes/kubernetes/issues/39699#issuecomment-440584152
https://github.com/instrumenta/kubeval
https://kubeyaml.com/