### PR TITLE
fix k8 staging deploy template

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -30,7 +30,7 @@ spec:
                   name: caesar-staging-env-vars
                   key: SECRET_KEY_BASE
             - name: RAILS_SERVE_STATIC_FILES
-              value: true
+              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -51,7 +51,7 @@ spec:
             - name: NEW_RELIC_APP_NAME
               value: Caesar (staging)
             - name: NEW_RELIC_MONITOR_MODE
-              value: true
+              value: 'true'
             - name: NEW_RELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
@@ -143,7 +143,7 @@ spec:
                   name: caesar-staging-env-vars
                   key: SECRET_KEY_BASE
             - name: RAILS_SERVE_STATIC_FILES
-              value: true
+              value: 'true'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -164,7 +164,7 @@ spec:
             - name: NEW_RELIC_APP_NAME
               value: Caesar (staging)
             - name: NEW_RELIC_MONITOR_MODE
-              value: true
+              value: 'true'
             - name: NEW_RELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
go around this maypole again - fix invalid string types, "STDIN": unrecognized type: string

linted with https://kubeyaml.com/

<img width="1280" alt="Screenshot 2019-07-17 at 10 16 41" src="https://user-images.githubusercontent.com/295329/61363486-fe282b80-a87b-11e9-9349-ede6d9fc3795.png">


