### PR TITLE
add probes for rolling deploys

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -86,6 +86,14 @@ spec:
                  - name: X-Forwarded-Proto
                    value: https
             initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 10
           env:
             - name: RAILS_ENV
               value: production
@@ -191,6 +199,11 @@ spec:
               memory: "100Mi"
               cpu: "500m"
           livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+          readinessProbe:
             httpGet:
               path: /
               port: 80

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -86,6 +86,14 @@ spec:
                  - name: X-Forwarded-Proto
                    value: https
             initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 81
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
+            initialDelaySeconds: 10
           env:
             - name: RAILS_ENV
               value: staging
@@ -180,6 +188,11 @@ spec:
               memory: "100Mi"
               cpu: "500m"
           livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+          readinessProbe:
             httpGet:
               path: /
               port: 80


### PR DESCRIPTION
Allow k8 to know when caesar app is ready to start serving traffic, i.e. after migration runs and puma server boots. I made up the numbers for live/readiness probes and am willing to run of data here :)

These values should avoid partial downtime failures we've been seeing, however it may depending on the migration states leave us with a failing app i.e. remove column and cached schema in rails app. 

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment