### PR TITLE
do not colocate sidekiq pods on k8 nodes

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -144,6 +144,16 @@ spec:
       labels:
         app: caesar-production-sidekiq
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - caesar-production-sidekiq
+            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-production-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -147,12 +147,21 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
           - labelSelector:
               matchExpressions:
               - key: app
                 operator: In
                 values:
                 - caesar-production-sidekiq
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - caesar-staging-sidekiq
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-production-sidekiq

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -146,7 +146,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - caesar-staging-sidekiq
+                - caesar-production-sidekiq
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-staging-sidekiq

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -138,6 +138,16 @@ spec:
       labels:
         app: caesar-staging-sidekiq
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - caesar-staging-sidekiq
+            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-staging-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__


### PR DESCRIPTION
ensure we don't saturate the memory / cpu of 1 k8 node by running caesar sidekiqs on it

https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#never-co-located-in-the-same-node

note this uses `preferredDuringSchedulingIgnoredDuringExecution` so deploys will always happen but these pods may end up colocated on the same node. 

https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
> Thus an example of requiredDuringSchedulingIgnoredDuringExecution would be “only run the pod on nodes with Intel CPUs” and an example preferredDuringSchedulingIgnoredDuringExecution would be “try to run this set of pods in failure zone XYZ, but if it’s not possible, then allow some to run elsewhere”.