### PR TITLE
Revert "do not colocate sidekiq pods on k8 nodes"

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -144,25 +144,6 @@ spec:
       labels:
         app: caesar-production-sidekiq
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 2
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - caesar-production-sidekiq
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - caesar-staging-sidekiq
-            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-production-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -138,16 +138,6 @@ spec:
       labels:
         app: caesar-staging-sidekiq
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - caesar-production-sidekiq
-            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-staging-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__


### PR DESCRIPTION
Reverts zooniverse/caesar#925

This has broken deploys - i'm reverting for now and will revisit asap.
```
deployment.apps/caesar-staging-app configured
error: error validating "STDIN": error validating data: [ValidationError(Deployment.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]): unknown field "labelSelector" in io.k8s.api.core.v1.WeightedPodAffinityTerm, ValidationError(Deployment.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]): unknown field "topologyKey" in io.k8s.api.core.v1.WeightedPodAffinityTerm, ValidationError(Deployment.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]): missing required field "weight" in io.k8s.api.core.v1.WeightedPodAffinityTerm, ValidationError(Deployment.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]): missing required field "podAffinityTerm" in io.k8s.api.core.v1.WeightedPodAffinityTerm]; if you choose to ignore these errors, turn validation off with --validate=false
```