### PR TITLE
Fix node anti affinity deployment configs

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -144,6 +144,28 @@ spec:
       labels:
         app: caesar-production-sidekiq
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 2
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - caesar-production-sidekiq
+                topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - caesar-staging-sidekiq
+                topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-production-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -138,6 +138,18 @@ spec:
       labels:
         app: caesar-staging-sidekiq
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - caesar-production-sidekiq
+              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-staging-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__


### PR DESCRIPTION
Reinstate the changes from #925 and reverted in #929 but this time with the correct directives for node anti affinity (avoid other pods) 

I've linted these yamls and tested with a dry-run apply deploy: 
```
cat kubernetes/deployment-staging.tmpl | kubectl apply --record --dry-run -o yaml -f -
cat kubernetes/deployment-production.tmpl | kubectl apply --record --dry-run -o yaml -f -
```