### PR TITLE
avoid duplicate CI runs on PR and branch pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
   - 2.4.1
+branches:
+  only:
+  - master
 cache: bundler
 sudo: false
 services:


### PR DESCRIPTION
Travis currently runs when you push a branch (not fork) and on a PR change, this will fix this and speed up the PR / merging cycle.

https://docs.travis-ci.com/user/customizing-the-build/#building-specific-branches

After merging this need to verify that the master branch still runs on CI as the docs are deployed in travis via the master branch.