### PR TITLE
Fixes #927 - distinguish between integers and strings in the rules

### DIFF
--- a/app/models/conditions/lookup.rb
+++ b/app/models/conditions/lookup.rb
@@ -7,6 +7,10 @@ module Conditions
       @absent_val = absent_val
     end
 
+    def absent_val_display
+      @absent_val.instance_of?(String) ? "'" + @absent_val.to_s + "'" : @absent_val
+    end
+
     def to_a
       ["lookup", @key, @absent_val]
     end
@@ -14,5 +18,6 @@ module Conditions
     def apply(bindings)
       bindings.fetch(@key, @absent_val)
     end
+
   end
 end

--- a/app/views/workflows/_condition.html.erb
+++ b/app/views/workflows/_condition.html.erb
@@ -37,7 +37,7 @@
 <% when Conditions::Lookup %>
   <span class="text-info yields-text">
     <abbr title="Default value: <%= condition.absent_val %>">
-      <%= condition.key %>
+      <%= condition.absent_val_display %>
     </abbr>
   </span>
 <% when Conditions::Constant %>

--- a/app/views/workflows/_condition.html.erb
+++ b/app/views/workflows/_condition.html.erb
@@ -42,7 +42,7 @@
   </span>
 <% when Conditions::Constant %>
   <span class="text-primary yields-text">
-    <%= condition.value %>
+    <%= condition.value.instance_of?(String) ? "'" + condition.value.to_s + "'" : condition.value %>
   </span>
 <% when Conditions::TextTransform %>
   <span class="nested-condition">

--- a/app/views/workflows/_condition.html.erb
+++ b/app/views/workflows/_condition.html.erb
@@ -36,8 +36,8 @@
   </span>
 <% when Conditions::Lookup %>
   <span class="text-info yields-text">
-    <abbr title="Default value: <%= condition.absent_val %>">
-      <%= condition.absent_val_display %>
+    <abbr title="Default value: <%= condition.absent_val_display %>">
+      <%= condition.key %>
     </abbr>
   </span>
 <% when Conditions::Constant %>

--- a/spec/models/conditions/lookup_spec.rb
+++ b/spec/models/conditions/lookup_spec.rb
@@ -11,4 +11,12 @@ describe Conditions::Lookup do
     default = double
     expect(described_class.new("b", default).apply("a" => expected)).to eq(default)
   end
+
+  it 'if absent_val is a string, absent_val_display() should wrap the value in single quotes' do
+    expect(described_class.new("a", "5").absent_val_display()).to eq("'5'")
+  end
+
+  it 'if absent_val is not a string, absent_val_display() should not wrap the value in single quotes' do
+    expect(described_class.new("a", 5).absent_val_display()).to eq(5)
+  end
 end


### PR DESCRIPTION
In Rules:
- constants that are strings will now be indicated as such in the interface by wrapping the value in single quotes
- lookup absent values that are strings will now be indicated as such in the interface by wrapping the value in single quotes

Fixes #927 