### PR TITLE
Allow resources to be either paused or halted

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -68,14 +68,14 @@ class ProjectsController < ApplicationController
       rerun_reducers
       respond_with project, location: project_path(project, anchor: 'reducers')
     else
-      was_paused = project.paused?
+      was_halted = project.halted?
       project.update(project_params.except('display_name'))
 
-      if !was_paused && project.paused?
-        flash[:notice] = 'Pausing project'
+      if !was_halted && project.halted?
+        flash[:notice] = 'Halting project'
       end
 
-      if was_paused && project.active?
+      if was_halted && project.active?
         flash[:notice] = 'Resuming project'
       end
 

--- a/app/models/is_reducible.rb
+++ b/app/models/is_reducible.rb
@@ -1,6 +1,18 @@
 module IsReducible
   extend ActiveSupport::Concern
 
+  def active?
+    raise NotImplementedError.new
+  end
+
+  def paused?
+    raise NotImplementedError.new
+  end
+
+  def halted?
+    raise NotImplementedError.new
+  end
+
   def concerns_subjects?
     reducers.where(topic: 'reduce_by_subject').present?
   end

--- a/app/models/is_reducible.rb
+++ b/app/models/is_reducible.rb
@@ -2,15 +2,15 @@ module IsReducible
   extend ActiveSupport::Concern
 
   def active?
-    raise NotImplementedError.new
+    raise NotImplementedError.new 'Reducible resources must implement this method'
   end
 
   def paused?
-    raise NotImplementedError.new
+    raise NotImplementedError.new 'Reducible resources must implement this method'
   end
 
   def halted?
-    raise NotImplementedError.new
+    raise NotImplementedError.new 'Reducible resources must implement this method'
   end
 
   def concerns_subjects?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,6 +18,10 @@ class Project < ApplicationRecord
 
   attr_accessor :rerun
 
+  def paused?
+    false
+  end
+
   def self.accessible_by(credential)
     return none unless credential.logged_in?
     return none if credential.expired?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,6 +18,8 @@ class Project < ApplicationRecord
 
   attr_accessor :rerun
 
+  # projects can't be paused because they don't have extractors associated
+  # with them, which means the paused state is identical to the halted state
   def paused?
     false
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,7 +14,7 @@ class Project < ApplicationRecord
   has_many :user_actions
   has_many :data_requests, as: :exportable
 
-  enum status: { paused: 0, active: 1 }
+  enum status: { halted: 0, active: 1 }
 
   attr_accessor :rerun
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -104,7 +104,7 @@ class Workflow < ApplicationRecord
   has_many :data_requests, as: :exportable
 
   enum rules_applied: [:all_matching_rules, :first_matching_rule]
-  enum status: { paused: 0, active: 1 }
+  enum status: { halted: 0, active: 1, paused: 2 }
 
   attr_accessor :rerun
 

--- a/app/views/projects/_settings.html.erb
+++ b/app/views/projects/_settings.html.erb
@@ -14,17 +14,18 @@
   </div>
 <% end %>
 
-<p class="pull-right">&nbsp;</p>
-<% if @project.active? %>
+<% unless @project.halted? %>
+  <p class="pull-right">&nbsp;</p>
   <%= simple_form_for(@project, url: [@project]) do |f| %>
-    <%= f.hidden_field :status, :value => 'paused' %>
+    <%= f.hidden_field :status, :value => 'halted' %>
     <%= f.button :button, class: 'btn btn-default pull-right' do %>
-      <span class="glyphicon glyphicon-pause"></span> Pause Project
+      <span class="glyphicon glyphicon-stop"></span> Halt Project
     <% end %>
   <% end %>
 <% end %>
 
-<% if @project.paused? %>
+<% unless @project.active? %>
+  <p class="pull-right">&nbsp;</p>
   <%= simple_form_for(@project, url: [@project]) do |f| %>
     <%= f.hidden_field :status, :value => 'active' %>
     <%= f.button :button, class: 'btn btn-default pull-right' do %>

--- a/app/views/projects/_summary.html.erb
+++ b/app/views/projects/_summary.html.erb
@@ -6,7 +6,7 @@
       <dt>Project Name</dt>
       <dd><%= @project.display_name %>
       <dt>Status</dt>
-      <dd><%= if @project.paused? then "Paused" else "Active" end %>
+      <dd><%= @project.status.humanize %></dd>
       <br/><br/>
       <dt>Reducers</dt>
       <dd>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -11,6 +11,7 @@
 <table class="table table-striped">
   <colgroup>
     <col style="width: 8em"/>
+    <col style="width: 1em"/>
     <col />
     <col style="width: 8em"/>
     <col style="width: 8em"/>
@@ -19,8 +20,9 @@
   </colgroup>
   <thead>
     <tr>
-      <th>Id</th>
-      <th>Name</th>
+      <th>Project Id</th>
+      <th></th>
+      <th>Project Name</th>
       <th class="text-muted">Extractors</th>
       <th>Reducers</th>
       <th class="text-muted">Rules</th>
@@ -32,6 +34,11 @@
     <% @projects.each do |project| %>
       <tr>
         <td><%= project.id %></td>
+        <td>
+          <% if project.halted? %>
+            <i class="glyphicon glyphicon-stop text-muted"></i>
+          <% end %>
+        </td>
         <td><%= link_to project.display_name || "No Name", project_path(project) %></td>
         <td class="text-muted">N/A</td>
         <td><%= project.reducers_count %></td>

--- a/app/views/workflows/_settings.html.erb
+++ b/app/views/workflows/_settings.html.erb
@@ -24,8 +24,18 @@
   </div>
 <% end %>
 
-<p class="pull-right">&nbsp;</p>
-<% if @workflow.active? %>
+<% unless @workflow.halted? %>
+  <p class="pull-right">&nbsp;</p>
+  <%= simple_form_for(@workflow, url: [@workflow]) do |f| %>
+    <%= f.hidden_field :status, :value => 'halted' %>
+    <%= f.button :button, class: 'btn btn-default pull-right' do %>
+      <span class="glyphicon glyphicon-stop"></span> Halt Workflow
+    <% end %>
+  <% end %>
+<% end %>
+
+<% unless @workflow.paused? %>
+  <p class="pull-right">&nbsp;</p>
   <%= simple_form_for(@workflow, url: [@workflow]) do |f| %>
     <%= f.hidden_field :status, :value => 'paused' %>
     <%= f.button :button, class: 'btn btn-default pull-right' do %>
@@ -34,7 +44,8 @@
   <% end %>
 <% end %>
 
-<% if @workflow.paused? %>
+<% unless @workflow.active? %>
+  <p class="pull-right">&nbsp;</p>
   <%= simple_form_for(@workflow, url: [@workflow]) do |f| %>
     <%= f.hidden_field :status, :value => 'active' %>
     <%= f.button :button, class: 'btn btn-default pull-right' do %>

--- a/app/views/workflows/_summary.html.erb
+++ b/app/views/workflows/_summary.html.erb
@@ -6,7 +6,7 @@
       <dt>Workflow Name</dt>
       <dd><%= @workflow.name %>
       <dt>Status</dt>
-      <dd><%= if @workflow.paused? then "Paused" else "Active" end %>
+      <dd><%= @workflow.status.humanize %></dd>
       <br/><br/>
       <dt>Project Id</dt>
       <dd><%= @workflow.project_id %>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -39,6 +39,9 @@
           <% if workflow.paused? %>
             <i class="glyphicon glyphicon-pause text-muted"></i>
           <% end %>
+          <% if workflow.halted? %>
+            <i class="glyphicon glyphicon-stop text-muted"></i>
+          <% end %>
         </td>
         <td><%= link_to workflow.name || "[Name unknown]", workflow_path([workflow]) %></td>
         <td><%= workflow.project_id %></td>

--- a/app/workers/check_rules_worker.rb
+++ b/app/workers/check_rules_worker.rb
@@ -7,7 +7,9 @@ class CheckRulesWorker
   def perform(reducible_id, reducible_type, subject_id, user_id = nil)
     reducible = reducible_type.constantize.find(reducible_id)
 
-    return if reducible.class.name.demodulize=='Workflow' && reducible.paused?
+    # if reducible is only paused, continue processing everything but extracts
+    # if reducible is halted, do not process anything
+    return if reducible.halted?
 
     reducible.rules_runner.check_rules(subject_id, user_id)
   end

--- a/app/workers/extract_worker.rb
+++ b/app/workers/extract_worker.rb
@@ -12,8 +12,9 @@ class ExtractWorker
 
     workflow = classification.workflow
 
-    # if reducible is only paused, continue processing everything but extracts
-    # if reducible is halted, do not process anything
+    # when deciding whether to run extractors, we need to handle both cases the same way, by doing nothing;
+    # when deciding whether to reduce or to run rules, they need to be handled in different ways
+    # checking to see if the workflow is active implies that it's not paused or halted
     return unless workflow.active?
 
     extracts = workflow.extractors_runner.extract(classification, and_reduce: true)

--- a/app/workers/extract_worker.rb
+++ b/app/workers/extract_worker.rb
@@ -11,7 +11,10 @@ class ExtractWorker
     return unless classification
 
     workflow = classification.workflow
-    return if workflow.paused?
+
+    # if reducible is only paused, continue processing everything but extracts
+    # if reducible is halted, do not process anything
+    return unless workflow.active?
 
     extracts = workflow.extractors_runner.extract(classification, and_reduce: true)
     DeleteClassificationWorker.perform_in(rand(30.minutes.to_i).seconds, classification.id)

--- a/app/workers/perform_subject_action_worker.rb
+++ b/app/workers/perform_subject_action_worker.rb
@@ -4,7 +4,11 @@ class PerformSubjectActionWorker
 
   def perform(action_id)
     action = SubjectAction.find(action_id)
-    return if action.workflow.paused?
+
+    # if reducible is only paused, continue processing everything but extracts
+    # if reducible is halted, do not process anything
+    return if action.workflow.halted?
+
     action.perform
   end
 end

--- a/app/workers/perform_user_action_worker.rb
+++ b/app/workers/perform_user_action_worker.rb
@@ -4,7 +4,11 @@ class PerformUserActionWorker
 
   def perform(action_id)
     action = UserAction.find(action_id)
-    return if action.workflow.paused?
+
+    # if reducible is only paused, continue processing everything but extracts
+    # if reducible is halted, do not process anything
+    return if action.workflow.halted?
+
     action.perform
   end
 end

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -22,7 +22,11 @@ class ReduceWorker
 
   def perform(reducible_id, reducible_class, subject_id, user_id, extract_ids = [])
     reducible = reducible_class.constantize.find(reducible_id)
-    return if reducible.paused?
+
+    # if reducible is only paused, continue processing everything but extracts
+    # if reducible is halted, do not process anything
+    return if reducible.halted?
+
     reducible.reducers_runner.reduce(subject_id, user_id, extract_ids, and_check_rules: true)
   end
 

--- a/spec/workers/check_rules_worker_spec.rb
+++ b/spec/workers/check_rules_worker_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe CheckRulesWorker, type: :worker do
+  let(:workflow) { create :workflow }
+  let(:subject) { create :subject }
+
+  it 'checks rules when the workflow is active' do
+    active_workflow = create :workflow, status: :active
+    create :subject_rule, workflow: active_workflow
+
+    dbl = instance_double(RunsRules, check_rules: [])
+    allow_any_instance_of(Workflow).to receive(:rules_runner).and_return(dbl)
+
+    described_class.new.perform(active_workflow.id, 'Workflow', subject.id, nil)
+
+    expect(dbl).to have_received(:check_rules)
+  end
+
+  it 'checks rules when the workflow is paused' do
+    paused_workflow = create :workflow, status: :paused
+    create :subject_rule, workflow: paused_workflow
+
+    dbl = instance_double(RunsRules, check_rules: [])
+    allow_any_instance_of(Workflow).to receive(:rules_runner).and_return(dbl)
+
+    described_class.new.perform(paused_workflow.id, 'Workflow', subject.id, nil)
+
+    expect(dbl).to have_received(:check_rules)
+  end
+
+  it 'does not check rules when the workflow is halted' do
+    halted_workflow = create :workflow, status: :halted
+    create :subject_rule, workflow: halted_workflow
+
+    dbl = instance_double(RunsRules, check_rules: [])
+    allow_any_instance_of(Workflow).to receive(:rules_runner).and_return(dbl)
+
+    described_class.new.perform(halted_workflow.id, 'Workflow', subject.id, nil)
+
+    expect(dbl).not_to have_received(:check_rules)
+  end
+
+end

--- a/spec/workers/extract_worker_spec.rb
+++ b/spec/workers/extract_worker_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe ExtractWorker, type: :worker do
   let(:workflow) { create :workflow }
@@ -7,6 +7,42 @@ RSpec.describe ExtractWorker, type: :worker do
   it 'works with classification ids' do
     classification = create :classification, workflow: workflow, subject: subject
     described_class.new.perform(classification.id)
+  end
+
+  it 'does extract when the workflow is active' do
+    active_workflow = create :workflow, status: :active
+    classification = create :classification, workflow: active_workflow, subject: subject
+
+    dbl = instance_double(RunsExtractors, extract: [])
+    allow_any_instance_of(Workflow).to receive(:extractors_runner).and_return(dbl)
+
+    described_class.new.perform(classification.id)
+
+    expect(dbl).to have_received(:extract)
+  end
+
+  it 'does not extract when the workflow is paused' do
+    paused_workflow = create :workflow, status: :paused
+    classification = create :classification, workflow: paused_workflow, subject: subject
+
+    dbl = instance_double(RunsExtractors, extract: [])
+    allow_any_instance_of(Workflow).to receive(:extractors_runner).and_return(dbl)
+
+    described_class.new.perform(classification.id)
+
+    expect(dbl).not_to have_received(:extract)
+  end
+
+  it 'does not extract when the workflow is halted' do
+    halted_workflow = create :workflow, status: :halted
+    classification = create :classification, workflow: halted_workflow, subject: subject
+
+    dbl = instance_double(RunsExtractors, extract: [])
+    allow_any_instance_of(Workflow).to receive(:extractors_runner).and_return(dbl)
+
+    described_class.new.perform(classification.id)
+
+    expect(dbl).not_to have_received(:extract)
   end
 
   it 'queues the classification to be deleted' do

--- a/spec/workers/perform_subject_action_worker_spec.rb
+++ b/spec/workers/perform_subject_action_worker_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe PerformSubjectActionWorker, type: :worker do
+  let(:workflow) { create :workflow }
+  let(:subject) { create :subject }
+
+  it 'performs action when the workflow is active' do
+    active_workflow = create :workflow, status: :active
+    create :subject_rule, workflow: active_workflow
+    action = create :subject_action, workflow: active_workflow
+
+    dbl = instance_double(SubjectAction, perform: nil, workflow: active_workflow)
+
+    allow(SubjectAction).to receive(:find).and_return(dbl)
+
+    described_class.new.perform(action.id)
+
+    expect(dbl).to have_received(:perform)
+  end
+
+  it 'performs action when the workflow is paused' do
+    paused_workflow = create :workflow, status: :paused
+    create :subject_rule, workflow: paused_workflow
+    action = create :subject_action, workflow: paused_workflow
+
+    dbl = instance_double(SubjectAction, perform: nil, workflow: paused_workflow)
+
+    allow(SubjectAction).to receive(:find).and_return(dbl)
+
+    described_class.new.perform(action.id)
+
+    expect(dbl).to have_received(:perform)
+  end
+
+  it 'does not perform action when the workflow is halted' do
+    paused_workflow = create :workflow, status: :paused
+    create :subject_rule, workflow: paused_workflow
+    action = create :subject_action, workflow: paused_workflow
+
+    dbl = instance_double(SubjectAction, perform: nil, workflow: paused_workflow)
+
+    allow(SubjectAction).to receive(:find).and_return(dbl)
+
+    described_class.new.perform(action.id)
+
+    expect(dbl).to have_received(:perform)
+  end
+
+end

--- a/spec/workers/perform_user_action_worker_spec.rb
+++ b/spec/workers/perform_user_action_worker_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe PerformUserActionWorker, type: :worker do
+  let(:workflow) { create :workflow }
+
+  it 'performs action when the workflow is active' do
+    active_workflow = create :workflow, status: :active
+    create :user_rule, workflow: active_workflow
+    action = create :user_action, workflow: active_workflow, user_id: 1234, effect_type: 'promote_user'
+
+    dbl = instance_double(UserAction, perform: nil, workflow: active_workflow)
+
+    allow(UserAction).to receive(:find).and_return(dbl)
+
+    described_class.new.perform(action.id)
+
+    expect(dbl).to have_received(:perform)
+  end
+
+  it 'performs action when the workflow is paused' do
+    paused_workflow = create :workflow, status: :paused
+    create :user_rule, workflow: paused_workflow
+    action = create :user_action, workflow: paused_workflow, user_id: 1234, effect_type: 'promote_user'
+
+    dbl = instance_double(UserAction, perform: nil, workflow: paused_workflow)
+
+    allow(UserAction).to receive(:find).and_return(dbl)
+
+    described_class.new.perform(action.id)
+
+    expect(dbl).to have_received(:perform)
+  end
+
+  it 'does not perform action when the workflow is halted' do
+    halted_workflow = create :workflow, status: :halted
+    create :user_rule, workflow: halted_workflow
+    action = create :user_action, workflow: halted_workflow, user_id: 1234, effect_type: 'promote_user'
+
+    dbl = instance_double(UserAction, perform: nil, workflow: halted_workflow)
+
+    allow(UserAction).to receive(:find).and_return(dbl)
+
+    described_class.new.perform(action.id)
+
+    expect(dbl).not_to have_received(:perform)
+  end
+
+end


### PR DESCRIPTION
Paused: no new extracts, everything else continues
Halted: no new extracts, reductions, rules, or actions

Currently `paused` workflows will be in the `halted` status after this change.

Resolves #954