### PR TITLE
Do not send empty extract lists to ext reducers

### DIFF
--- a/app/models/reducers/external_reducer.rb
+++ b/app/models/reducers/external_reducer.rb
@@ -10,6 +10,7 @@ module Reducers
     config_field :version, default: 1
 
     def reduce_into(extracts, reduction)
+      return nil if extracts.empty?
       if default_reduction?
         http_reduce(reduction, extracts)
       elsif running_reduction?

--- a/spec/models/reducers/external_reducer_spec.rb
+++ b/spec/models/reducers/external_reducer_spec.rb
@@ -91,5 +91,11 @@ describe Reducers::ExternalReducer do
       reducer.reduce_into(extracts, running_reduction)
       expect(running_reduction.store).to have_key('bar')
     end
+
+    it 'does not make a request if there are no extracts', :focus do
+      expect(reducer).not_to receive(:http_reduce)
+      result = reducer.reduce_into([], build(:subject_reduction))
+      expect(result).to be(nil)
+    end
   end
 end


### PR DESCRIPTION
Aggregation's TESS user skill reducer throws a 500 when you send it an empty list of extracts. This makes sure that doesn't happen. 

It _was_ happening because we've got a lot of bunk feedback extracts from non-training subjects (see https://github.com/zooniverse/caesar/issues/973, https://github.com/zooniverse/caesar/issues/972) that just get filtered out during the reduction pass. This works fine, except that even an empty list passed to `http_reduce` would get sent to the external reducer. Seems safe to assume that we'll never want to pass an external reducer an empty list, because what's the point? So it just returns nil, which gets chomped by the select at the end of `reduce_into`.