### PR TITLE
Add training_behavior to reducer form

### DIFF
--- a/app/views/reducers/_form.html.erb
+++ b/app/views/reducers/_form.html.erb
@@ -35,7 +35,8 @@
         <%= filters.input :from %>
         <%= filters.input :to %>
         <%= filters.input :extractor_keys, placeholder: '["list", "of", "keys"]' %>
-        <%= filters.input :repeated_classifications, collection: ::Filters::FilterByRepeatedness::REPEATED_CLASSIFICATIONS, selected: 1 %>
+        <%= filters.input :repeated_classifications, collection: ::Filters::FilterByRepeatedness::REPEATED_CLASSIFICATIONS %>
+        <%= filters.input :training_behavior, collection: ::Filters::FilterByTrainingBehavior::TRAINING_BEHAVIOR %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Closes #528 

This allows users to configure the `training_behavior` filter for reducers by exposing the three options (`["ignore_training", "training_only", "experiment_only"]`) as a dropdown.

This PR also changes the filter form behavior with regards to defaults: previously, the `keep_first` option for filtering on repeated classifications was selected by default.  This default choice was _not_ enabled on reducer creation, only after its first update via the already-selected form entry. Here, I adopt the creation default for both repeatedness and training behavior filters: no filtering.

I have not written tests for this new feature; I require help to write tests.