### PR TITLE
add reduce_after_extraction param on extract worker

### DIFF
--- a/app/workers/extract_worker.rb
+++ b/app/workers/extract_worker.rb
@@ -6,7 +6,10 @@ class ExtractWorker
     (count ** 8) + 15 + (rand(30) * count + 1)
   end
 
-  def perform(classification_id)
+  def perform(classification_id, reduce_after_extraction=nil)
+    if reduce_after_extraction.nil?
+      reduce_after_extraction = true
+    end
     classification = Classification.find_by_id(classification_id)
     return unless classification
 
@@ -17,7 +20,7 @@ class ExtractWorker
     # checking to see if the workflow is active implies that it's not paused or halted
     return unless workflow.active?
 
-    extracts = workflow.extractors_runner.extract(classification, and_reduce: true)
+    extracts = workflow.extractors_runner.extract(classification, and_reduce: reduce_after_extraction)
     DeleteClassificationWorker.perform_in(rand(30.minutes.to_i).seconds, classification.id)
 
     extracts

--- a/app/workers/extract_worker.rb
+++ b/app/workers/extract_worker.rb
@@ -6,10 +6,7 @@ class ExtractWorker
     (count ** 8) + 15 + (rand(30) * count + 1)
   end
 
-  def perform(classification_id, reduce_after_extraction=nil)
-    if reduce_after_extraction.nil?
-      reduce_after_extraction = true
-    end
+  def perform(classification_id, reduce_after_extraction=true)
     classification = Classification.find_by_id(classification_id)
     return unless classification
 

--- a/spec/workers/extract_worker_spec.rb
+++ b/spec/workers/extract_worker_spec.rb
@@ -4,6 +4,33 @@ RSpec.describe ExtractWorker, type: :worker do
   let(:workflow) { create :workflow }
   let(:subject) { create :subject }
 
+  describe "#perform" do
+    let(:classification) do
+      create :classification, workflow: workflow, subject: subject
+    end
+    let(:extractors_runner_double) { instance_double("RunsExtractors")}
+
+    before do
+      allow(Classification).to receive(:find_by_id).and_return(classification)
+      allow(workflow).to receive(:extractors_runner).and_return(extractors_runner_double)
+    end
+
+    it 'defaults the run_reducer_after_extraction param to true' do
+      expect(extractors_runner_double).to receive(:extract).with(classification, and_reduce: true)
+      described_class.new.perform(classification.id)
+    end
+
+    it 'allows the run_reducer_after_extraction param to be set' do
+      expect(extractors_runner_double).to receive(:extract).with(classification, and_reduce: false)
+      described_class.new.perform(classification.id, false)
+    end
+
+    it 'allows the run_reducer_after_extraction param to be set' do
+      expect(extractors_runner_double).to receive(:extract).with(classification, and_reduce: true)
+      described_class.new.perform(classification.id, true)
+    end
+  end
+
   it 'works with classification ids' do
     classification = create :classification, workflow: workflow, subject: subject
     described_class.new.perform(classification.id)


### PR DESCRIPTION
allow configurable extract worker to avoid running reductions after extracts, keep the default behaviour of reduce after extracts but allow us to re-run extracts to backfill broken ones without re-re-triggering reductions

my use case for this change was i need to replace some broken extracts, ideally i could re-run the ExtractWorker in this case but it will re-trigger the reducers by default, i don't want that. I want the reducers to be run at another time of my choosing and configuration. 

The explicit use case is fixing fixing broken Tess extracts and the replaying the specific broken / dead sidekiq reduction jobs