### PR TITLE
remove unsed testing gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,8 +68,6 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: [:mri, :mingw, :x64_mingw]
   gem 'pry-byebug'
-  gem 'capybara', '~> 3.28'
-  gem 'selenium-webdriver'
   gem 'rspec-rails', '~> 3.8'
   gem 'pry-rails'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,16 +75,6 @@ GEM
       sassc (>= 2.0.0)
     builder (3.2.3)
     byebug (11.0.1)
-    capybara (3.28.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.5)
-      xpath (~> 3.2)
-    childprocess (1.0.1)
-      rake (< 13.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     congestion (0.0.3)
@@ -259,7 +249,6 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.1.0)
-    regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (3.0.0)
@@ -296,7 +285,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
     safe_yaml (1.0.5)
     sass (3.7.2)
       sass-listen (~> 4.0.0)
@@ -312,9 +300,6 @@ GEM
     sassc (2.0.0)
       ffi (~> 1.9.6)
       rake
-    selenium-webdriver (3.142.3)
-      childprocess (>= 0.5, < 2.0)
-      rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.11.0)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (5.2.7)
@@ -375,8 +360,6 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -387,7 +370,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4.1)
   byebug
-  capybara (~> 3.28)
   deferred_associations
   factory_bot_rails
   flipper
@@ -419,7 +401,6 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   rubocop
   sass-rails (~> 5.0)
-  selenium-webdriver
   sentry-raven
   sidekiq
   sidekiq-congestion (~> 0.1.0)


### PR DESCRIPTION
capybara and selenium-webdriver aren't used right now, add them back in as needed