### PR TITLE
only use newrelic in staging & production envs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-ui'
 gem 'panoptes-client', '~> 0.4.0'
-gem 'newrelic_rpm'
 gem 'lograge'
 gem 'logstash-event'
 gem 'rollbar'
@@ -63,6 +62,10 @@ gem 'strong_migrations'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
+
+group :production, :staging do
+  gem 'newrelic_rpm'
+end
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     netrc (0.11.0)
-    newrelic_rpm (6.5.0.357)
+    newrelic_rpm (6.7.0.359)
     nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)


### PR DESCRIPTION
Avoid using newrelic in the testing & dev envs. This removes the error in travis when new relic tries to fetch metadata from an env that doesn't allow HTTP requests..