### PR TITLE
Add retirement reason dropdown in UI for subject rule effect

### DIFF
--- a/app/models/effects/retire_subject.rb
+++ b/app/models/effects/retire_subject.rb
@@ -1,5 +1,8 @@
 module Effects
   class RetireSubject < Effect
+
+    CONFIG_CHOICES = ["classification_count", "flagged", "nothing_here", "blank", "consensus", "other", "human"]
+
     def perform(workflow_id, subject_id)
       Effects.panoptes.retire_subject(workflow_id, subject_id, reason: reason)
     end
@@ -9,7 +12,7 @@ module Effects
     end
 
     def self.config_fields
-      [:reason].freeze
+      [[:reason, CONFIG_CHOICES]].freeze
     end
 
     def reason

--- a/app/models/effects/retire_subject.rb
+++ b/app/models/effects/retire_subject.rb
@@ -12,6 +12,8 @@ module Effects
     end
 
     def self.config_fields
+      # use 2-element response (key, choices) to enable dropdown in
+      # subject_rule_effect _form view, or 1-element (key) for text input
       [[:reason, CONFIG_CHOICES]].freeze
     end
 

--- a/app/models/effects/retire_subject.rb
+++ b/app/models/effects/retire_subject.rb
@@ -1,7 +1,7 @@
 module Effects
   class RetireSubject < Effect
-
-    CONFIG_CHOICES = ["classification_count", "flagged", "nothing_here", "blank", "consensus", "other", "human"]
+    CONFIG_CHOICES = ["classification_count", "flagged", "nothing_here",
+                      "blank", "consensus", "other", "human"]
 
     def perform(workflow_id, subject_id)
       Effects.panoptes.retire_subject(workflow_id, subject_id, reason: reason)

--- a/app/views/subject_rule_effects/_form.html.erb
+++ b/app/views/subject_rule_effects/_form.html.erb
@@ -9,9 +9,13 @@
     <%= f.input :action, :as => :hidden %>
     <br />
     <div class="form-group">
-      <% Effects[@subject_rule_effect.action].config_fields.each do |key, options| %>
+      <% Effects[@subject_rule_effect.action].config_fields.each do |key, choices| %>
         <label><%= key.capitalize %></label><br/>
-        <%= text_field_tag "subject_rule_effect[config[#{key}]]", @subject_rule_effect.config[key], { class: 'form-control' } %>
+        <% if choices == nil %>
+          <%= text_field_tag "subject_rule_effect[config[#{key}]]", @subject_rule_effect.config[key.to_s], { class: 'form-control' } %>
+        <% else %>
+          <%= select_tag "subject_rule_effect[config[#{key}]]", options_for_select(choices, @subject_rule_effect.config[key.to_s]), { class: 'form-control' } %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/user_rule_effects/_form.html.erb
+++ b/app/views/user_rule_effects/_form.html.erb
@@ -10,7 +10,7 @@
     <br />
     <% Effects[@user_rule_effect.action].config_fields.each do |key, options| %>
       <label><%= key.capitalize %></label><br/>
-      <%= text_field_tag "user_rule_effect[config[#{key}]]", @user_rule_effect.config[key], { class: 'form-control' } %>
+      <%= text_field_tag "user_rule_effect[config[#{key}]]", @user_rule_effect.config[key.to_s], { class: 'form-control' } %>
     <% end %>
   </div>
   <br />

--- a/app/views/user_rules/edit.html.erb
+++ b/app/views/user_rules/edit.html.erb
@@ -9,7 +9,6 @@
 
   <ul class="dropdown-menu">
     <li><%= link_to "Promote User", new_workflow_user_rule_user_rule_effect_path(@workflow, @user_rule, action_type: 'promote_user') %></li>
-    <li><%= link_to "Send to External URL", new_workflow_user_rule_user_rule_effect_path(@workflow, @user_rule, action_type: 'external') %></li>
   </ul>
 </div>
 <table class="table table-striped table-sm">


### PR DESCRIPTION
Fixes #671

Adds dropdown in UI form for `reason` parameter of `retire_subject` subject rule effect, instead of existing text form.  This change prevents effect configurations that use an invalid retirement reason -- a common gotcha.

Dropdown choices are listed in `retire_subject` model, and passing list as second element along with param name in `config_fields` call enables the dropdown input on form for this particular action via if statement in view.  Other effects will continue to pass single param name that triggers the text field form input.

Possible enhancement: add `ActiveModel::Validations` (as used for filters), but this seems a moot point if the dropdown selection is enabled.

Also fixed:
- Use of symbolic key (rather than string) in effect model's `config_fields` function was causing `@subject_rule_effect.config[key]` to return `nil`.  I convert key to string in `config` call in subject and user rule effect views to access existing param values.
- Removed external effect from user rule effect dropdown list, as it is not a valid choice in its current form.

Changes have been tested in local development environment.