### PR TITLE
downgrade rack gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
-    rack (2.1.1)
+    rack (2.0.8)
     rack-cors (1.0.5)
       rack (>= 1.6.0)
     rack-protection (2.0.5)


### PR DESCRIPTION
rack 2.1.1 breaks the sidekiq ui - downgrading to include the security release in 2.0.8 and waiting till the release a 2.1.2 or 2.2 fix. 

https://github.com/rack/rack/pull/1428