### PR TITLE
fix redirect path after failing to create a rule effect

### DIFF
--- a/app/controllers/subject_rule_effects_controller.rb
+++ b/app/controllers/subject_rule_effects_controller.rb
@@ -45,7 +45,9 @@ class SubjectRuleEffectsController < ApplicationController
     respond_to do |format|
       format.html do
         flash[:alert] = 'Error creating a subject effect rule'
-        redirect_to action: 'new'
+        redirect_to new_workflow_subject_rule_subject_rule_effect_path(
+          action_type: effect_params[:action]
+        )
       end
       format.json { raise(Pundit::NotAuthorizedError) }
     end

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -26,8 +26,9 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
       it 'redirects to the new path in html mode' do
         post :create, params: create_params, format: :html
+        action_type = create_params.dig(:subject_rule_effect, :action)
         expect(response).to redirect_to(
-          new_workflow_subject_rule_subject_rule_effect_path
+          new_workflow_subject_rule_subject_rule_effect_path action_type: action_type
         )
       end
 

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
         post :create, params: create_params, format: :html
         action_type = create_params.dig(:subject_rule_effect, :action)
         expect(response).to redirect_to(
-          new_workflow_subject_rule_subject_rule_effect_path action_type: action_type
+          new_workflow_subject_rule_subject_rule_effect_path(action_type: action_type)
         )
       end
 


### PR DESCRIPTION
ensure the redirect after failed create action doesn't 500, pass the action_type query param with the redirect to not fail