### PR TITLE
Subject Rule Effect Permissions

### DIFF
--- a/app/controllers/subject_rule_effects_controller.rb
+++ b/app/controllers/subject_rule_effects_controller.rb
@@ -2,7 +2,8 @@ class SubjectRuleEffectsController < ApplicationController
   responders :flash
 
   def index
-    authorize workflow, policy_class: SubjectRuleEffectPolicy
+    # using the WorkflowPolicy for 'authorize workflow' here, not the SubjectRuleEffectPolicy
+    authorize workflow
     effects = policy_scope(SubjectRuleEffect).where(subject_rule_id: params[:subject_rule_id])
     respond_with effects
   end
@@ -16,6 +17,7 @@ class SubjectRuleEffectsController < ApplicationController
   end
 
   def new
+    # using the WorkflowPolicy for 'authorize workflow' here, not the SubjectRuleEffectPolicy
     authorize workflow, :edit?
     @subject_rule_effect = SubjectRuleEffect.new(action: params[:action_type], subject_rule: subject_rule)
     respond_with workflow, subject_rule, @subject_rule_effect
@@ -32,9 +34,11 @@ class SubjectRuleEffectsController < ApplicationController
   end
 
   def create
-    authorize workflow, policy_class: SubjectRuleEffectPolicy
+    # using the WorkflowPolicy for 'authorize workflow' here, not the SubjectRuleEffectPolicy
+    authorize workflow, :edit?
 
     @subject_rule_effect = SubjectRuleEffect.new(effect_params)
+    authorize @subject_rule_effect
     @subject_rule_effect.save
 
     respond_to do |format|

--- a/app/controllers/subject_rule_effects_controller.rb
+++ b/app/controllers/subject_rule_effects_controller.rb
@@ -27,7 +27,7 @@ class SubjectRuleEffectsController < ApplicationController
     # TODO: the finders for SubjectRuleEffect in this controller
     # are ripe for a preload / eager_load as we'll use the
     # subject_rule.workflow relation in the policy scopes
-    @subject_rule_effect = SubjectRuleEffect.find(params[:id])
+    @subject_rule_effect = SubjectRuleEffect.eager_load(:subject_rule).find(params[:id])
     authorize @subject_rule_effect
 
     respond_with workflow, subject_rule, @subject_rule_effect
@@ -38,6 +38,7 @@ class SubjectRuleEffectsController < ApplicationController
     authorize workflow, :edit?
 
     @subject_rule_effect = SubjectRuleEffect.new(effect_params)
+    # using the SubjectRuleEffectPolicy here
     authorize @subject_rule_effect
     @subject_rule_effect.save
 
@@ -48,7 +49,7 @@ class SubjectRuleEffectsController < ApplicationController
   rescue Pundit::NotAuthorizedError
     respond_to do |format|
       format.html do
-        flash[:alert] = 'Error creating a subject effect rule. To create these, please email contact@zooniverse.org with the workflow ID, rule ID, and desired effect details to request these be changes be made by a Zooniverse admin.'
+        flash[:alert] = 'You do not have permission to create this effect. Please confirm that you have permissions to the associated workflow, subject set or collection.'
         redirect_to new_workflow_subject_rule_subject_rule_effect_path(
           action_type: effect_params[:action]
         )
@@ -70,7 +71,7 @@ class SubjectRuleEffectsController < ApplicationController
   rescue Pundit::NotAuthorizedError
     respond_to do |format|
       format.html do
-        flash[:alert] = 'Error updating a subject effect rule. To edit these, please email contact@zooniverse.org with the workflow ID, rule ID, and desired effect details to request these be changes be made by a Zooniverse admin.'
+        flash[:alert] = 'You do not have permission to make this change. Please confirm that you have permissions to the associated subject set or collection.'
         redirect_to edit_workflow_subject_rule_subject_rule_effect_path(@subject_rule_effect)
       end
       format.json { raise(Pundit::NotAuthorizedError) }

--- a/app/controllers/subject_rule_effects_controller.rb
+++ b/app/controllers/subject_rule_effects_controller.rb
@@ -2,19 +2,19 @@ class SubjectRuleEffectsController < ApplicationController
   responders :flash
 
   def index
-    authorize workflow, :validate_workflow, policy_class: SubjectRuleEffectPolicy
+    authorize workflow, policy_class: SubjectRuleEffectPolicy
     effects = policy_scope(SubjectRuleEffect).where(subject_rule_id: params[:subject_rule_id])
     respond_with effects
   end
 
   def show
-    authorize workflow, :validate_workflow, policy_class: SubjectRuleEffectPolicy
+    authorize workflow, policy_class: SubjectRuleEffectPolicy
     @subject_rule_effect = policy_scope(SubjectRuleEffect).find(params[:id])
     respond_with workflow, subject_rule, @subject_rule_effect
   end
 
   def new
-    authorize workflow, :validate_workflow, policy_class: SubjectRuleEffectPolicy
+    authorize workflow, policy_class: SubjectRuleEffectPolicy
     @subject_rule_effect = SubjectRuleEffect.new(action: params[:action_type], subject_rule: subject_rule)
     respond_with workflow, subject_rule, @subject_rule_effect
   end
@@ -27,8 +27,6 @@ class SubjectRuleEffectsController < ApplicationController
   end
 
   def create
-    authorize workflow, :validate_workflow, policy_class: SubjectRuleEffectPolicy
-
     @subject_rule_effect = SubjectRuleEffect.new(effect_params)
     authorize @subject_rule_effect
     @subject_rule_effect.save
@@ -40,7 +38,7 @@ class SubjectRuleEffectsController < ApplicationController
   rescue Pundit::NotAuthorizedError
     respond_to do |format|
       format.html do
-        flash[:alert] = 'You do not have permission to create this effect. Please confirm that you have permissions to the associated workflow, subject set or collection.'
+        flash[:alert] = 'You do not have permission to create a subject rule effect for this project.'
         redirect_to new_workflow_subject_rule_subject_rule_effect_path(
           action_type: effect_params[:action]
         )
@@ -62,7 +60,7 @@ class SubjectRuleEffectsController < ApplicationController
   rescue Pundit::NotAuthorizedError
     respond_to do |format|
       format.html do
-        flash[:alert] = 'You do not have permission to make this change. Please confirm that you have permissions to the associated subject set or collection.'
+        flash[:alert] = 'You do not have permission to update this subject rule effect for this project.'
         redirect_to edit_workflow_subject_rule_subject_rule_effect_path(@subject_rule_effect)
       end
       format.json { raise(Pundit::NotAuthorizedError) }

--- a/app/controllers/subject_rule_effects_controller.rb
+++ b/app/controllers/subject_rule_effects_controller.rb
@@ -2,43 +2,34 @@ class SubjectRuleEffectsController < ApplicationController
   responders :flash
 
   def index
-    # using the WorkflowPolicy for 'authorize workflow' here, not the SubjectRuleEffectPolicy
-    authorize workflow
+    authorize workflow, :validate_workflow, policy_class: SubjectRuleEffectPolicy
     effects = policy_scope(SubjectRuleEffect).where(subject_rule_id: params[:subject_rule_id])
     respond_with effects
   end
 
   def show
-    # TODO: Add this to the SubjectRuleEffect policy class
-    # and pass in the found subject_rule_effect
-    authorize workflow
+    authorize workflow, :validate_workflow, policy_class: SubjectRuleEffectPolicy
     @subject_rule_effect = policy_scope(SubjectRuleEffect).find(params[:id])
     respond_with workflow, subject_rule, @subject_rule_effect
   end
 
   def new
-    # using the WorkflowPolicy for 'authorize workflow' here, not the SubjectRuleEffectPolicy
-    authorize workflow, :edit?
+    authorize workflow, :validate_workflow, policy_class: SubjectRuleEffectPolicy
     @subject_rule_effect = SubjectRuleEffect.new(action: params[:action_type], subject_rule: subject_rule)
     respond_with workflow, subject_rule, @subject_rule_effect
   end
 
   def edit
-    # TODO: the finders for SubjectRuleEffect in this controller
-    # are ripe for a preload / eager_load as we'll use the
-    # subject_rule.workflow relation in the policy scopes
-    @subject_rule_effect = SubjectRuleEffect.eager_load(:subject_rule).find(params[:id])
+    @subject_rule_effect = SubjectRuleEffect.includes(subject_rule: [:workflow]).find(params[:id])
     authorize @subject_rule_effect
 
     respond_with workflow, subject_rule, @subject_rule_effect
   end
 
   def create
-    # using the WorkflowPolicy for 'authorize workflow' here, not the SubjectRuleEffectPolicy
-    authorize workflow, :edit?
+    authorize workflow, :validate_workflow, policy_class: SubjectRuleEffectPolicy
 
     @subject_rule_effect = SubjectRuleEffect.new(effect_params)
-    # using the SubjectRuleEffectPolicy here
     authorize @subject_rule_effect
     @subject_rule_effect.save
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -34,7 +34,7 @@ class ApplicationPolicy
     false
   end
 
-  def has_valid_credentials?
+  def valid_credentials?
     credential.logged_in? && !credential.expired?
   end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -34,6 +34,10 @@ class ApplicationPolicy
     false
   end
 
+  def has_valid_credentials?
+    credential.logged_in? && !credential.expired?
+  end
+
   def scope
     Pundit.policy_scope!(credential, record.class)
   end

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -7,15 +7,6 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     end
   end
 
-  def index?
-    # record is a workflow from the controller
-    if credential.admin?
-      true
-    else
-      credential.project_ids.include?(record.project_id)
-    end
-  end
-
   def create?
     update?
   end
@@ -54,6 +45,14 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     else
       subject_rule_project_id = record.subject_rule.workflow.project_id
       credential.project_ids.include?(subject_rule_project_id)
+    end
+  end
+
+  def validate_workflow
+    if credential.admin?
+      true
+    else
+      credential.project_ids.include?(record.project_id)
     end
   end
 end

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -32,6 +32,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
 
   def update?
     return true if credential.admin?
+    return false if !has_valid_credentials?
 
     if record.config.key?('subject_set_id')
       subject_set = Effects.panoptes.subject_set(record.config['subject_set_id'])

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -36,7 +36,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     if credential.admin?
       true
     else
-      valid_associated_project?(record)
+      user_has_project_access?(record)
     end
   end
 
@@ -45,13 +45,14 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     return false unless valid_credentials?
     return true if credential.admin?
 
-    return false unless valid_associated_project?(record)
+    return false unless user_has_project_access?(record)
 
     if record.effect.is_a?(Effects::AddSubjectToSet)
       valid_subject_set?(record)
     elsif record.effect.is_a?(Effects::AddSubjectToCollection)
       valid_collection?(record)
     else
+      # at this point we have checked that user has project access, so return true
       true
     end
   end
@@ -68,7 +69,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
   end
 
   # pass in SubjectRuleEffect record
-  def valid_associated_project?(record)
+  def user_has_project_access?(record)
     subject_rule_project_id = record.subject_rule.workflow.project_id
     credential.project_ids.include?(subject_rule_project_id)
   end

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -21,7 +21,6 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
   end
 
   def edit?
-    # record is a subject_rule_effect from the controller
     if credential.admin?
       true
     else
@@ -40,7 +39,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
 
       credential.project_ids.include?(subject_set['links']['project'])
     elsif record.config.key?('collection_id')
-      collection = Effects.panoptes.collection(record.config[:subject_set_id])
+      collection = Effects.panoptes.collection(record.config['collection_id'])
       raise ActiveRecord::RecordNotFound if collection.nil?
 
       credential.project_ids.include?(collection['links']['projects'].first)
@@ -50,7 +49,6 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
   end
 
   def destroy?
-    # record is a subject_rule_effect from the controller
     if credential.admin?
       true
     else

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -46,7 +46,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     return true if credential.admin?
 
     return false unless valid_associated_project?(record)
-    return valid_subject_set_or_collection?(record)
+    valid_subject_set_or_collection?(record)
   end
 
   # record passed in from controller is a subject_rule_effect
@@ -68,12 +68,12 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
 
   # pass in SubjectRuleEffect record
   def valid_subject_set_or_collection?(record)
-    if record.config.key?('subject_set_id')
+    if record.effect.is_a?(Effects::AddSubjectToSet)
       subject_set = Effects.panoptes.subject_set(record.config['subject_set_id'])
       raise ActiveRecord::RecordNotFound if subject_set.nil?
 
       credential.project_ids.include?(subject_set['links']['project'])
-    elsif record.config.key?('collection_id')
+    elsif record.effect.is_a?(Effects::AddSubjectToCollection)
       collection = Effects.panoptes.collection(record.config['collection_id'])
       raise ActiveRecord::RecordNotFound if collection.nil?
 

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -15,8 +15,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     if credential.admin?
       true
     else
-      subject_rule_project_id = record.subject_rule.workflow.project_id
-      credential.project_ids.include?(subject_rule_project_id)
+      valid_subject_rule_project?(record)
     end
   end
 
@@ -24,6 +23,34 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     return true if credential.admin?
     return false unless valid_credentials?
 
+    return false unless valid_subject_rule_project?(record)
+    return valid_subject_set_or_collection?(record)
+  end
+
+  def destroy?
+    if credential.admin?
+      true
+    else
+      valid_subject_rule_project?(record)
+    end
+  end
+
+  def validate_workflow
+    if credential.admin?
+      true
+    else
+      credential.project_ids.include?(record.project_id)
+    end
+  end
+
+  # pass in SubjectRuleEffect record
+  def valid_subject_rule_project?(record)
+    subject_rule_project_id = record.subject_rule.workflow.project_id
+    credential.project_ids.include?(subject_rule_project_id)
+  end
+
+  # pass in SubjectRuleEffect record
+  def valid_subject_set_or_collection?(record)
     if record.config.key?('subject_set_id')
       subject_set = Effects.panoptes.subject_set(record.config['subject_set_id'])
       raise ActiveRecord::RecordNotFound if subject_set.nil?
@@ -36,23 +63,6 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
       credential.project_ids.include?(collection['links']['projects'].first)
     else
       true
-    end
-  end
-
-  def destroy?
-    if credential.admin?
-      true
-    else
-      subject_rule_project_id = record.subject_rule.workflow.project_id
-      credential.project_ids.include?(subject_rule_project_id)
-    end
-  end
-
-  def validate_workflow
-    if credential.admin?
-      true
-    else
-      credential.project_ids.include?(record.project_id)
     end
   end
 end

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -7,44 +7,61 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     end
   end
 
+  # record passed in from controller is a workflow
+  def index?
+    if credential.admin?
+      true
+    else
+      valid_workflow?(record, credential)
+    end
+  end
+
+  # record passed in from controller is a workflow
+  def show?
+    index?
+  end
+
+  # record passed in from controller is a workflow
+  def new?
+    index?
+  end
+
+  # record passed in from controller is a subject_rule_effect
   def create?
     update?
   end
 
+  # record passed in from controller is a subject_rule_effect
   def edit?
     if credential.admin?
       true
     else
-      valid_subject_rule_project?(record)
+      valid_associated_project?(record)
     end
   end
 
+  # record passed in from controller is a subject_rule_effect
   def update?
-    return true if credential.admin?
     return false unless valid_credentials?
+    return true if credential.admin?
 
-    return false unless valid_subject_rule_project?(record)
+    return false unless valid_associated_project?(record)
     return valid_subject_set_or_collection?(record)
   end
 
+  # record passed in from controller is a subject_rule_effect
   def destroy?
-    if credential.admin?
-      true
-    else
-      valid_subject_rule_project?(record)
-    end
+    edit?
   end
 
-  def validate_workflow
-    if credential.admin?
-      true
-    else
-      credential.project_ids.include?(record.project_id)
-    end
+  private
+
+  def valid_workflow?(workflow, credential)
+    credential.project_ids.include?(workflow.project_id)
   end
 
   # pass in SubjectRuleEffect record
-  def valid_subject_rule_project?(record)
+  def valid_associated_project?(record)
     subject_rule_project_id = record.subject_rule.workflow.project_id
     credential.project_ids.include?(subject_rule_project_id)
   end

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -32,7 +32,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
 
   def update?
     return true if credential.admin?
-    return false if !has_valid_credentials?
+    return false unless valid_credentials?
 
     if record.config.key?('subject_set_id')
       subject_set = Effects.panoptes.subject_set(record.config['subject_set_id'])

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
         end
 
         it 'changes an effect' do
-          effect = create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
           put :update, params: update_params, format: :json
 
           expect(response.status).to eq(204)
@@ -115,7 +114,6 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
         end
 
         it 'redirects to the subject rule in html mode' do
-          effect = create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
           put :update, params: update_params, format: :html
           expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
         end

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
           it 'flashes an error message' do
             post :create, params: create_params, format: :html
-            msg = 'Error creating a subject effect rule. To create these, please email contact@zooniverse.org with the workflow ID, rule ID, and desired effect details to request these be changes be made by a Zooniverse admin.'
+            msg = 'You do not have permission to create this effect. Please confirm that you have permissions to the associated workflow, subject set or collection.'
             expect(flash[:alert]).to eq(msg)
           end
         end
@@ -151,7 +151,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
           it 'flashes an error message' do
             put :update, params: subject_set_update_params, format: :html
-            msg = 'Error updating a subject effect rule. To edit these, please email contact@zooniverse.org with the workflow ID, rule ID, and desired effect details to request these be changes be made by a Zooniverse admin.'
+            msg = 'You do not have permission to make this change. Please confirm that you have permissions to the associated subject set or collection.'
             expect(flash[:alert]).to eq(msg)
           end
         end
@@ -255,6 +255,15 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
       it 'redirects to the subject rule in html mode' do
         post :create, params: {subject_rule_effect: {action: 'retire_subject', config: {}}, workflow_id: workflow.id, subject_rule_id: rule.id }, format: :html
         expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow,rule))
+      end
+    end
+
+    describe '#edit' do
+      it 'returns an effect for editing' do
+        effect = create :subject_rule_effect, subject_rule: rule
+        get :edit, params: { id: effect.id, subject_rule_id: rule.id, workflow_id: workflow.id }, format: :json
+        result = JSON.parse(response.body)
+        expect(result["id"]).to eq(effect.id)
       end
     end
 

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
         effect = create :subject_rule_effect, subject_rule: rule
         get :edit, params: { id: effect.id, subject_rule_id: rule.id, workflow_id: workflow.id }, format: :json
         result = JSON.parse(response.body)
-        expect(result["id"]).to eq(effect.id)
+        expect(result['id']).to eq(effect.id)
       end
     end
 

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
           put :update, params: update_params, format: :json
 
           expect(response.status).to eq(204)
-          effect = SubjectRuleEffect.find(effect.id)
-          expect(effect.config['foo']).to eq('baz')
+          effect_record = SubjectRuleEffect.find(effect.id)
+          expect(effect_record.config['foo']).to eq('baz')
         end
 
         it 'redirects to the subject rule in html mode' do

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
         end
 
         it 'makes a new effect' do
-          post :create, params: { subject_rule_effect: { action: 'retire_subject', config: {} }, workflow_id: workflow.id, subject_rule_id: rule.id }, format: :json
+          post :create, params: create_params, format: :json
 
           expect(response.status).to eq(201)
           result = JSON.parse(response.body)
@@ -30,7 +30,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
         end
 
         it 'redirects to the subject rule in html mode' do
-          post :create, params: { subject_rule_effect: { action: 'retire_subject', config: {} }, workflow_id: workflow.id, subject_rule_id: rule.id }, format: :html
+          post :create, params: create_params, format: :html
           expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
         end
       end
@@ -107,7 +107,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
         it 'changes an effect' do
           effect = create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
-          put :update, params: { subject_rule_effect: { config: { foo: 'baz' } }, id: effect.id, subject_rule_id: rule.id, workflow_id: workflow.id }, format: :json
+          put :update, params: update_params, format: :json
 
           expect(response.status).to eq(204)
           effect = SubjectRuleEffect.find(effect.id)
@@ -116,7 +116,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
         it 'redirects to the subject rule in html mode' do
           effect = create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
-          put :update, params: { subject_rule_effect: { config: { foo: 'baz' } }, id: effect.id, subject_rule_id: rule.id, workflow_id: workflow.id }, format: :html
+          put :update, params: update_params, format: :html
           expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
         end
       end
@@ -216,8 +216,8 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
         rules = [create(:subject_rule_effect, subject_rule: rule),
                  create(:subject_rule_effect, subject_rule: rule)]
 
-                 get :index, params: {workflow_id: workflow.id, subject_rule_id: rule.id}, format: :json
-                 expect(json_response.map { |i| i["id"] }).to match_array(rules.map(&:id))
+        get :index, params: {workflow_id: workflow.id, subject_rule_id: rule.id}, format: :json
+        expect(json_response.map { |i| i["id"] }).to match_array(rules.map(&:id))
       end
 
       it 'returns empty list when there are no subject rules' do

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
           it 'flashes an error message' do
             post :create, params: create_params, format: :html
-            msg = 'You do not have permission to create this effect. Please confirm that you have permissions to the associated workflow, subject set or collection.'
+            msg = 'You do not have permission to create a subject rule effect for this project.'
             expect(flash[:alert]).to eq(msg)
           end
         end
@@ -151,7 +151,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
           it 'flashes an error message' do
             put :update, params: subject_set_update_params, format: :html
-            msg = 'You do not have permission to make this change. Please confirm that you have permissions to the associated subject set or collection.'
+            msg = 'You do not have permission to update this subject rule effect for this project.'
             expect(flash[:alert]).to eq(msg)
           end
         end

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -7,98 +7,175 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
     fake_session admin: false, project_ids: [workflow.project_id], logged_in: true
   end
 
-  context 'as a permissioned user' do
+  context 'as a user with permissions to workflow' do
     before { credentials }
 
     describe '#create' do
-      let(:create_params) do
-        {
-          subject_rule_effect: { action: 'retire_subject', config: {} },
-          workflow_id: workflow.id,
-          subject_rule_id: rule.id
-        }
+      context 'when effect does not add subjects to set or collection' do
+        let(:create_params) do
+          {
+            subject_rule_effect: { action: 'retire_subject', config: {} },
+            workflow_id: workflow.id,
+            subject_rule_id: rule.id
+          }
+        end
+
+        it 'makes a new effect' do
+          post :create, params: { subject_rule_effect: { action: 'retire_subject', config: {} }, workflow_id: workflow.id, subject_rule_id: rule.id }, format: :json
+
+          expect(response.status).to eq(201)
+          result = JSON.parse(response.body)
+          expect(result['id']).not_to be(nil)
+          expect(result['subject_rule_id']).to eq(rule.id)
+        end
+
+        it 'redirects to the subject rule in html mode' do
+          post :create, params: { subject_rule_effect: { action: 'retire_subject', config: {} }, workflow_id: workflow.id, subject_rule_id: rule.id }, format: :html
+          expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
+        end
       end
 
-      it 'does not create a new effect' do
-        post :create, params: create_params, format: :json
-        expect(response.status).to eq(401)
-      end
+      context 'when effect adds subjects to set' do
+        let(:create_params) do
+          {
+            subject_rule_effect: { action: 'add_subject_to_set', config: { 'subject_set_id': 777 } },
+            workflow_id: workflow.id,
+            subject_rule_id: rule.id
+          }
+        end
 
-      it 'redirects to the new path in html mode' do
-        post :create, params: create_params, format: :html
-        action_type = create_params.dig(:subject_rule_effect, :action)
-        expect(response).to redirect_to(
-          new_workflow_subject_rule_subject_rule_effect_path(action_type: action_type)
-        )
-      end
+        context 'when user does not have permission to that set' do
+          before do
+            allow_any_instance_of(SubjectRuleEffectPolicy).to receive(:create?).and_return(false)
+          end
 
-      it 'flashes an error message' do
-        post :create, params: create_params, format: :html
-        msg = 'Error creating a subject effect rule. To create these, please email contact@zooniverse.org with the workflow ID, rule ID, and desired effect details to request these be changes be made by a Zooniverse admin.'
-        expect(flash[:alert]).to eq(msg)
-      end
+          it 'does not create a new effect' do
+            post :create, params: create_params, format: :json
+            expect(response.status).to eq(401)
+          end
 
-      # TODO: fix these pending specs when revisiting admin lockdown
-      xit 'makes a new effect' do
-        post :create, params: {subject_rule_effect: {action: 'retire_subject', config: {}}, workflow_id: workflow.id, subject_rule_id: rule.id }, format: :json
+          it 'redirects to the new path in html mode' do
+            post :create, params: create_params, format: :html
+            action_type = create_params.dig(:subject_rule_effect, :action)
+            expect(response).to redirect_to(
+              new_workflow_subject_rule_subject_rule_effect_path(action_type: action_type)
+            )
+          end
 
-        expect(response.status).to eq(201)
-        result = JSON.parse(response.body)
-        expect(result["id"]).not_to be(nil)
-        expect(result["subject_rule_id"]).to eq(rule.id)
-      end
+          it 'flashes an error message' do
+            post :create, params: create_params, format: :html
+            msg = 'Error creating a subject effect rule. To create these, please email contact@zooniverse.org with the workflow ID, rule ID, and desired effect details to request these be changes be made by a Zooniverse admin.'
+            expect(flash[:alert]).to eq(msg)
+          end
+        end
 
-      # TODO: fix these pending specs when revisiting admin lockdown
-      xit 'redirects to the subject rule in html mode' do
-        post :create, params: {subject_rule_effect: {action: 'retire_subject', config: {}}, workflow_id: workflow.id, subject_rule_id: rule.id }, format: :html
-        expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow,rule))
+        context 'when user has permission to that set' do
+          before do
+            allow_any_instance_of(SubjectRuleEffectPolicy).to receive(:create?).and_return(true)
+          end
+
+          it 'makes a new effect' do
+            post :create, params: create_params, format: :json
+
+            expect(response.status).to eq(201)
+            result = JSON.parse(response.body)
+            expect(result['id']).not_to be(nil)
+            expect(result['subject_rule_id']).to eq(rule.id)
+          end
+
+          it 'redirects to the subject rule in html mode' do
+            post :create, params: create_params, format: :html
+            expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
+          end
+        end
       end
     end
 
     describe '#update' do
-      let(:effect) do
-        create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
-      end
-      let(:update_params) do
-        {
-          subject_rule_effect: { config: { foo: 'baz' } },
-          id: effect.id,
-          subject_rule_id: rule.id,
-          workflow_id: workflow.id
-        }
-      end
+      context 'when effect does not add subjects to set or collection' do
+        let(:effect) do
+          create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
+        end
+        let(:update_params) do
+          {
+            subject_rule_effect: { config: { foo: 'baz' } },
+            id: effect.id,
+            subject_rule_id: rule.id,
+            workflow_id: workflow.id
+          }
+        end
 
-      it 'does not update a subject rule effect' do
-        put :update, params: update_params, format: :json
-        expect(response.status).to eq(401)
-      end
+        it 'changes an effect' do
+          effect = create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
+          put :update, params: { subject_rule_effect: { config: { foo: 'baz' } }, id: effect.id, subject_rule_id: rule.id, workflow_id: workflow.id }, format: :json
 
-      it 'redirects to the edit path in html mode' do
-        put :update, params: update_params, format: :html
-        expect(response).to redirect_to(
-          edit_workflow_subject_rule_subject_rule_effect_path(effect)
-        )
-      end
+          expect(response.status).to eq(204)
+          effect = SubjectRuleEffect.find(effect.id)
+          expect(effect.config['foo']).to eq('baz')
+        end
 
-      it 'flashes an error message' do
-        put :update, params: update_params, format: :html
-        msg = 'Error updating a subject effect rule. To edit these, please email contact@zooniverse.org with the workflow ID, rule ID, and desired effect details to request these be changes be made by a Zooniverse admin.'
-        expect(flash[:alert]).to eq(msg)
-      end
-
-      xit 'changes an effect' do
-        effect = create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
-        put :update, params: { subject_rule_effect: { config: { foo: 'baz' }}, id: effect.id, subject_rule_id: rule.id, workflow_id: workflow.id }, format: :json
-
-        expect(response.status).to eq(204)
-        effect = SubjectRuleEffect.find(effect.id)
-        expect(effect.config['foo']).to eq('baz')
+        it 'redirects to the subject rule in html mode' do
+          effect = create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
+          put :update, params: { subject_rule_effect: { config: { foo: 'baz' } }, id: effect.id, subject_rule_id: rule.id, workflow_id: workflow.id }, format: :html
+          expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
+        end
       end
 
-      xit 'redirects to the subject rule in html mode' do
-        effect = create :subject_rule_effect, action: 'retire_subject', config: { foo: 'bar' }, subject_rule: rule
-        put :update, params: { subject_rule_effect: { config: { foo: 'baz' }}, id: effect.id, subject_rule_id: rule.id, workflow_id: workflow.id }, format: :html
-        expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow,rule))
+      context 'when effect adds subjects to subject set' do
+        let(:subject_set_effect) do
+          create :subject_rule_effect, action: 'add_subject_to_set', config: { 'subject_set_id': 777 }, subject_rule: rule
+        end
+        let(:subject_set_update_params) do
+          {
+            subject_rule_effect: { action: 'add_subject_to_set', config: { 'subject_set_id': 333 } },
+            id: subject_set_effect.id,
+            subject_rule_id: rule.id,
+            workflow_id: workflow.id
+          }
+        end
+
+        context 'when user does not have permission to that set' do
+          before do
+            allow_any_instance_of(SubjectRuleEffectPolicy).to receive(:update?).and_return(false)
+          end
+
+          it 'does not update a subject rule effect' do
+            put :update, params: subject_set_update_params, format: :json
+            expect(response.status).to eq(401)
+          end
+
+          it 'redirects to the edit path in html mode' do
+            put :update, params: subject_set_update_params, format: :html
+            expect(response).to redirect_to(
+              edit_workflow_subject_rule_subject_rule_effect_path(subject_set_effect)
+            )
+          end
+
+          it 'flashes an error message' do
+            put :update, params: subject_set_update_params, format: :html
+            msg = 'Error updating a subject effect rule. To edit these, please email contact@zooniverse.org with the workflow ID, rule ID, and desired effect details to request these be changes be made by a Zooniverse admin.'
+            expect(flash[:alert]).to eq(msg)
+          end
+        end
+
+        context 'when user has permission to that set' do
+          before do
+            allow_any_instance_of(SubjectRuleEffectPolicy).to receive(:update?).and_return(true)
+          end
+
+          it 'changes an effect' do
+            put :update, params: subject_set_update_params, format: :json
+
+            expect(response.status).to eq(204)
+            updated_effect = SubjectRuleEffect.find(subject_set_effect.id)
+            expect(updated_effect.config['subject_set_id']).to eq('333')
+          end
+
+          it 'redirects to the subject rule in html mode' do
+            put :update, params: subject_set_update_params, format: :html
+            expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
+          end
+        end
       end
     end
 
@@ -137,10 +214,10 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
     describe '#index' do
       it 'lists effects for a rule' do
         rules = [create(:subject_rule_effect, subject_rule: rule),
-                    create(:subject_rule_effect, subject_rule: rule)]
+                 create(:subject_rule_effect, subject_rule: rule)]
 
-        get :index, params: {workflow_id: workflow.id, subject_rule_id: rule.id}, format: :json
-        expect(json_response.map { |i| i["id"] }).to match_array(rules.map(&:id))
+                 get :index, params: {workflow_id: workflow.id, subject_rule_id: rule.id}, format: :json
+                 expect(json_response.map { |i| i["id"] }).to match_array(rules.map(&:id))
       end
 
       it 'returns empty list when there are no subject rules' do

--- a/spec/policies/subject_rule_effect_policy_spec.rb
+++ b/spec/policies/subject_rule_effect_policy_spec.rb
@@ -102,7 +102,7 @@ describe SubjectRuleEffectPolicy do
         allow(Effects).to receive(:panoptes).and_return(panoptes)
       end
 
-      it 'grants access when effect\'s subject set belongs to project that user is owner of' do
+      it "grants access when effect's subject set belongs to project that user is owner of" do
         expect(subject).to permit(set_and_collection_owner_credential, add_to_set_effect)
       end
 
@@ -110,7 +110,7 @@ describe SubjectRuleEffectPolicy do
         expect(subject).not_to permit(workflow_owner_credential, add_to_set_effect)
       end
 
-      it "grants access when effect's subject set belongs to project that user is owner of" do
+      it "grants access when effect's collection belongs to project that user is owner of" do
         # subject set and collection share project id, subj set owner is also the collection owner
         expect(subject).to permit(set_and_collection_owner_credential, add_to_collection_effect)
       end

--- a/spec/policies/subject_rule_effect_policy_spec.rb
+++ b/spec/policies/subject_rule_effect_policy_spec.rb
@@ -84,7 +84,7 @@ describe SubjectRuleEffectPolicy do
     end
   end
 
-  permissions :create? do
+  permissions :create?, :update? do
     it 'denies access when not logged in' do
       expect(subject).not_to permit(not_logged_in_credential, effect)
     end
@@ -118,20 +118,6 @@ describe SubjectRuleEffectPolicy do
       it "denies access when effect's collection belongs to project that user does not have access to" do
         expect(subject).not_to permit(workflow_owner_credential, add_to_collection_effect)
       end
-    end
-  end
-
-  permissions :create?, :update? do
-    it 'denies access when not logged in' do
-      expect(subject).not_to permit(not_logged_in_credential, effect)
-    end
-
-    it 'denies access when token has expired' do
-      expect(subject).not_to permit(expired_credential, effect)
-    end
-
-    it 'grants access to an admin' do
-      expect(subject).to permit(admin_credential, effect)
     end
   end
 

--- a/spec/policies/subject_rule_effect_policy_spec.rb
+++ b/spec/policies/subject_rule_effect_policy_spec.rb
@@ -101,7 +101,7 @@ describe SubjectRuleEffectPolicy do
         allow(Effects).to receive(:panoptes).and_return(panoptes)
       end
 
-      it 'grants access when effect\'s subject set belongs to project that user is owner of',  :focus do
+      it 'grants access when effect\'s subject set belongs to project that user is owner of' do
         expect(subject).to permit(set_and_collection_owner_credential, add_to_set_effect)
       end
 
@@ -109,7 +109,7 @@ describe SubjectRuleEffectPolicy do
         expect(subject).not_to permit(workflow_owner_credential, add_to_set_effect)
       end
 
-      it 'grants access when effect\'s subject set belongs to project that user is owner of', :focus do
+      it 'grants access when effect\'s subject set belongs to project that user is owner of' do
         # subject set and collection share project id, subj set owner is also the collection owner
         expect(subject).to permit(set_and_collection_owner_credential, add_to_collection_effect)
       end
@@ -127,12 +127,6 @@ describe SubjectRuleEffectPolicy do
 
     it 'denies access when token has expired' do
       expect(subject).not_to permit(expired_credential, effect)
-    end
-
-    # temp fix for to stop non-admin users modify the rule effects
-    it 'denies access to all user that are collaborators on the project' do
-      credential = fake_credential(project_ids: [workflow.project_id])
-      expect(subject).not_to permit(credential, effect)
     end
 
     it 'grants access to an admin' do

--- a/spec/policies/subject_rule_effect_policy_spec.rb
+++ b/spec/policies/subject_rule_effect_policy_spec.rb
@@ -106,16 +106,16 @@ describe SubjectRuleEffectPolicy do
         expect(subject).to permit(set_and_collection_owner_credential, add_to_set_effect)
       end
 
-      it 'denies access when effect\'s subject set belongs to project that user does not have access to' do
+      it "denies access when effect's subject set belongs to project that user does not have access to" do
         expect(subject).not_to permit(workflow_owner_credential, add_to_set_effect)
       end
 
-      it 'grants access when effect\'s subject set belongs to project that user is owner of' do
+      it "grants access when effect's subject set belongs to project that user is owner of" do
         # subject set and collection share project id, subj set owner is also the collection owner
         expect(subject).to permit(set_and_collection_owner_credential, add_to_collection_effect)
       end
 
-      it 'denies access when effect\'s collection belongs to project that user does not have access to' do
+      it "denies access when effect's collection belongs to project that user does not have access to" do
         expect(subject).not_to permit(workflow_owner_credential, add_to_collection_effect)
       end
     end
@@ -151,7 +151,7 @@ describe SubjectRuleEffectPolicy do
     end
   end
 
-  permissions :validate_workflow do
+  permissions :index?, :show?, :new? do
     it 'denies access when not logged in' do
       expect(subject).not_to permit(not_logged_in_credential, workflow)
     end

--- a/spec/policies/subject_rule_effect_policy_spec.rb
+++ b/spec/policies/subject_rule_effect_policy_spec.rb
@@ -5,18 +5,18 @@ require 'rails_helper'
 describe SubjectRuleEffectPolicy do
   subject { described_class }
   let(:set_and_collection_project_id) { 76 }
-  let(:subject_set) {
+  let(:subject_set) do
     {
       'id' => 777,
       'links' => { 'project' => set_and_collection_project_id }
     }
-  }
-  let(:collection) {
+  end
+  let(:collection) do
     {
       'id' => 333,
       'links' => { 'projects' => [set_and_collection_project_id] }
     }
-   }
+  end
   let(:workflow) { create :workflow }
   let(:rule) { create :subject_rule, workflow: workflow }
 
@@ -24,7 +24,7 @@ describe SubjectRuleEffectPolicy do
   let(:expired_credential) { fake_credential expired: true }
   let(:admin_credential) { fake_credential admin: true }
   let(:workflow_owner_credential) { fake_credential(project_ids: [workflow.project_id]) }
-  let(:set_and_collection_owner_credential) { fake_credential(project_ids: [set_and_collection_project_id])}
+  let(:set_and_collection_owner_credential) { fake_credential(project_ids: [set_and_collection_project_id]) }
 
   let(:effect) do
     create(
@@ -54,7 +54,7 @@ describe SubjectRuleEffectPolicy do
   let(:panoptes) do
     double('PanoptesAdapter',
            subject_set: subject_set,
-           collection: collection )
+           collection: collection)
   end
 
   before { effect }

--- a/spec/policies/subject_rule_effect_policy_spec.rb
+++ b/spec/policies/subject_rule_effect_policy_spec.rb
@@ -25,7 +25,7 @@ describe SubjectRuleEffectPolicy do
   let(:expired_credential) { fake_credential expired: true }
   let(:admin_credential) { fake_credential admin: true }
   let(:workflow_owner_credential) { fake_credential(project_ids: [workflow.project_id]) }
-  let(:set_and_collection_owner_credential) { fake_credential(project_ids: [set_and_collection_project_id]) }
+  let(:set_and_collection_owner_credential) { fake_credential(project_ids: [set_and_collection_project_id, workflow.project_id]) }
 
   let(:effect) do
     create(


### PR DESCRIPTION
As per conversation with zach and cliff in the #caesar channel, we have decided that we do not want to change permissions for actions where effect is being shown, but not edited. This means that we only need to update policy methods for create and update in the `SubjectRuleEffectPolicy` class.

---

Note: when testing locally,  the test "Kinesis stream processes the stream events" in ./spec/requests/kinesis_spec.rb randomly fails, though not consistently. It's on my slate to look into this, but if anyone already knows why this is happening please let me know.