### PR TITLE
Update panoptes client version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'sidekiq-logstash'
 gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-ui'
-gem 'panoptes-client', '~> 1.0'
+gem 'panoptes-client', '~> 1.1'
 gem 'lograge'
 gem 'logstash-event'
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       omniauth (~> 1.2)
     omniauth-zooniverse (0.0.4)
       omniauth-oauth2 (= 1.3.1)
-    panoptes-client (1.0.0)
+    panoptes-client (1.1.0)
       deprecate
       faraday
       faraday-panoptes (~> 0.3.0)
@@ -387,7 +387,7 @@ DEPENDENCIES
   newrelic_rpm
   omniauth
   omniauth-zooniverse
-  panoptes-client (~> 1.0)
+  panoptes-client (~> 1.1)
   pg (~> 1.1)
   pry-byebug
   pry-rails


### PR DESCRIPTION
Gemfile must be updated to specify new version of the panoptes-client ruby gem. New version of gem includes method for retrieving a single collection by id:
https://github.com/zooniverse/panoptes-client.rb/commit/100de31d0dbfc52c7cc7a51b40c2f446fbf4715d

This method is used to verify that the user has permission to add subjects to the collection when creating a new Subject Rule Effect of type "Add to Collection". Currently, the code is erroring because it is still using the old panoptes-client gem which does not have the `collection` method:
https://sentry.io/organizations/zooniverse-27/issues/1659310299/?project=1490239&query=is%3Aunresolved