### PR TITLE
Subject Rule Effect validation: convert collection/set project id to int

### DIFF
--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -79,7 +79,8 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     subject_set = Effects.panoptes.subject_set(record.config['subject_set_id'])
     raise ActiveRecord::RecordNotFound if subject_set.nil?
 
-    credential.project_ids.include?(subject_set['links']['project'].to_i)
+    subject_set_project_id = subject_set['links']['project'].to_i
+    credential.project_ids.include?(subject_set_project_id)
   end
 
   # pass in SubjectRuleEffect record
@@ -87,6 +88,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     collection = Effects.panoptes.collection(record.config['collection_id'])
     raise ActiveRecord::RecordNotFound if collection.nil?
 
-    credential.project_ids.include?(collection['links']['projects'].first.to_i)
+    collection_project_id = collection['links']['projects'].first.to_i
+    credential.project_ids.include?(collection_project_id)
   end
 end

--- a/app/policies/subject_rule_effect_policy.rb
+++ b/app/policies/subject_rule_effect_policy.rb
@@ -79,7 +79,7 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     subject_set = Effects.panoptes.subject_set(record.config['subject_set_id'])
     raise ActiveRecord::RecordNotFound if subject_set.nil?
 
-    credential.project_ids.include?(subject_set['links']['project'])
+    credential.project_ids.include?(subject_set['links']['project'].to_i)
   end
 
   # pass in SubjectRuleEffect record
@@ -87,6 +87,6 @@ class SubjectRuleEffectPolicy < ApplicationPolicy
     collection = Effects.panoptes.collection(record.config['collection_id'])
     raise ActiveRecord::RecordNotFound if collection.nil?
 
-    credential.project_ids.include?(collection['links']['projects'].first)
+    credential.project_ids.include?(collection['links']['projects'].first.to_i)
   end
 end

--- a/spec/policies/subject_rule_effect_policy_spec.rb
+++ b/spec/policies/subject_rule_effect_policy_spec.rb
@@ -8,13 +8,13 @@ describe SubjectRuleEffectPolicy do
   let(:subject_set) do
     {
       'id' => 777,
-      'links' => { 'project' => set_and_collection_project_id }
+      'links' => { 'project' => set_and_collection_project_id.to_s }
     }
   end
   let(:collection) do
     {
       'id' => 333,
-      'links' => { 'projects' => [set_and_collection_project_id] }
+      'links' => { 'projects' => [set_and_collection_project_id.to_s] }
     }
   end
   let(:workflow) { create :workflow }


### PR DESCRIPTION
Validation was failing in staging because we were trying to compare a string to an int. The `project_id` stored on the subject set and collection objects was stored as a string, while the caesar credentials object stored project_ids as integers.

Fix this by converting the `project_id` found on the subject set or collection to an integer.