### PR TITLE
update sidekiq configuration

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:verbose: <%= ENV.fetch('SIDEKIQ_VERBOSE', false) %>
+:verbose: <%= !!ENV.fetch('SIDEKIQ_VERBOSE', false) %>
 :concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10).to_i %>
 :timeout:  <%= ENV.fetch('SIDEKIQ_TIMEOUT', 25).to_i %>
 :queues:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,6 @@
-:verbose: false
-#:logfile: ./log/sidekiq.log
-:pidfile: ./tmp/pids/sidekiq.pid
-:concurrency: <%= ENV["SIDEKIQ_CONCURRENCY"] || 10 %>
-:timeout: 30
+:verbose: <%= ENV.fetch('SIDEKIQ_VERBOSE', false) %>
+:concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10).to_i %>
+:timeout:  <%= ENV.fetch('SIDEKIQ_TIMEOUT', 25).to_i %>
 :queues:
   - [internal, 4]
   - [default, 3]

--- a/docker/stop-sidekiq.sh
+++ b/docker/stop-sidekiq.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-for pidfile in tmp/pids/sidekiq_*.pid
-do
-    sidekiqctl quiet $pidfile
-done
-
-sleep 30

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -267,10 +267,6 @@ spec:
             limits:
               memory: "750Mi"
               cpu: "500m"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/app/docker/stop-sidekiq.sh"]
           args: ["/app/docker/start-sidekiq.sh"]
           env:
             - name: RAILS_ENV
@@ -408,10 +404,6 @@ spec:
             limits:
               memory: "2500Mi"
               cpu: "1000m"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/app/docker/stop-sidekiq.sh"]
           args: ["/app/docker/start-sidekiq.sh"]
           env:
             - name: RAILS_ENV

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -249,10 +249,6 @@ spec:
             limits:
               memory: "200Mi"
               cpu: "500m"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/app/docker/stop-sidekiq.sh"]
           args: ["/app/docker/start-sidekiq.sh"]
           env:
             - name: RAILS_ENV


### PR DESCRIPTION
use env vars to configure sidekiq

add better k8s default for timeout (25s) to link with k8s default shutdown grace period (30s). 

remove the sidekiq container lifecycle shutdown hooks and the associated sidekiq shutdown script