### PR TITLE
Revert "use sidekiq config yml"

### DIFF
--- a/docker/start-sidekiq.sh
+++ b/docker/start-sidekiq.sh
@@ -6,4 +6,6 @@ set -ex
 mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid
 
-exec bundle exec sidekiq -C config/sidekiq.yml
+# allow the sidekiq args to come via the env variables
+CLI_ARGS=${SIDEKIQ_ARGS:-''}
+exec bundle exec sidekiq $CLI_ARGS


### PR DESCRIPTION
Reverts zooniverse/caesar#1162

this is used to ensure tess queues are processed https://github.com/zooniverse/caesar/blob/52628f3926dc2a3c28054ddf2927b8f8f45b43ac/kubernetes/deployment-production.tmpl#L471

I'm reinstating this code and will look to move away from custom tess sidekiq processing another time as we've fixed the underlying issues that necessitated running more sidekiq pods.

Apologies - i should have remembered this was being used.