### PR TITLE
do not report rest client errors to sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,11 @@
+# frozen_string_literal: true
+
 Raven.configure do |config|
+  # https://docs.sentry.io/clients/ruby/config/
   config.dsn = ENV['SENTRY_DSN']
 
   config.current_environment = ENV['SENTRY_ENV'] || Rails.env
   config.sanitize_fields = ["credentials"]
+
+  config.excluded_exceptions << 'RestClient::BadRequest'
 end


### PR DESCRIPTION
do not allow these failing upstream service errors to count in sentry