### PR TITLE
use tmp disk for serving static assets

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -215,7 +215,10 @@ spec:
               mountPath: "/etc/nginx-sites"
       volumes:
         - name: static-assets
-          emptyDir: {}
+          hostPath:
+            # directory location on host node temp disk
+            path: /mnt/caesar-production-app-static-assets
+            type: DirectoryOrCreate
         - name: caesar-nginx-config
           configMap:
             name: caesar-nginx-conf-production

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -206,7 +206,10 @@ spec:
               mountPath: "/etc/nginx-sites"
       volumes:
         - name: static-assets
-          emptyDir: {}
+          hostPath:
+            # directory location on host node temp disk
+            path: /mnt/caesar-staging-app-static-assets
+            type: DirectoryOrCreate
         - name: caesar-nginx-config
           configMap:
             name: caesar-nginx-conf-staging


### PR DESCRIPTION
avoid any disk IO on the host node use the tmp scratch disk instead