### PR TITLE
Hpa scaling and cpu requests

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -517,8 +517,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: caesar-production-tess-sidekiq
-  minReplicas: 2
-  maxReplicas: 4
+  minReplicas: 1
+  maxReplicas: 2
   targetCPUUtilizationPercentage: 80
 ---
 apiVersion: v1

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -378,7 +378,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: caesar-production-sidekiq
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: 4
   targetCPUUtilizationPercentage: 80
 ---

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -74,7 +74,7 @@ spec:
           resources:
             requests:
               memory: "500Mi"
-              cpu: "50m"
+              cpu: "100m"
             limits:
               memory: "500Mi"
               cpu: "500m"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -271,7 +271,7 @@ spec:
           resources:
             requests:
               memory: "500Mi"
-              cpu: "10m"
+              cpu: "50m"
             limits:
               memory: "500Mi"
               cpu: "500m"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -74,7 +74,7 @@ spec:
           resources:
             requests:
               memory: "500Mi"
-              cpu: "10m"
+              cpu: "50m"
             limits:
               memory: "500Mi"
               cpu: "500m"


### PR DESCRIPTION
Increase the caesar app CPU requests to decrease the resulting CPU % values the HPA uses to scale the app
e.g. 
old behaviour 79Mi use / 50Mi target = 158% (so max replicas activated)
VS
new behaviour 79Mi use / 100Mi target = 79% (no scaling needed till above 80% for a period of time)