### PR TITLE
remove rake db:migrate on app boot

### DIFF
--- a/docker/start-puma.sh
+++ b/docker/start-puma.sh
@@ -6,8 +6,4 @@ set -ex
 mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid
 
-if [ "$RAILS_ENV" != "development" ]; then
-  bin/rails db:migrate
-fi
-
 exec bundle exec puma -C config/puma.rb


### PR DESCRIPTION
As the schema isn't changing we don't need to do this on boot. 

Removing this startup cost this will avoid slow starting (thrashing) containers and we will sort out a `rake db:migrate` job like we have in panoptes when the need arises, see https://github.com/zooniverse/panoptes/pull/3376