### PR TITLE
allow tess to process non tess queues

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -494,7 +494,7 @@ spec:
                   name: caesar-production-env-vars
                   key: SENTRY_DSN
             - name: SIDEKIQ_ARGS
-              value: '-q tess -q internal -q default -q external - q batch'
+              value: '-q tess -q internal -q default -q external -q batch'
             - name: SIDEKIQ_CONCURRENCY
               value: '10'
             - name: SIDEKIQ_WEB_PASSWORD

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -494,7 +494,7 @@ spec:
                   name: caesar-production-env-vars
                   key: SENTRY_DSN
             - name: SIDEKIQ_ARGS
-              value: '-q tess'
+              value: '-q tess -q internal -q default -q external - q batch'
             - name: SIDEKIQ_CONCURRENCY
               value: '10'
             - name: SIDEKIQ_WEB_PASSWORD


### PR DESCRIPTION
tess sidekiq is mostly idle, if it's running it should be doing some work
by default prioritize the tess queue, otherwise normal queues in priority order, https://github.com/zooniverse/caesar/blob/5178631974ca1b08c3bd23b4fa145ebea1c7cc85/config/sidekiq.yml#L4-L8
see https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues