### PR TITLE
decrease sidekiq tess concurrency to 1

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -506,7 +506,7 @@ spec:
             - name: SIDEKIQ_ARGS
               value: '-q tess -q internal -q default -q external -q batch'
             - name: SIDEKIQ_CONCURRENCY
-              value: '10'
+              value: '1'
             - name: SIDEKIQ_WEB_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
make sidekiq-tess serial execution to avoid the db load when working through the PH Tess user reductions