### PR TITLE
switch pdb to percent of available replicas

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -241,7 +241,7 @@ kind: PodDisruptionBudget
 metadata:
    name: caesar-production-app-pdb
 spec:
-  minAvailable: 2
+  minAvailable: 50%
   selector:
     matchLabels:
       app: caesar-production-app
@@ -374,7 +374,7 @@ kind: PodDisruptionBudget
 metadata:
    name: caesar-production-sidekiq-pdb
 spec:
-  minAvailable: 1
+  minAvailable: 50%
   selector:
     matchLabels:
       app: caesar-production-sidekiq
@@ -523,7 +523,7 @@ kind: PodDisruptionBudget
 metadata:
    name: caesar-production-sidekiq-tess-pdb
 spec:
-  minAvailable: 1
+  minAvailable: 50%
   selector:
     matchLabels:
       app: caesar-production-sidekiq-tess

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -227,16 +227,6 @@ spec:
   maxReplicas: 2
   targetCPUUtilizationPercentage: 80
 ---
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-   name: caesar-staging-app-pdb
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: caesar-staging-app
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
#### switch pdb to percent of available replicas
avoid hard coding the number of PDB replicas, instead use a percent of the available replicas https://kubernetes.io/docs/tasks/run-application/configure-pdb/

This allows more lenient eviction rules for the relevant pods. I came across pods that wouldn't evict due to the PDB settings when doing the cluster / node pool upgrades the other day. Specifically from https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
> If you set maxUnavailable to 0% or 0, or you set minAvailable to 100% or the number of replicas, you are requiring zero voluntary evictions. When you set zero voluntary evictions for a workload object such as ReplicaSet, then you cannot successfully drain a Node running one of those Pods. If you try to drain a Node where an unevictable Pod is running, the drain never completes. This is permitted as per the semantics of PodDisruptionBudget.

#### remove the staging app pdb
Allow the scheduler to keep this node up, we can tolerate some downtime on the staging app and if it's down we can manually investigate / intervene (most likely due to node issues)