### PR TITLE
remove pod anti affinity scheduling

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -261,28 +261,6 @@ spec:
       labels:
         app: caesar-production-sidekiq
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 2
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - caesar-production-sidekiq
-                topologyKey: "kubernetes.io/hostname"
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - caesar-staging-sidekiq
-                topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-production-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__
@@ -407,29 +385,6 @@ spec:
       labels:
         app: caesar-production-tess-sidekiq
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 2
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - caesar-production-sidekiq
-                        - caesar-production-tess-sidekiq
-                topologyKey: "kubernetes.io/hostname"
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - caesar-staging-sidekiq
-                topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-production-tess-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -243,18 +243,6 @@ spec:
       labels:
         app: caesar-staging-sidekiq
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - caesar-production-sidekiq
-              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: caesar-staging-sidekiq
           image: zooniverse/caesar:__IMAGE_TAG__


### PR DESCRIPTION
these pods don't need to be isolated from each other anymore as the underlying tess sidekiq system is stable now.

ensure we don't increase k8s nodes by scheduling these pods out and help keep the number of k8s nodes to a minimum