### PR TITLE
Optimise pod limits & requests and hpa scaling

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -73,8 +73,8 @@ spec:
           image: zooniverse/caesar:__IMAGE_TAG__
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "100m"
+              memory: "300Mi"
+              cpu: "250m"
             limits:
               memory: "500Mi"
               cpu: "500m"
@@ -193,7 +193,7 @@ spec:
             - containerPort: 80
           resources:
             requests:
-              memory: "100Mi"
+              memory: "70Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"
@@ -266,11 +266,11 @@ spec:
           image: zooniverse/caesar:__IMAGE_TAG__
           resources:
             requests:
-              memory: "750Mi"
-              cpu: "200m"
+              memory: "500Mi"
+              cpu: "250m"
             limits:
               memory: "750Mi"
-              cpu: "500m"
+              cpu: "1000m"
           args: ["/app/docker/start-sidekiq.sh"]
           env:
             - name: RAILS_ENV
@@ -368,7 +368,7 @@ spec:
     name: caesar-production-sidekiq
   minReplicas: 1
   maxReplicas: 4
-  targetCPUUtilizationPercentage: 80
+  targetCPUUtilizationPercentage: 90
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -390,8 +390,8 @@ spec:
           image: zooniverse/caesar:__IMAGE_TAG__
           resources:
             requests:
-              memory: "2500Mi"
-              cpu: "200m"
+              memory: "1000Mi"
+              cpu: "500m"
             limits:
               memory: "2500Mi"
               cpu: "1000m"
@@ -495,7 +495,7 @@ spec:
     name: caesar-production-tess-sidekiq
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 80
+  targetCPUUtilizationPercentage: 90
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -73,8 +73,8 @@ spec:
           image: zooniverse/caesar:__IMAGE_TAG__
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "50m"
+              memory: "300Mi"
+              cpu: "200m"
             limits:
               memory: "500Mi"
               cpu: "500m"
@@ -182,7 +182,7 @@ spec:
           image: zooniverse/apps-nginx:xenial
           resources:
             requests:
-              memory: "100Mi"
+              memory: "70Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"
@@ -225,7 +225,7 @@ spec:
     name: caesar-staging-app
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 80
+  targetCPUUtilizationPercentage: 90
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -248,8 +248,8 @@ spec:
           image: zooniverse/caesar:__IMAGE_TAG__
           resources:
             requests:
-              memory: "500Mi"
-              cpu: "50m"
+              memory: "300Mi"
+              cpu: "200m"
             limits:
               memory: "500Mi"
               cpu: "500m"
@@ -331,7 +331,7 @@ spec:
     name: caesar-staging-sidekiq
   minReplicas: 1
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 80
+  targetCPUUtilizationPercentage: 90
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Update the K8s pod CPU and RAM limits and modify how the HPA works to have a more stable service and less scaling events. linked to https://github.com/zooniverse/panoptes/pull/3601

All values for new requests and limits are based on value inspection from the following cmd to inspect the history of the deployment pods `kubectl top pod --containers | grep caesar`

Specifically this PR introduces these changes:

- modify the API RAM and CPU requests and limits
- modify the sidekiq pods to request less RAM and decrease their limits now the exports run on their own deployment
- modify the tess sidekiq ram requests to allow less pressure on node scheduling
- increase the thresholds for scaling events to avoid scaling events

All these changes should provide less scheduling pressure and allow us to run more pods on the same number of K8s nodes (we can modify the node count if there are seperate IOPS issues). 

The changes to the hpa thresholds should also help avoid the HPA frequently scaling the API deployments and thus reduce the pod registration events in the nginx ingress controller (these cause nginx reloads and can impact traffic flow through the ingresses).