### PR TITLE
use latest nginx image in prod reverse proxy

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -188,12 +188,12 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "cp -R /app/public/* /static-assets"]
         - name: caesar-production-nginx
-          image: zooniverse/apps-nginx:xenial
+          image: zooniverse/nginx:1.19.0
           ports:
             - containerPort: 80
           resources:
             requests:
-              memory: "70Mi"
+              memory: "25Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"
@@ -202,12 +202,23 @@ spec:
             httpGet:
               path: /
               port: 80
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
             initialDelaySeconds: 10
           readinessProbe:
             httpGet:
               path: /
               port: 80
+              httpHeaders:
+                 - name: X-Forwarded-Proto
+                   value: https
             initialDelaySeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                # SIGTERM triggers a quick exit; gracefully terminate instead
+                command: ["/usr/sbin/nginx","-s","quit"]
           volumeMounts:
             - name: static-assets
               mountPath: "/static-assets"


### PR DESCRIPTION
follow up from #1317 

this PR adds the maintained nginx image directives / config for the caesar production app reverse proxy. This version of nginx uses a lot less RAM and should resolve the OOM issues we've been having with the nginx reverse proxy container pod and thus less app pod restarts.