### PR TITLE
update the caesar docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.5
   - 2.6
 branches:
   only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,33 @@
-FROM ruby:2.5-stretch
+FROM ruby:2.6-slim-stretch
 WORKDIR /app
-ENV PORT=80
-ARG RAILS_ENV=production
 
 RUN apt-get update && \
-    curl https://deb.nodesource.com/setup_6.x | bash - && \
-    apt-get install --no-install-recommends -y git curl libpq-dev nodejs libjemalloc1 && \
+    apt-get install --no-install-recommends -y \
+    build-essential \
+    libpq-dev \
+    nodejs \
+    libjemalloc1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
 
-RUN mkdir config && curl "https://ip-ranges.amazonaws.com/ip-ranges.json" > config/aws_ips.json
-
 ADD ./Gemfile /app/
 ADD ./Gemfile.lock /app/
 
-RUN if [ "$RAILS_ENV" = "development" ]; then bundle install; else bundle install --without development test; fi
+ENV PORT=80
+ARG RAILS_ENV=production
+ENV RAILS_ENV=$RAILS_ENV
+
+RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1` && \
+    if echo "development test" | grep -w "$RAILS_ENV"; then \
+    bundle install; \
+    else bundle install --without development test; fi
 
 ADD ./ /app
 
-RUN (cd /app && git log --format="%H" -n 1 > ./public/commit_id.txt)
+RUN (echo $REVISION > ./public/commit_id.txt)
 RUN (cd /app && mkdir -p tmp/pids)
 RUN (cd /app && SECRET_KEY_BASE=1 bundle exec rails assets:precompile)
-
-RUN mkdir -p log && \
-    ln -sf /dev/stdout log/production.log && \
-    ln -sf /dev/stdout log/staging.log && \
-    ln -sf /dev/stdout log/sidekiq.log && \
-    ln -sf /dev/stdout log/newrelic_agent.log
 
 EXPOSE 80
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,10 @@ pipeline {
       steps {
         script {
           def dockerRepoName = 'zooniverse/caesar'
-          def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
-          def newImage = docker.build(dockerImageName)
+          def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
+          def buildArgs = "--build-arg REVISION='${GIT_COMMIT}' ."
+          def newImage = docker.build(dockerImageName, buildArgs)
           newImage.push()
-          newImage.push('${GIT_COMMIT}')
 
           if (BRANCH_NAME == 'master') {
             stage('Update latest tag') {

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,47 +1,19 @@
-# Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum, this matches the default thread size of Active Record.
-#
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+# frozen_string_literal: true
+
+# For more information: https://github.com/puma/puma/blob/master/examples/config.rb
+app_path = File.expand_path(File.dirname(File.dirname(__FILE__)))
+
+pidfile "#{app_path}/tmp/pids/server.pid"
+state_path "#{app_path}/tmp/pids/puma.state"
+
+environment ENV.fetch('RAILS_ENV', 'development')
+port        ENV.fetch('PORT', 3000)
+
+bind "tcp://0.0.0.0:#{port}"
+
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 2).to_i
+# === Non-Cluster mode (no worker / forking) ===
 threads 1, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests, default is 3000.
-#
-port        ENV.fetch("PORT") { 3000 }
-
-# Specifies the `environment` that Puma will run in.
-#
-environment ENV.fetch("RAILS_ENV") { "development" }
-
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked webserver processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory. If you use this option
-# you need to make sure to reconnect any threads in the `on_worker_boot`
-# block.
-#
-# preload_app!
-
-# The code in the `on_worker_boot` will be called if you are using
-# clustered mode by specifying a number of `workers`. After each worker
-# process is booted this block will be run, if you are using `preload_app!`
-# option you will want to use this block to reconnect to any threads
-# or connections that may have been created at application boot, Ruby
-# cannot share connections between processes.
-#
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
-
-# Allow puma to be restarted by `rails restart` command.
-plugin :tmp_restart
+# Additional text to display in process listing
+tag 'caesar_app'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     command: redis-server --appendonly yes
 
   app:
+    image: caesar:local
     build:
       context: .
       args:
@@ -29,10 +30,7 @@ services:
       - postgres:postgres
 
   sidekiq:
-    build:
-      context: .
-      args:
-        RAILS_ENV: development
+    image: caesar:local
     command: ["/app/docker/start-sidekiq.sh"]
     volumes:
       - ./:/app
@@ -41,6 +39,7 @@ services:
       - "REDIS_URL=redis://redis:6379"
       - "DATABASE_URL=postgresql://caesar:caesar@postgres/caesar_development"
       - "DATABASE_URL_TEST=postgresql://caesar:caesar@postgres/caesar_test"
+      - "SIDEKIQ_VERBOSE=true"
     links:
       - redis:redis
       - postgres:postgres

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -102,7 +102,7 @@ spec:
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
             - name: RAILS_MAX_THREADS
-              value: '2'
+              value: '4'
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
@@ -113,8 +113,6 @@ spec:
                 secretKeyRef:
                   name: caesar-production-env-vars
                   key: SECRET_KEY_BASE
-            - name: DATABASE_POOL_SIZE
-              value: '11'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -288,8 +286,6 @@ spec:
               value: production
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
-            - name: RAILS_MAX_THREADS
-              value: '2'
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
@@ -301,7 +297,7 @@ spec:
                   name: caesar-production-env-vars
                   key: SECRET_KEY_BASE
             - name: DATABASE_POOL_SIZE
-              value: '11'
+              value: '10'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -345,8 +341,6 @@ spec:
                 secretKeyRef:
                   name: caesar-production-env-vars
                   key: SENTRY_DSN
-            - name: SIDEKIQ_CONCURRENCY
-              value: '10'
             - name: SIDEKIQ_WEB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -412,8 +406,6 @@ spec:
               value: production
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
-            - name: RAILS_MAX_THREADS
-              value: '2'
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
@@ -425,7 +417,7 @@ spec:
                   name: caesar-production-env-vars
                   key: SECRET_KEY_BASE
             - name: DATABASE_POOL_SIZE
-              value: '11'
+              value: '1'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -108,6 +108,8 @@ spec:
                   key: SECRET_KEY_BASE
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
+            - name: DATABASE_POOL_SIZE
+              value: '2'
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -320,6 +322,8 @@ spec:
                 secretKeyRef:
                   name: caesar-staging-env-vars
                   key: SENTRY_DSN
+            - name: SIDEKIQ_CONCURRENCY
+              value: '4'
             - name: SIDEKIQ_WEB_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This PR introduces some changes to the caesar docker image, the aim is to shrink the overall image size and upgrading ruby.

Specifically the changes are
- use the slim base image
- upgrade to ruby 2.6
- test travis on 2.6 exclusively
- cleanup dockerfile to use less dependencies (remove curl, git etc)
- remove unused aws cruft
- inject the revision at build time for use in file (avoid git dep)
- update the sidekiq and puma configs with other service apps
- align the db connections with sidekiq & puma concurrency settings (create only the db connection we need)

