### PR TITLE
Fix app puma boot and AR connection pool config for tess sidekiq

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("DATABASE_POOL_SIZE") { 4 } %>
+  pool: <%= ENV.fetch("DATABASE_POOL_SIZE") { 4 }.to_i %>
 development:
   <<: *default
   database: caesar_development

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,8 +7,8 @@ pidfile "#{app_path}/tmp/pids/server.pid"
 state_path "#{app_path}/tmp/pids/puma.state"
 
 environment ENV.fetch('RAILS_ENV', 'development')
-port        ENV.fetch('PORT', 3000)
 
+port = ENV.fetch('PORT', 3000)
 bind "tcp://0.0.0.0:#{port}"
 
 threads_count = ENV.fetch('RAILS_MAX_THREADS', 2).to_i


### PR DESCRIPTION
related to the changes in #1319 this PR updates the apps to 
- allow puma to boot on the correct port (use the bind not port dsl)
- use integer for AR connection pool size in tess serial sidekiq service