### PR TITLE
add revision ARG and ENV to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ADD ./Gemfile.lock /app/
 ENV PORT=80
 ARG RAILS_ENV=production
 ENV RAILS_ENV=$RAILS_ENV
+ARG REVISION=''
+ENV REVISION=$REVISION
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1` && \
     if echo "development test" | grep -w "$RAILS_ENV"; then \


### PR DESCRIPTION
related to changes in #1319 

This PR introduces the docker image build ARG for the REVISION (git commit ID) env var. This ARG and ENV replace the use of git in the image build and thus the git dependency in the image.