### PR TITLE
Use GH Actions to run tests for CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,6 +15,11 @@ jobs:
           POSTGRES_DB: caesar_test
           POSTGRES_PASSWORD: ""
         ports: ["5432:5432"]
+        options:
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,6 @@ jobs:
       postgres:
         image: postgres:11
         env:
-          POSTGRES_DB: caesar_test
           POSTGRES_PASSWORD: postgres
         ports: ["5432:5432"]
         options:
@@ -33,6 +32,7 @@ jobs:
         env:
           RAILS_ENV: test
           PGHOST: localhost
+          DATABASE_URL_TEST: postgresql://localhost/caesar_test?user=postgres
         run: |
           bin/rails db:create
           bin/rails db:schema:load

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           RAILS_ENV: test
           PGHOST: localhost
-          DATABASE_URL_TEST: postgresql://localhost:postgres/caesar_test?user=postgres
+          DATABASE_URL_TEST: postgresql://postgres:postgres@localhost/caesar_test
         run: |
           bin/rails db:create
           bin/rails db:schema:load

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup test database
         env:
           RAILS_ENV: test
-          PGHOST: postgres
+          PGHOST: localhost
           PGUSER: caesar_test
         run: |
           bin/rails db:create

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -38,4 +38,8 @@ jobs:
           bin/rails db:schema:load
 
       - name: Run tests
+        env:
+          RAILS_ENV: test
+          PGHOST: localhost
+          DATABASE_URL_TEST: postgresql://postgres:postgres@localhost/caesar_test
         run: bin/rspec

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           POSTGRES_USER: caesar_test
           POSTGRES_DB: caesar_test
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: postgres
         ports: ["5432:5432"]
         options:
           --health-cmd pg_isready
@@ -33,7 +33,7 @@ jobs:
       - name: Setup test database
         env:
           RAILS_ENV: test
-          PGHOST: 127.0.0.1
+          PGHOST: localhost
           PGUSER: caesar_test
         run: |
           bin/rails db:create

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,6 +18,11 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --entrypoint redis-server
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup test database
         env:
           RAILS_ENV: test
-          PGHOST: localhost
+          PGHOST: postgres
           PGUSER: caesar_test
         run: |
           bin/rails db:create

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup test database
         env:
           RAILS_ENV: test
-          PGHOST: localhost
+          PGHOST: 127.0.0.1
           PGUSER: caesar_test
         run: |
           bin/rails db:create

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,38 @@
+name: Run Tests
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: caesar_test
+          POSTGRES_DB: caesar_test
+          POSTGRES_PASSWORD: ""
+        ports: ["5432:5432"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup test database
+        env:
+          RAILS_ENV: test
+          PGHOST: localhost
+          PGUSER: caesar_test
+        run: |
+          bin/rails db:create
+          bin/rails db:schema:load
+
+      - name: Run tests
+        run: bin/rspec

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,6 +15,12 @@ jobs:
           POSTGRES_DB: caesar_test
           POSTGRES_PASSWORD: ""
         ports: ["5432:5432"]
+        options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           RAILS_ENV: test
           PGHOST: localhost
-          DATABASE_URL_TEST: postgresql://localhost/caesar_test:postgres?user=postgres
+          DATABASE_URL_TEST: postgresql://localhost:postgres/caesar_test?user=postgres
         run: |
           bin/rails db:create
           bin/rails db:schema:load

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,7 +12,8 @@ jobs:
         image: postgres:11
         env:
           POSTGRES_PASSWORD: postgres
-        ports: ["5432:5432"]
+        ports:
+        - 5432:5432
         options:
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,8 +14,8 @@ jobs:
           POSTGRES_USER: caesar_test
           POSTGRES_DB: caesar_test
           POSTGRES_PASSWORD: ""
-        ports:
-        - 5432:5432
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           RAILS_ENV: test
           PGHOST: localhost
-          DATABASE_URL_TEST: postgresql://localhost/caesar_test?user=postgres
+          DATABASE_URL_TEST: postgresql://localhost/caesar_test:postgres?user=postgres
         run: |
           bin/rails db:create
           bin/rails db:schema:load

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,6 @@ jobs:
       postgres:
         image: postgres:11
         env:
-          POSTGRES_USER: caesar_test
           POSTGRES_DB: caesar_test
           POSTGRES_PASSWORD: postgres
         ports: ["5432:5432"]
@@ -34,7 +33,6 @@ jobs:
         env:
           RAILS_ENV: test
           PGHOST: localhost
-          PGUSER: caesar_test
         run: |
           bin/rails db:create
           bin/rails db:schema:load

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,13 +14,8 @@ jobs:
           POSTGRES_USER: caesar_test
           POSTGRES_DB: caesar_test
           POSTGRES_PASSWORD: ""
-        ports: ["5432:5432"]
-        options: >-
-          --mount type=tmpfs,destination=/var/lib/postgresql/data
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+        ports:
+        - 5432:5432
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,7 +15,6 @@ jobs:
           POSTGRES_DB: caesar_test
           POSTGRES_PASSWORD: ""
         ports: ["5432:5432"]
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Replace TravisCI with a Github Action to automatically run the specs for CI. Travis has so severely limited its free tier that it has become unusable, and GHA is the obvious choice to replace it.


First step toward migrating to GHA for deployment.