### PR TITLE
add reducer_key identifier to subject_reduction payload

### DIFF
--- a/app/models/subject_reduction.rb
+++ b/app/models/subject_reduction.rb
@@ -24,6 +24,7 @@ class SubjectReduction < ApplicationRecord
       reducible: { id: reducible_id, type: reducible_type },
       data: data,
       subject: subject.attributes,
+      reducer_key: reducer_key,
       created_at: created_at,
       updated_at: updated_at
     }.with_indifferent_access

--- a/spec/models/subject_reduction_spec.rb
+++ b/spec/models/subject_reduction_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe SubjectReduction, type: :model do
     expect(build(:subject_reduction)).to be_valid
   end
 
+  it '#prepare' do
+    extract1 = create(:extract, user_id: 1)
+    reduction = create(:subject_reduction, extracts: [extract1])
+    prepared = reduction.prepare
+    expected_attributes = %w[id data subject reducer_key created_at updated_at]
+    expected_payload = reduction.attributes.slice(*expected_attributes)
+    # add the formatted payload attributes before testing
+    expected_payload['reducible'] = { 'id' => reduction.reducible_id, 'type' => reduction.reducible_type }
+    expected_payload['subject'] = reduction.subject.attributes
+    expect(expected_payload).to include(prepared)
+  end
+
   it "should prepare auxiliary attributes" do
     extract1 = create(:extract, user_id: 1)
     extract2 = create(:extract, user_id: 2)

--- a/spec/models/subject_reduction_spec.rb
+++ b/spec/models/subject_reduction_spec.rb
@@ -6,25 +6,27 @@ RSpec.describe SubjectReduction, type: :model do
     expect(build(:subject_reduction)).to be_valid
   end
 
-  it '#prepare' do
-    extract1 = create(:extract, user_id: 1)
-    reduction = create(:subject_reduction, extracts: [extract1])
-    prepared = reduction.prepare
-    expected_attributes = %w[id data subject reducer_key created_at updated_at]
-    expected_payload = reduction.attributes.slice(*expected_attributes)
-    # add the formatted payload attributes before testing
-    expected_payload['reducible'] = { 'id' => reduction.reducible_id, 'type' => reduction.reducible_type }
-    expected_payload['subject'] = reduction.subject.attributes
-    expect(expected_payload).to include(prepared)
-  end
+  describe '#prepare' do
+    it 'correctly prepares the subject_reduction payload as a hash' do
+      extract1 = create(:extract, user_id: 1)
+      reduction = create(:subject_reduction, extracts: [extract1])
+      prepared = reduction.prepare
+      expected_attributes = %w[id data subject reducer_key created_at updated_at]
+      expected_payload = reduction.attributes.slice(*expected_attributes)
+      # add the formatted payload attributes before testing
+      expected_payload['reducible'] = { 'id' => reduction.reducible_id, 'type' => reduction.reducible_type }
+      expected_payload['subject'] = reduction.subject.attributes
+      expect(expected_payload).to include(prepared)
+    end
 
-  it "should prepare auxiliary attributes" do
-    extract1 = create(:extract, user_id: 1)
-    extract2 = create(:extract, user_id: 2)
-    extract3 = create(:extract, user_id: 3)
-    reduction = create(:subject_reduction, extracts: [extract1, extract2, extract3])
+    it 'adds subject attributes to the payload' do
+      extract1 = create(:extract, user_id: 1)
+      extract2 = create(:extract, user_id: 2)
+      extract3 = create(:extract, user_id: 3)
+      reduction = create(:subject_reduction, extracts: [extract1, extract2, extract3])
 
-    prepared = reduction.prepare
-    expect(prepared[:subject]).to eq(reduction.subject.attributes)
+      prepared = reduction.prepare
+      expect(prepared[:subject]).to eq(reduction.subject.attributes)
+    end
   end
 end


### PR DESCRIPTION
closes #1341

Ensure we can identify which reducer created this subject_reduction payload.

This will be used by external apps to link the reducer / workflow to the payload when the workflow has multiple reducers that post to an end point. 

Specifically if an external org has a single API ingestion point for subject reduction payloads and they have multiple reducers posting to this end point then the payloads can't be linked to the individual reducers. 

This PR adds the reducer key to alleviate this issue.