### PR TITLE
Update sidekiq uniquejobs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # gem 'bcrypt', '~> 3.1.7'
 gem 'sidekiq'
 gem 'sidekiq-congestion', '~> 0.1.0'
-gem 'sidekiq-unique-jobs'
+gem 'sidekiq-unique-jobs', '~> 7.1.0'
 gem 'sidekiq-logstash'
 gem 'flipper'
 gem 'flipper-active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,14 +73,17 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    brpoplpush-redis_script (0.1.2)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      redis (>= 1.0, <= 5.0)
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     congestion (0.1.0)
       connection_pool (>= 2.0)
       redis (>= 3.1)
-    connection_pool (2.2.3)
+    connection_pool (2.2.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -315,10 +318,11 @@ GEM
     sidekiq-logstash (1.2.0)
       logstash-event (~> 1.2)
       sidekiq (>= 3.0, < 6)
-    sidekiq-unique-jobs (6.0.13)
+    sidekiq-unique-jobs (7.1.5)
+      brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
-      sidekiq (>= 4.0, < 7.0)
-      thor (~> 0)
+      sidekiq (>= 5.0, < 7.0)
+      thor (>= 0.20, < 2.0)
     simple_form (5.0.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -338,7 +342,7 @@ GEM
     stoplight (2.1.3)
     strong_migrations (0.4.1)
       activerecord (>= 5)
-    thor (0.20.3)
+    thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     to_regexp (0.2.1)
@@ -406,7 +410,7 @@ DEPENDENCIES
   sidekiq
   sidekiq-congestion (~> 0.1.0)
   sidekiq-logstash
-  sidekiq-unique-jobs
+  sidekiq-unique-jobs (~> 7.1.0)
   simple_form
   spring
   spring-commands-rspec

--- a/app/workers/check_rules_worker.rb
+++ b/app/workers/check_rules_worker.rb
@@ -1,7 +1,7 @@
 class CheckRulesWorker
   include Sidekiq::Worker
   sidekiq_options retry: 2
-  sidekiq_options unique: :until_executing unless Rails.env.test?
+  sidekiq_options lock: :until_executing unless Rails.env.test?
   sidekiq_options queue: 'internal'
 
   # TODO: Remove this class after CheckSubjectRulesWorker and CheckUserRulesWorker have been deployed

--- a/app/workers/check_subject_rules_worker.rb
+++ b/app/workers/check_subject_rules_worker.rb
@@ -1,7 +1,7 @@
 class CheckSubjectRulesWorker
   include Sidekiq::Worker
   sidekiq_options retry: 2
-  sidekiq_options unique: :until_executing unless Rails.env.test?
+  sidekiq_options lock: :until_executing unless Rails.env.test?
   sidekiq_options queue: 'internal'
 
   def perform(reducible_id, reducible_type, subject_id)

--- a/app/workers/check_user_rules_worker.rb
+++ b/app/workers/check_user_rules_worker.rb
@@ -1,7 +1,7 @@
 class CheckUserRulesWorker
   include Sidekiq::Worker
   sidekiq_options retry: 2
-  sidekiq_options unique: :until_executing unless Rails.env.test?
+  sidekiq_options lock: :until_executing unless Rails.env.test?
   sidekiq_options queue: 'internal'
 
   def perform(reducible_id, reducible_type, user_id)

--- a/app/workers/describe_workflow_worker.rb
+++ b/app/workers/describe_workflow_worker.rb
@@ -2,7 +2,7 @@
 class DescribeWorkflowWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'batch'
-  sidekiq_options unique: :until_executed unless Rails.env.test?
+  sidekiq_options lock: :until_executed unless Rails.env.test?
 
   def perform(workflow_id)
     light = Stoplight("describe-workflow-#{workflow_id}") do

--- a/app/workers/fetch_classifications_worker.rb
+++ b/app/workers/fetch_classifications_worker.rb
@@ -15,7 +15,7 @@ class FetchClassificationsWorker
     @@FetchForUser
   end
 
-  sidekiq_options unique: :until_executed unless Rails.env.test?
+  sidekiq_options lock: :until_executed unless Rails.env.test?
 
   def perform(workflow_id, object_id, object_type)
     workflow = Workflow.find(workflow_id)

--- a/app/workers/reduce_worker.rb
+++ b/app/workers/reduce_worker.rb
@@ -1,7 +1,7 @@
 class ReduceWorker
   include Sidekiq::Worker
   sidekiq_options retry: 5
-  sidekiq_options unique: :until_and_while_executing, unique_args: :unique_args unless Rails.env.test?
+  sidekiq_options lock: :until_and_while_executing, lock_args_method: :unique_args unless Rails.env.test?
   sidekiq_options queue: 'internal'
   sidekiq_retry_in do |count|
     (count ** 8) + 15 + (rand(30) * count + 1)
@@ -32,9 +32,9 @@ class ReduceWorker
 
   def self.test_uniq(testing)
     if testing
-      sidekiq_options unique: :until_and_while_executing, unique_args: :unique_args
+      sidekiq_options lock: :until_and_while_executing, lock_args_method: :unique_args
     else
-      sidekiq_options unique: :until_and_while_executing, unique_args: :unique_args unless Rails.env.test?
+      sidekiq_options lock: :until_and_while_executing, lock_args_method: :unique_args unless Rails.env.test?
     end
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,10 +1,9 @@
 require 'sidekiq/web'
-require "sidekiq-unique-jobs"
+require 'sidekiq-unique-jobs'
 Sidekiq::Logstash.setup
 
-
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV["REDIS_URL"] }
+  config.redis = { url: ENV['REDIS_URL'] }
 
   config.client_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Client
@@ -18,7 +17,7 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV["REDIS_URL"] }
+  config.redis = { url: ENV['REDIS_URL'] }
 
   config.client_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Client

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,2 +1,26 @@
 require 'sidekiq/web'
+require "sidekiq-unique-jobs"
 Sidekiq::Logstash.setup
+
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV["REDIS_URL"] }
+
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
+
+  config.server_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Server
+  end
+
+  SidekiqUniqueJobs::Server.configure(config)
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV["REDIS_URL"] }
+
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
+end


### PR DESCRIPTION
Update to latest major version, required syntax changes included. 

I noticed that the locks aren't manually cleaned up in the way [described in the docs](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/master/README.md#3-cleanup-dead-locks) (we're on sidekiq 5):

```
class MyWorker
  sidekiq_retries_exhausted do |msg, _ex|
    digest = msg['lock_digest']
    SidekiqUniqueJobs::Digests.new.delete_by_digest(digest) if digest
  end
end
```
This'll be the next thing to try if this doesn't help the erroneous digest-locking behavior.