### PR TITLE
Build and deploy docs to GH Pages on merge to master

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,5 +1,6 @@
 name: Publish Docs to Github Pages
 on:
+  workflow_dispatch:
   push:
       branches:
         - master

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,25 @@
+name: Publish Docs to Github Pages
+on:
+  push:
+      branches:
+        - master
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
+      - name: Build Middleman
+        run: bundle exec middleman build --clean
+        working-directory: ${{ github.workspace }}/docs
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages
+          folder: ${{ github.workspace }}/docs/build


### PR DESCRIPTION
Build docs with Middleman and then deploy them to Github Pages via the gh-pages branch and an [only-slightly-less-than-official](https://github.blog/2020-09-25-github-action-hero-james-ives-and-github-pages-deploy/) marketplace action.

Question: Travis used to build and deploy these docs whenever the PR was updated. This PR makes the deploy part of the merge to master & deploy to staging, but can also be executed manually. Is this sufficient, or should the live docs still be updated on every push so they can be checked during the review process? My pref is in this PR, lmk if you feel differently.