### PR TITLE
add memory cache_store to staging env

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
aligns the staging and production envs, used when `Rails.cache` cmds are called, e.g. https://github.com/zooniverse/caesar/blob/68b50a8c4eec11981de6f433e1cb0a559fe6981c/app/controllers/status_controller.rb#L7