### PR TITLE
Update json response on post

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
   rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
+  rescue_from ActiveRecord::RecordNotUnique, with: :record_not_unique
 
   private
 
@@ -70,6 +71,10 @@ class ApplicationController < ActionController::Base
 
   def record_invalid(exception)
     render json: exception.record.errors, status: 422
+  end
+
+  def record_not_unique(exception)
+    render json: { error: exception.message }, status: 422
   end
 
   def not_authorized

--- a/app/controllers/extractors_controller.rb
+++ b/app/controllers/extractors_controller.rb
@@ -35,7 +35,7 @@ class ExtractorsController < ApplicationController
     @extractor.save
     respond_to do |format|
       format.html { respond_with @extractor, location: workflow_path(workflow, anchor: 'extractors') }
-      format.json { respond_with @extractor }
+      format.json { render json: @extractor }
     end
   end
 

--- a/app/controllers/extractors_controller.rb
+++ b/app/controllers/extractors_controller.rb
@@ -1,5 +1,6 @@
 class ExtractorsController < ApplicationController
   responders :flash
+  rescue_from Extractor::UnknownTypeError, with: :record_not_valid
 
   def index
     authorize workflow
@@ -78,5 +79,9 @@ class ExtractorsController < ApplicationController
       *klass.configuration_fields.keys,
       config: {},
     ).merge(workflow_id: workflow.id)
+  end
+
+  def record_not_valid(exception)
+    render json: { error: exception.message }, status: 422
   end
 end

--- a/app/controllers/extractors_controller.rb
+++ b/app/controllers/extractors_controller.rb
@@ -35,7 +35,7 @@ class ExtractorsController < ApplicationController
     @extractor.save
     respond_to do |format|
       format.html { respond_with @extractor, location: workflow_path(workflow, anchor: 'extractors') }
-      format.json { render json: @extractor }
+      format.json { respond_with @extractor, location: workflow_path(workflow, anchor: 'extractors') }
     end
   end
 

--- a/app/controllers/extractors_controller.rb
+++ b/app/controllers/extractors_controller.rb
@@ -32,10 +32,13 @@ class ExtractorsController < ApplicationController
     extractor_class = Extractor.of_type(params[:extractor][:type])
     @extractor = extractor_class.new(extractor_params(extractor_class))
 
-    @extractor.save
     respond_to do |format|
+      if @extractor.save
+        format.json { render json: @extractor }
+      else
+        format.json { render json: @extractor.errors, status: :unprocessable_entity }
+      end
       format.html { respond_with @extractor, location: workflow_path(workflow, anchor: 'extractors') }
-      format.json { respond_with @extractor, location: workflow_path(workflow, anchor: 'extractors') }
     end
   end
 

--- a/app/controllers/reducers_controller.rb
+++ b/app/controllers/reducers_controller.rb
@@ -56,6 +56,10 @@ class ReducersController < ApplicationController
         format.json { render json: @reducer.errors, status: :unprocessable_entity }
       end
       format.html { respond_with @reducer, location: redirect_path }
+    rescue StandardError => e
+      flash[:alert] = e
+      format.json { render json: e, status: :unprocessable_entity }
+      format.html { render :new, status: :unprocessable_entity }
     end
   end
 

--- a/app/controllers/reducers_controller.rb
+++ b/app/controllers/reducers_controller.rb
@@ -48,11 +48,14 @@ class ReducersController < ApplicationController
     end
 
     @reducer = reducer_class.new(new_params)
-    @reducer.save
 
     respond_to do |format|
+      if @reducer.save
+        format.json { render json: @reducer }
+      else
+        format.json { render json: @reducer.errors, status: :unprocessable_entity }
+      end
       format.html { respond_with @reducer, location: redirect_path }
-      format.json { respond_with @reducer, location: workflow_reducer_path(workflow, @reducer) }
     end
   end
 

--- a/app/models/extractor.rb
+++ b/app/models/extractor.rb
@@ -2,6 +2,8 @@ class Extractor < ApplicationRecord
   include Configurable
 
   class ExtractionFailed < StandardError; end
+ 
+  class UnknownTypeError < StandardError; end
 
   def self.of_type(type)
     case type.to_s
@@ -20,7 +22,7 @@ class Extractor < ApplicationRecord
     when "shape"
       Extractors::AggregationExtractors::ShapeExtractor
     else
-      raise "Unknown type #{type}"
+      raise UnknownTypeError, "Unknown type #{type}"
     end
   end
 

--- a/app/models/extractor.rb
+++ b/app/models/extractor.rb
@@ -2,7 +2,7 @@ class Extractor < ApplicationRecord
   include Configurable
 
   class ExtractionFailed < StandardError; end
- 
+
   class UnknownTypeError < StandardError; end
 
   def self.of_type(type)

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -1,6 +1,7 @@
 class Reducer < ApplicationRecord
   include Configurable
   include BelongsToReducibleCached
+  class UnknownTypeError < StandardError; end
 
   enum topic: {
     reduce_by_subject: 0,
@@ -35,7 +36,7 @@ class Reducer < ApplicationRecord
     when 'sqs'
       Reducers::SqsReducer
     else
-      raise "Unknown type #{type}"
+      raise UnknownTypeError, "Unknown type #{type}"
     end
   end
 

--- a/spec/controllers/extractors_controller_spec.rb
+++ b/spec/controllers/extractors_controller_spec.rb
@@ -97,6 +97,12 @@ describe ExtractorsController, :type => :controller do
         post :create, params: { workflow_id: workflow.id, extractor: { key: nil, type: 'external' } }
         expect(response.status).to eq(422)
       end
+
+      it 'returns 422 on unknown types' do
+        extractor_params[:type] = ''
+        post :create, params: { workflow_id: workflow.id, extractor: extractor_params }
+        expect(response.status).to eq(422)
+      end
     end
 
     describe '#update' do

--- a/spec/controllers/extractors_controller_spec.rb
+++ b/spec/controllers/extractors_controller_spec.rb
@@ -86,7 +86,7 @@ describe ExtractorsController, :type => :controller do
       it 'renders json when Accept Header is application/json' do
         request.headers['Accept'] = 'application/json'
         post :create, params: { workflow_id: workflow.id, extractor: extractor_params }
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(201)
         parsed_body = JSON.parse(response.body)
         expect(parsed_body['key']).to eq(extractor_params[:key])
         expect(parsed_body['id']).not_to be(nil)

--- a/spec/controllers/extractors_controller_spec.rb
+++ b/spec/controllers/extractors_controller_spec.rb
@@ -78,18 +78,24 @@ describe ExtractorsController, :type => :controller do
         expect(workflow.extractors.first.url).to eq('https://example.org')
       end
 
+      it 'renders json when Accept Header is application/json' do
+        request.headers['Accept'] = 'application/json'
+        post :create, params: { workflow_id: workflow.id, extractor: extractor_params }
+        expect(response.status).to eq(200)
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['key']).to eq(extractor_params[:key])
+        expect(parsed_body['id']).not_to be(nil)
+      end
+
       it 'renders form on errors' do
         post :create, params: { workflow_id: workflow.id, extractor: { key: nil, type: 'external' } }
         expect(response.status).to eq(200)
       end
 
-      it 'renders json when Accept Header is application/json' do
+      it 'returns 422 on errors and Accept Header is application/json' do
         request.headers['Accept'] = 'application/json'
-        post :create, params: { workflow_id: workflow.id, extractor: extractor_params }
-        expect(response.status).to eq(201)
-        parsed_body = JSON.parse(response.body)
-        expect(parsed_body['key']).to eq(extractor_params[:key])
-        expect(parsed_body['id']).not_to be(nil)
+        post :create, params: { workflow_id: workflow.id, extractor: { key: nil, type: 'external' } }
+        expect(response.status).to eq(422)
       end
     end
 

--- a/spec/controllers/extractors_controller_spec.rb
+++ b/spec/controllers/extractors_controller_spec.rb
@@ -69,7 +69,7 @@ describe ExtractorsController, :type => :controller do
     end
 
     describe '#create' do
-      let(:extractor_params) { { key: 'a', type: 'external', url: 'https://example.org'} }
+      let(:extractor_params) { { key: 'a', type: 'external', url: 'https://example.org' } }
 
       it 'creates a new extractor' do
         post :create, params: { workflow_id: workflow.id, extractor: extractor_params }

--- a/spec/controllers/extractors_controller_spec.rb
+++ b/spec/controllers/extractors_controller_spec.rb
@@ -69,18 +69,27 @@ describe ExtractorsController, :type => :controller do
     end
 
     describe '#create' do
-      let(:extractor_params) { {key: 'a', type: 'external', url: 'https://example.org'} }
+      let(:extractor_params) { { key: 'a', type: 'external', url: 'https://example.org'} }
 
       it 'creates a new extractor' do
-        post :create, params: {workflow_id: workflow.id, extractor: extractor_params}
+        post :create, params: { workflow_id: workflow.id, extractor: extractor_params }
         expect(response).to redirect_to(workflow_path(workflow, anchor: 'extractors'))
         expect(workflow.extractors.count).to eq(1)
         expect(workflow.extractors.first.url).to eq('https://example.org')
       end
 
       it 'renders form on errors' do
-        post :create, params: {workflow_id: workflow.id, extractor: {key: nil, type: 'external'}}
+        post :create, params: { workflow_id: workflow.id, extractor: { key: nil, type: 'external' } }
         expect(response.status).to eq(200)
+      end
+
+      it 'renders json when Accept Header is application/json' do
+        request.headers['Accept'] = 'application/json'
+        post :create, params: { workflow_id: workflow.id, extractor: extractor_params }
+        expect(response.status).to eq(200)
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['key']).to eq(extractor_params[:key])
+        expect(parsed_body['id']).not_to be(nil)
       end
     end
 

--- a/spec/controllers/reducers_controller_spec.rb
+++ b/spec/controllers/reducers_controller_spec.rb
@@ -89,7 +89,7 @@ describe ReducersController, :type => :controller do
           }
         }, format: :json
 
-        expect(response).to have_http_status(:created)
+        expect(response).to have_http_status(:ok)
         expect(workflow.reducers.count).to eq(1)
         expect(workflow.reducers.first.filters['extractor_keys']).to eq(['test'])
       end
@@ -105,7 +105,7 @@ describe ReducersController, :type => :controller do
           }
         }, format: :json
 
-        expect(response).to have_http_status(:created)
+        expect(response).to have_http_status(:ok)
         expect(workflow.reducers.count).to eq(1)
         expect(workflow.reducers.first.filters['extractor_keys']).to eq(['test'])
       end
@@ -114,8 +114,13 @@ describe ReducersController, :type => :controller do
         post :create, params: {workflow_id: workflow.id, reducer: {key: nil, type: 'external'}}
         expect(response.status).to eq(200)
       end
-    end
 
+      it 'renders 422 on error and Accept headers is application/json' do
+        request.headers['Accept'] = 'application/json'
+        post :create, params: { workflow_id: workflow.id, reducer: { key: nil, type: 'external' } }
+        expect(response.status).to eq(422)
+      end
+    end
     describe '#update' do
       it 'updates the specified reducer' do
         put :update, params: {workflow_id: workflow.id,

--- a/spec/controllers/reducers_controller_spec.rb
+++ b/spec/controllers/reducers_controller_spec.rb
@@ -120,6 +120,11 @@ describe ReducersController, :type => :controller do
         post :create, params: { workflow_id: workflow.id, reducer: { key: nil, type: 'external' } }
         expect(response.status).to eq(422)
       end
+
+      it 'renders 422 on non-unique/db key error' do
+        post :create, params: { workflow_id: workflow.id, reducer: { key: reducer.key, type: 'external' } }
+        expect(response.status).to eq(422)
+      end
     end
     describe '#update' do
       it 'updates the specified reducer' do

--- a/spec/controllers/reducers_controller_spec.rb
+++ b/spec/controllers/reducers_controller_spec.rb
@@ -108,7 +108,7 @@ describe ReducersController, :type => :controller do
       end
 
       it 'renders form on errors' do
-        post :create, params: { workflow_id: workflow.id, reducer: { key: nil, type: 'external' }}
+        post :create, params: { workflow_id: workflow.id, reducer: { key: nil, type: 'external' } }
         expect(response.status).to eq(200)
       end
 


### PR DESCRIPTION
Updating responses on Create when Accept header is `application/json` . This ties into work being done in python-client to connect python client to caesar. Prioritizing POST calls for now, since scope of work for python-client caesar connection is Read and Create. Will come back and update Update and Delete methods when we cross that bridge (or can do it now, if someone says otherwise) 