### PR TITLE
Update json response on post (rules and effects)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,6 +81,12 @@ class ApplicationController < ActionController::Base
     head 401
   end
 
+  def json_error_messages(errors)
+    errors_array = []
+    errors.full_messages.each { |msg| errors_array << { message: msg } }
+    { errors: errors_array }
+  end
+
   def handle_unauthenticated_request(message)
     respond_to do |format|
       format.html do

--- a/app/controllers/extractors_controller.rb
+++ b/app/controllers/extractors_controller.rb
@@ -37,7 +37,7 @@ class ExtractorsController < ApplicationController
       if @extractor.save
         format.json { render json: @extractor }
       else
-        format.json { render json: @extractor.errors, status: :unprocessable_entity }
+        format.json { render json: json_error_messages(@extractor.errors), status: :unprocessable_entity }
       end
       format.html { respond_with @extractor, location: workflow_path(workflow, anchor: 'extractors') }
     end

--- a/app/controllers/reducers_controller.rb
+++ b/app/controllers/reducers_controller.rb
@@ -52,7 +52,7 @@ class ReducersController < ApplicationController
       if @reducer.save
         format.json { render json: @reducer }
       else
-        format.json { render json: @reducer.errors, status: :unprocessable_entity }
+        format.json { render json: json_error_messages(@reducer.errors), status: :unprocessable_entity }
       end
       format.html { respond_with @reducer, location: redirect_path }
     end

--- a/app/controllers/subject_rule_effects_controller.rb
+++ b/app/controllers/subject_rule_effects_controller.rb
@@ -32,7 +32,7 @@ class SubjectRuleEffectsController < ApplicationController
 
     respond_to do |format|
       if @subject_rule_effect.save
-        format.json { respond_with workflow, subject_rule, @subject_rule_effect }
+        format.json { render json: @subject_rule_effect }
       else
         format.json { render json: json_error_messages(@subject_rule_effect.errors), status: :unprocessable_entity }
       end

--- a/app/controllers/subject_rule_effects_controller.rb
+++ b/app/controllers/subject_rule_effects_controller.rb
@@ -29,11 +29,14 @@ class SubjectRuleEffectsController < ApplicationController
   def create
     @subject_rule_effect = SubjectRuleEffect.new(effect_params)
     authorize @subject_rule_effect
-    @subject_rule_effect.save
 
     respond_to do |format|
+      if @subject_rule_effect.save
+        format.json { respond_with workflow, subject_rule, @subject_rule_effect }
+      else
+        format.json { render json: json_error_messages(@subject_rule_effect.errors), status: :unprocessable_entity }
+      end
       format.html { respond_with workflow, subject_rule, @subject_rule_effect, location: edit_workflow_subject_rule_path(workflow, subject_rule) }
-      format.json { respond_with workflow, subject_rule, @subject_rule_effect }
     end
   rescue Pundit::NotAuthorizedError
     respond_to do |format|
@@ -95,5 +98,9 @@ class SubjectRuleEffectsController < ApplicationController
       :action_type,
       config: {}
     ).merge(subject_rule_id: params[:subject_rule_id])
+  end
+
+  def record_not_valid(exception)
+    render json: { error: exception.message }, status: 422
   end
 end

--- a/app/controllers/user_rule_effects_controller.rb
+++ b/app/controllers/user_rule_effects_controller.rb
@@ -32,11 +32,14 @@ class UserRuleEffectsController < ApplicationController
     authorize workflow, :edit?
 
     @user_rule_effect = UserRuleEffect.new(effect_params)
-    @user_rule_effect.save
 
     respond_to do |format|
+      if @user_rule_effect.save
+        format.json { render json: @user_rule_effect }
+      else
+        format.json { render json: json_error_messages(@user_rule_effect.errors), status: :unprocessable_entity}
+      end
       format.html { respond_with @user_rule_effect, location: edit_workflow_user_rule_path(workflow, user_rule) }
-      format.json { respond_with workflow, user_rule, @user_rule_effect }
     end
   end
 

--- a/app/controllers/user_rule_effects_controller.rb
+++ b/app/controllers/user_rule_effects_controller.rb
@@ -37,7 +37,7 @@ class UserRuleEffectsController < ApplicationController
       if @user_rule_effect.save
         format.json { render json: @user_rule_effect }
       else
-        format.json { render json: json_error_messages(@user_rule_effect.errors), status: :unprocessable_entity}
+        format.json { render json: json_error_messages(@user_rule_effect.errors), status: :unprocessable_entity }
       end
       format.html { respond_with @user_rule_effect, location: edit_workflow_user_rule_path(workflow, user_rule) }
     end

--- a/app/models/effects/add_subject_to_collection.rb
+++ b/app/models/effects/add_subject_to_collection.rb
@@ -15,7 +15,7 @@ module Effects
     end
 
     def collection_id
-      config.fetch("collection_id")
+      config.fetch('collection_id', nil)
     end
   end
 end

--- a/app/models/effects/add_subject_to_set.rb
+++ b/app/models/effects/add_subject_to_set.rb
@@ -17,7 +17,7 @@ module Effects
     end
 
     def subject_set_id
-      config.fetch("subject_set_id", nil)
+      config.fetch('subject_set_id', nil)
     end
 
     def self.was_duplicate(err)

--- a/app/models/effects/add_subject_to_set.rb
+++ b/app/models/effects/add_subject_to_set.rb
@@ -17,7 +17,7 @@ module Effects
     end
 
     def subject_set_id
-      config.fetch("subject_set_id")
+      config.fetch("subject_set_id", nil)
     end
 
     def self.was_duplicate(err)

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -99,16 +99,6 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
             expect(result['id']).to be(nil)
             expect(result['errors']).not_to be(nil)
           end
-
-          it 'redirects to subject rule in html mode when missing config' do
-            post :create, params: {
-              subject_rule_effect: { action: 'add_subject_to_set', config: {} },
-              workflow_id: workflow.id,
-              subject_rule_id: rule.id
-            }, format: :html
-
-            expect(response.status).to eq(200)
-          end
         end
       end
     end

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -108,7 +108,6 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
             }, format: :html
 
             expect(response.status).to eq(200)
-            expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
           end
         end
       end

--- a/spec/controllers/subject_rule_effects_controller_spec.rb
+++ b/spec/controllers/subject_rule_effects_controller_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
         it 'makes a new effect' do
           post :create, params: create_params, format: :json
-
-          expect(response.status).to eq(201)
+          expect(response.status).to eq(200)
           result = JSON.parse(response.body)
           expect(result['id']).not_to be(nil)
           expect(result['subject_rule_id']).to eq(rule.id)
@@ -77,7 +76,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
           it 'makes a new effect' do
             post :create, params: create_params, format: :json
 
-            expect(response.status).to eq(201)
+            expect(response.status).to eq(200)
             result = JSON.parse(response.body)
             expect(result['id']).not_to be(nil)
             expect(result['subject_rule_id']).to eq(rule.id)
@@ -85,6 +84,30 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
 
           it 'redirects to the subject rule in html mode' do
             post :create, params: create_params, format: :html
+            expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
+          end
+
+          it 'return 422 when missing config' do
+            post :create, params: {
+              subject_rule_effect: { action: 'add_subject_to_set', config: {} },
+              workflow_id: workflow.id,
+              subject_rule_id: rule.id
+            }, format: :json
+
+            expect(response.status).to eq(422)
+            result = JSON.parse(response.body)
+            expect(result['id']).to be(nil)
+            expect(result['errors']).not_to be(nil)
+          end
+
+          it 'redirects to subject rule in html mode when missing config' do
+            post :create, params: {
+              subject_rule_effect: { action: 'add_subject_to_set', config: {} },
+              workflow_id: workflow.id,
+              subject_rule_id: rule.id
+            }, format: :html
+
+            expect(response.status).to eq(200)
             expect(response).to redirect_to(edit_workflow_subject_rule_path(workflow, rule))
           end
         end
@@ -246,7 +269,7 @@ RSpec.describe SubjectRuleEffectsController, type: :controller do
       it 'makes a new effect' do
         post :create, params: {subject_rule_effect: {action: 'retire_subject', config: {}}, workflow_id: workflow.id, subject_rule_id: rule.id }, format: :json
 
-        expect(response.status).to eq(201)
+        expect(response.status).to eq(200)
         result = JSON.parse(response.body)
         expect(result["id"]).not_to be(nil)
         expect(result["subject_rule_id"]).to eq(rule.id)

--- a/spec/controllers/user_rule_effects_controller_spec.rb
+++ b/spec/controllers/user_rule_effects_controller_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe UserRuleEffectsController, type: :controller do
         post :create, params: {user_rule_effect: {action: 'promote_user', config: { workflow_id: 1234 }}, workflow_id: workflow.id, user_rule_id: rule.id }, format: :html
         expect(response).to redirect_to(edit_workflow_user_rule_path(workflow,rule))
       end
+
+      it 'returns 422 when incorrectly configured' do
+        post :create, params: { user_rule_effect: { action: 'promote_user' }, workflow_id: workflow.id, user_rule_id: rule.id }, format: :json
+
+        expect(response.status).to eq(422)
+        result = JSON.parse(response.body)
+        expect(result['id']).to be(nil)
+        expect(result['errors']).not_to be(nil)
+      end
     end
 
     describe "#update" do

--- a/spec/controllers/user_rule_effects_controller_spec.rb
+++ b/spec/controllers/user_rule_effects_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe UserRuleEffectsController, type: :controller do
       it 'makes a new effect' do
         post :create, params: {user_rule_effect: {action: 'promote_user', config: { workflow_id: 1234 }}, workflow_id: workflow.id, user_rule_id: rule.id }, format: :json
 
-        expect(response.status).to eq(201)
+        expect(response.status).to eq(200)
         result = JSON.parse(response.body)
         expect(result["id"]).not_to be(nil)
         expect(result["user_rule_id"]).to eq(rule.id)


### PR DESCRIPTION
Additions to https://github.com/zooniverse/caesar/pull/1360. Missed creation of rules and effects on initial go and  formatting json error responses to follow format of Panoptes. See https://github.com/zooniverse/panoptes-python-client/blob/d037716d8d9fe853aa67834eb382047e1fe038a6/panoptes_client/panoptes.py#L282 to L288. 