### PR TITLE
Add external effect with basic authentication HTTP headers

### DIFF
--- a/app/models/effects.rb
+++ b/app/models/effects.rb
@@ -20,6 +20,8 @@ module Effects
       Effects::PromoteUser
     when "external"
       Effects::External
+    when 'external_with_basic_auth'
+      Effects::ExternalWithBasicAuth
     else
       raise UnknownEffect, "Don't know what to do with #{effect_type}"
     end

--- a/app/models/effects/external.rb
+++ b/app/models/effects/external.rb
@@ -1,34 +1,28 @@
+# frozen_string_literal: true
+
 module Effects
   class External < Effect
     class ExternalEffectFailed < StandardError; end
     class InvalidConfiguration < StandardError; end
 
+    attr_reader :workflow_id, :subject_id
+
+    def self.config_fields
+      @config_fields ||= %i[url reducer_key].freeze
+    end
+
     def perform(workflow_id, subject_id)
+      @workflow_id = workflow_id
+      @subject_id = subject_id
+
       raise InvalidConfiguration unless valid?
+      raise ExternalEffectFailed, 'Incorrect number of reductions found' if reductions.length != 1
 
-      reductions = SubjectReduction.where(
-        workflow_id: workflow_id,
-        subject_id: subject_id,
-        reducer_key: reducer_key
-      )
-
-      if reductions.length != 1
-        raise ExternalEffectFailed, "Incorrect number of reductions found"
-      end
-
-      begin
-        response = RestClient.post(url, reductions.first.prepare.to_json, {content_type: :json, accept: :json})
-      rescue RestClient::InternalServerError
-        raise ExternalEffectFailed
-      end
+      post_payload_to_url
     end
 
     def valid?
       reducer_key.present? && url.present? && valid_url?
-    end
-
-    def self.config_fields
-      [:url, :reducer_key].freeze
     end
 
     def url
@@ -39,17 +33,37 @@ module Effects
       config[:reducer_key]
     end
 
+    private
+
+    def reductions
+      @reductions ||= SubjectReduction.where(
+        workflow_id: workflow_id,
+        subject_id: subject_id,
+        reducer_key: reducer_key
+      )
+    end
+
+    def reduction_payload
+      reductions.first.prepare.to_json
+    end
+
     def valid_url?
-      if url.present?
-        begin
-          uri = URI.parse(url)
-          uri && uri.host && uri.kind_of?(URI::HTTPS)
-        rescue URI::InvalidURIError
-          false
-        end
-      else
-        false
-      end
+      return false unless url.present?
+
+      uri = URI.parse(url)
+      uri&.host && uri.is_a?(URI::HTTPS)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def post_payload_to_url
+      RestClient.post(url, reduction_payload, post_request_headers)
+    rescue RestClient::InternalServerError
+      raise ExternalEffectFailed
+    end
+
+    def post_request_headers
+      { content_type: :json, accept: :json }
     end
   end
 end

--- a/app/models/effects/external_with_basic_auth.rb
+++ b/app/models/effects/external_with_basic_auth.rb
@@ -1,0 +1,56 @@
+module Effects
+  class ExternalWithBasicAuth < Effect
+    class ExternalEffectFailed < StandardError; end
+    class InvalidConfiguration < StandardError; end
+
+    def perform(workflow_id, subject_id)
+      raise InvalidConfiguration unless valid?
+
+      reductions = SubjectReduction.where(
+        workflow_id: workflow_id,
+        subject_id: subject_id,
+        reducer_key: reducer_key
+      )
+
+      if reductions.length != 1
+        raise ExternalEffectFailed, "Incorrect number of reductions found"
+      end
+
+      begin
+        response = RestClient.post(url, reductions.first.prepare.to_json, {content_type: :json, accept: :json})
+      rescue RestClient::InternalServerError
+        raise ExternalEffectFailed
+      end
+    end
+
+    def valid?
+      # TOD: this should not be valid unless the basic creds are in the config as well
+      reducer_key.present? && url.present? && valid_url?
+    end
+
+    def self.config_fields
+      [:url, :reducer_key].freeze
+    end
+
+    def url
+      config[:url]
+    end
+
+    def reducer_key
+      config[:reducer_key]
+    end
+
+    def valid_url?
+      if url.present?
+        begin
+          uri = URI.parse(url)
+          uri && uri.host && uri.kind_of?(URI::HTTPS)
+        rescue URI::InvalidURIError
+          false
+        end
+      else
+        false
+      end
+    end
+  end
+end

--- a/app/models/subject_rule_effect.rb
+++ b/app/models/subject_rule_effect.rb
@@ -1,7 +1,7 @@
 class SubjectRuleEffect < ApplicationRecord
   belongs_to :subject_rule
 
-  enum action: [:retire_subject, :add_subject_to_set, :add_subject_to_collection, :external]
+  enum action: %i[retire_subject add_subject_to_set add_subject_to_collection external external_with_basic_auth]
 
   validates :action, presence: true, inclusion: {in: SubjectRuleEffect.actions.keys}
   validate :valid_effect?

--- a/app/views/subject_rules/edit.html.erb
+++ b/app/views/subject_rules/edit.html.erb
@@ -12,6 +12,7 @@
     <li><%= link_to "Add to Subject Set", new_workflow_subject_rule_subject_rule_effect_path(@workflow, @subject_rule, action_type: 'add_subject_to_set') %></li>
     <li><%= link_to "Add to Collection", new_workflow_subject_rule_subject_rule_effect_path(@workflow, @subject_rule, action_type: 'add_subject_to_collection') %></li>
     <li><%= link_to "Send to External URL", new_workflow_subject_rule_subject_rule_effect_path(@workflow, @subject_rule, action_type: 'external') %></li>
+    <li><%= link_to "Send to External URL with Basic Auth", new_workflow_subject_rule_subject_rule_effect_path(@workflow, @subject_rule, action_type: 'external_with_basic_auth') %></li>
   </ul>
 </div>
 <table class="table table-striped table-sm">

--- a/spec/models/effects/external_with_basic_auth_spec.rb
+++ b/spec/models/effects/external_with_basic_auth_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Effects::ExternalWithBasicAuth do
+  # let(:subject) { create(:subject) }
+  # let(:reduction) { create(:subject_reduction, reducer_key: "key", subject: subject, data: {}) }
+  # let(:url) { "https://example.org/post/reduction/here" }
+  # let(:effect) { described_class.new(url: url, reducer_key: "key") }
+
+  # before do
+  #   stub_request(:post, url).to_return(status: 200, headers: {})
+  # end
+
+  # it 'sends the reductions to the external API' do
+  #   effect.perform(reduction.workflow_id, reduction.subject_id)
+  #   expect(a_request(:post, url).with(body: reduction.prepare.to_json))
+  #     .to have_been_made.once
+  # end
+
+  # it 'raises an error if more than one reduction is matched' do
+  #   new_reduction = create(:subject_reduction, reducible: reduction.reducible, subgroup: "lol", reducer_key: "key", subject: subject, data: {})
+
+  #   expect do
+  #     effect.perform(reduction.workflow_id, reduction.subject_id)
+  #   end.to raise_error(Effects::External::ExternalEffectFailed)
+  # end
+
+  # it 'raises an error if the post fails' do
+  #   stub_request(:post, url).to_return(status: 500, headers: {})
+
+  #   expect do
+  #     effect.perform(reduction.workflow_id, reduction.subject_id)
+  #   end.to raise_error(Effects::External::ExternalEffectFailed)
+  # end
+
+  # describe 'validations' do
+  #   it 'is not valid with a non-https url' do
+  #     effect = described_class.new(url: "http://foo.com")
+  #     expect(effect).not_to be_valid
+  #   end
+
+  #   it 'is not valid with some strange url' do
+  #     effect = described_class.new(url: "https:\\foo+3")
+  #     expect(effect).not_to be_valid
+  #   end
+
+  #   it 'raises an error if no key is specified' do
+  #     effect = described_class.new(url: url)
+
+  #     expect do
+  #       effect.perform(reduction.workflow_id, reduction.subject_id)
+  #     end.to raise_error(Effects::External::InvalidConfiguration)
+  #   end
+
+  #   it 'does not care about symbol keys' do
+  #     effect = described_class.new("url": "https://www.google.com")
+  #     expect(effect.url).not_to be(nil)
+  #     effect = described_class.new(url: "https://www.google.com")
+  #     expect(effect.url).not_to be(nil)
+  #   end
+
+  #   it 'does not post if no url is configured' do
+  #     effect = described_class.new(url: nil)
+
+  #     expect do
+  #       effect.perform(reduction.workflow_id, reduction.subject_id)
+  #     end.to raise_error(Effects::External::InvalidConfiguration)
+  #   end
+  # end
+end

--- a/spec/models/effects/external_with_basic_auth_spec.rb
+++ b/spec/models/effects/external_with_basic_auth_spec.rb
@@ -1,69 +1,99 @@
 require 'spec_helper'
 
 describe Effects::ExternalWithBasicAuth do
-  # let(:subject) { create(:subject) }
-  # let(:reduction) { create(:subject_reduction, reducer_key: "key", subject: subject, data: {}) }
-  # let(:url) { "https://example.org/post/reduction/here" }
-  # let(:effect) { described_class.new(url: url, reducer_key: "key") }
+  let(:subject) { create(:subject) }
+  let(:reduction) { create(:subject_reduction, reducer_key: "key", subject: subject, data: {}) }
+  let(:url) { 'https://example.org/post/reduction/here' }
+  let(:username) { 'sloan-api' }
+  let(:password) { 'sloan-api-password' }
+  let(:effect_config) { { url: url, reducer_key: "key", username: username, password: password } }
+  let(:effect) { described_class.new(effect_config) }
 
-  # before do
-  #   stub_request(:post, url).to_return(status: 200, headers: {})
-  # end
+  before do
+    stub_request(:post, url)
+      .with(
+        basic_auth: [username, password],
+        headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+      )
+      .to_return(status: 200, headers: {})
+  end
 
-  # it 'sends the reductions to the external API' do
-  #   effect.perform(reduction.workflow_id, reduction.subject_id)
-  #   expect(a_request(:post, url).with(body: reduction.prepare.to_json))
-  #     .to have_been_made.once
-  # end
+  it 'sends the reductions to the external API' do
+    effect.perform(reduction.workflow_id, reduction.subject_id)
+    expect(
+      a_request(:post, url).with(body: reduction.prepare.to_json)
+    ).to have_been_made.once
+  end
 
-  # it 'raises an error if more than one reduction is matched' do
-  #   new_reduction = create(:subject_reduction, reducible: reduction.reducible, subgroup: "lol", reducer_key: "key", subject: subject, data: {})
+  it 'raises an error if more than one reduction is matched' do
+    create(:subject_reduction, reducible: reduction.reducible, subgroup: 'lol', reducer_key: 'key', subject: subject, data: {})
+    expect do
+      effect.perform(reduction.workflow_id, reduction.subject_id)
+    end.to raise_error(Effects::ExternalWithBasicAuth::ExternalEffectFailed)
+  end
 
-  #   expect do
-  #     effect.perform(reduction.workflow_id, reduction.subject_id)
-  #   end.to raise_error(Effects::External::ExternalEffectFailed)
-  # end
+  it 'raises an error if the post fails' do
+    stub_request(:post, url)
+      .with(
+        basic_auth: [username, password],
+        headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+      )
+      .to_return(status: 500, headers: {})
 
-  # it 'raises an error if the post fails' do
-  #   stub_request(:post, url).to_return(status: 500, headers: {})
+    expect do
+      effect.perform(reduction.workflow_id, reduction.subject_id)
+    end.to raise_error(Effects::ExternalWithBasicAuth::ExternalEffectFailed)
+  end
 
-  #   expect do
-  #     effect.perform(reduction.workflow_id, reduction.subject_id)
-  #   end.to raise_error(Effects::External::ExternalEffectFailed)
-  # end
+  it 'does not post if no url is configured' do
+    effect = described_class.new(url: nil)
 
-  # describe 'validations' do
-  #   it 'is not valid with a non-https url' do
-  #     effect = described_class.new(url: "http://foo.com")
-  #     expect(effect).not_to be_valid
-  #   end
+    expect do
+      effect.perform(reduction.workflow_id, reduction.subject_id)
+    end.to raise_error(Effects::ExternalWithBasicAuth::InvalidConfiguration)
+  end
 
-  #   it 'is not valid with some strange url' do
-  #     effect = described_class.new(url: "https:\\foo+3")
-  #     expect(effect).not_to be_valid
-  #   end
+  describe 'config' do
+    it 'does not care about symbol keys' do
+      effect = described_class.new("url": "https://www.google.com")
+      expect(effect.url).not_to be(nil)
+      effect = described_class.new(url: "https://www.google.com")
+      expect(effect.url).not_to be(nil)
+    end
+  end
 
-  #   it 'raises an error if no key is specified' do
-  #     effect = described_class.new(url: url)
+  describe 'validations' do
+    it 'is invalid with a non-https url' do
+      effect_config[:url] = 'http://foo.com'
+      effect = described_class.new(effect_config)
+      expect(effect).not_to be_valid
+    end
 
-  #     expect do
-  #       effect.perform(reduction.workflow_id, reduction.subject_id)
-  #     end.to raise_error(Effects::External::InvalidConfiguration)
-  #   end
+    it 'is invalid with some strange url' do
+      effect_config[:url] = 'https:\\foo+3'
+      effect = described_class.new(effect_config)
+      expect(effect).not_to be_valid
+    end
 
-  #   it 'does not care about symbol keys' do
-  #     effect = described_class.new("url": "https://www.google.com")
-  #     expect(effect.url).not_to be(nil)
-  #     effect = described_class.new(url: "https://www.google.com")
-  #     expect(effect.url).not_to be(nil)
-  #   end
+    it 'raises an error if no key is specified' do
+      effect = described_class.new(effect_config.except(:reducer_key))
+      expect do
+        effect.perform(reduction.workflow_id, reduction.subject_id)
+      end.to raise_error(Effects::ExternalWithBasicAuth::InvalidConfiguration)
+    end
 
-  #   it 'does not post if no url is configured' do
-  #     effect = described_class.new(url: nil)
+    it 'raises an error if no username is specified' do
+      effect = described_class.new(effect_config.except(:username))
+      expect do
+        effect.perform(reduction.workflow_id, reduction.subject_id)
+      end.to raise_error(Effects::ExternalWithBasicAuth::InvalidConfiguration)
+    end
 
-  #     expect do
-  #       effect.perform(reduction.workflow_id, reduction.subject_id)
-  #     end.to raise_error(Effects::External::InvalidConfiguration)
-  #   end
-  # end
+    it 'raises an error if no password is specified' do
+      effect = described_class.new(effect_config.except(:password))
+      expect do
+        effect.perform(reduction.workflow_id, reduction.subject_id)
+      end.to raise_error(Effects::ExternalWithBasicAuth::InvalidConfiguration)
+    end
+  end
 end

--- a/spec/models/effects/external_with_basic_auth_spec.rb
+++ b/spec/models/effects/external_with_basic_auth_spec.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Effects::ExternalWithBasicAuth do
   let(:subject) { create(:subject) }
-  let(:reduction) { create(:subject_reduction, reducer_key: "key", subject: subject, data: {}) }
+  let(:reduction) { create(:subject_reduction, reducer_key: 'key', subject: subject, data: {}) }
   let(:url) { 'https://example.org/post/reduction/here' }
   let(:username) { 'sloan-api' }
   let(:password) { 'sloan-api-password' }
-  let(:effect_config) { { url: url, reducer_key: "key", username: username, password: password } }
+  let(:effect_config) { { url: url, reducer_key: 'key', username: username, password: password } }
   let(:effect) { described_class.new(effect_config) }
 
   before do
@@ -55,9 +57,9 @@ describe Effects::ExternalWithBasicAuth do
 
   describe 'config' do
     it 'does not care about symbol keys' do
-      effect = described_class.new("url": "https://www.google.com")
+      effect = described_class.new('url': 'https://www.google.com')
       expect(effect.url).not_to be(nil)
-      effect = described_class.new(url: "https://www.google.com")
+      effect = described_class.new(url: 'https://www.google.com')
       expect(effect.url).not_to be(nil)
     end
   end

--- a/spec/models/subject_rule_effect_spec.rb
+++ b/spec/models/subject_rule_effect_spec.rb
@@ -2,9 +2,29 @@ require 'rails_helper'
 
 RSpec.describe SubjectRuleEffect, type: :model do
   describe 'validations' do
-    it 'is invalid when config is wrong' do
-      rule_effect = build :subject_rule_effect, action: :retire_subject, config: {}
-      expect(rule_effect).not_to be_valid
+    let(:subject_rule) { build :subject_rule }
+    let(:subject_rule_effect) do
+      build :subject_rule_effect, subject_rule: subject_rule, action: :retire_subject, config: { 'reason' => 'classification_count' }
+    end
+
+    it 'is valid by default' do
+      expect(subject_rule_effect).to be_valid
+    end
+
+    it 'is invalid when config is incorrectly setup' do
+      subject_rule_effect.config = { 'reason' => '' }
+      expect(subject_rule_effect).not_to be_valid
+    end
+
+    describe 'external_with_basic_auth action' do
+      let(:config) { { url: 'https://example.com', reducer_key: 'my_reducer', username: '', password: '' } }
+      let(:subject_rule_effect) do
+        build :subject_rule_effect, subject_rule: subject_rule, action: :external_with_basic_auth, config: config
+      end
+
+      it 'allows external_with_basic_auth action type' do
+        expect(subject_rule_effect).to be_valid
+      end
     end
   end
 end

--- a/spec/models/subject_rule_effect_spec.rb
+++ b/spec/models/subject_rule_effect_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SubjectRuleEffect, type: :model do
     end
 
     describe 'external_with_basic_auth action' do
-      let(:config) { { url: 'https://example.com', reducer_key: 'my_reducer', username: '', password: '' } }
+      let(:config) { { url: 'https://example.com', reducer_key: 'my_reducer', username: 'user', password: 'pass' } }
       let(:subject_rule_effect) do
         build :subject_rule_effect, subject_rule: subject_rule, action: :external_with_basic_auth, config: config
       end


### PR DESCRIPTION
This PR adds a new subject rule effect called `external_with_basic_auth`. This new effect is the same as the external effect but instead of posting without any authorization headers this one will use the HTTP basic auth via the effect configuration params `username` and `password`.

The implementation of `Effects::ExternalWithBasicAuth` inherits from the existing `Effects::External` class behaviours but uses a different library (httparty) to POST the HTTP request with basic auth credentials. I chose inheritance as these two classes share a lot of behaviour and will most likely do so long term (should we need we can undo the inheritance and duplicate the code from the original `Effects::External`).

Finally - I refactored the `Effects::External` to allow for easier implementation of the inheriting class with what i feel is a slightly cleaner implementation but i left the interface alone so no spec changes on this class.