### PR TITLE
Copy commit_id.txt to /public in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ ADD ./Gemfile.lock /app/
 ENV PORT=80
 ARG RAILS_ENV=production
 ENV RAILS_ENV=$RAILS_ENV
-ARG REVISION=''
-ENV REVISION=$REVISION
 
 RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xargs -I % expr % - 1` && \
     if echo "development test" | grep -w "$RAILS_ENV"; then \
@@ -27,7 +25,7 @@ RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xa
 
 ADD ./ /app
 
-RUN (echo $REVISION > ./public/commit_id.txt)
+RUN (cp commit_id.txt ./public/commit_id.txt)
 RUN (cd /app && mkdir -p tmp/pids)
 RUN (cd /app && SECRET_KEY_BASE=1 bundle exec rails assets:precompile)
 


### PR DESCRIPTION
Caesar makes its commit_id.txt available via nginx from its /public folder. The shared workflow that builds and pushes Docker images puts it in the app root. This just adds a step in the Dockerfile to copy the file that the workflow creates to the /public folder so Caesar can use it.