### PR TITLE
Move commit file logic out of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN bundle config --global jobs `cat /proc/cpuinfo | grep processor | wc -l | xa
 
 ADD ./ /app
 
-RUN (cp commit_id.txt ./public/commit_id.txt)
 RUN (cd /app && mkdir -p tmp/pids)
 RUN (cd /app && SECRET_KEY_BASE=1 bundle exec rails assets:precompile)
 

--- a/docker/start-puma.sh
+++ b/docker/start-puma.sh
@@ -3,6 +3,9 @@
 # ensure we stop on error (-e) and log cmds (-x)
 set -ex
 
+# Copy commit_id.txt to the public folder or create default
+[ -f ./commit_id.txt ] && cp ./commit_id.txt ./public/commit_id.txt || echo "asdf123" > ./public/commit_id.txt
+
 mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid
 


### PR DESCRIPTION
Assuming the commit_id.txt file exists breaks building the image locally, since it's created by an action on deploy. This moves the associated logic of checking for the file's existence and copying it into the ./public folder (or creating it if it doesn't exist) from the Dockerfile and into the puma start script.