### PR TITLE
improve reducer UI form behaviours

### DIFF
--- a/app/views/reducers/_form.html.erb
+++ b/app/views/reducers/_form.html.erb
@@ -32,11 +32,12 @@
     <div class="panel-body collapse" id="filterInputs">
       <p>Using filters it is possible to limit which extracts this reducer works on.</p>
       <%= f.simple_fields_for :filters do |filters| %>
-        <%= filters.input :from %>
-        <%= filters.input :to %>
-        <%= filters.input :extractor_keys, placeholder: '["list", "of", "keys"]' %>
-        <%= filters.input :repeated_classifications, collection: ::Filters::FilterByRepeatedness::REPEATED_CLASSIFICATIONS %>
-        <%= filters.input :training_behavior, collection: ::Filters::FilterByTrainingBehavior::TRAINING_BEHAVIOR %>
+        <%= filters.input :from, input_html: { value: @reducer.filters['from'] } %>
+        <%= filters.input :to, input_html: { value: @reducer.filters['to'] } %>
+        <%= filters.input :extractor_keys, placeholder: '["list", "of", "keys"]', input_html: { value: @reducer.filters['extractor_keys'].to_s } %>
+        <%= filters.input :repeated_classifications, collection: ::Filters::FilterByRepeatedness::REPEATED_CLASSIFICATIONS, selected: @reducer.filters['repeated_classifications'] %>
+        <%= filters.input :empty_extracts, collection: ::Filters::FilterByEmptiness::EMPTY_EXTRACTS, selected: @reducer.filters['empty_extracts'] %>
+        <%= filters.input :training_behavior, collection: ::Filters::FilterByTrainingBehavior::TRAINING_BEHAVIOR, selected: @reducer.filters['training_behavior'] %>
       <% end %>
     </div>
   </div>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -35,6 +35,8 @@ en:
         to: "Counts based on classifications in chronological order. Zero-based. A value of 2 would ignore all classifications after the first two for a subject. Supports negative numbers, which count from the end, such that -2 would ignore the last classification, and -1 (default) will not ignore any classifications. When using negative numbers, keep in mind that the meaning of 'the last classification' changes when another classification is made."
         extractor_keys: "Whitelist of keys of extractors. Ignores extracts from non-whitelisted extractors. Does nothing if left completely empty."
         repeated_classifications: "What to do when a user makes multiple classifications for a subject. Usually you'll want to ensure that classifications are made independently without prior knowledge, so the default is to keep the first classification made, and ignore others from that user (per subject)."
+        empty_extracts: "Choose keep_all to use all known the extracts or ignore_empty to include only include extracts that have data."
+        training_behavior: "Choose to ignore any training subjects or include only training subjects. Experimental - Use experiment_only for rejecting all training subjects."
     # hints:
     #   defaults:
     #     username: 'User name to sign in.'


### PR DESCRIPTION
This PR adds the `empty_extracts` filter to the UI form - this will allow the reducer to include or ignore extracts with empty data payloads created when the classification annotations don't have the task key.

Also this PR fixes the existing filter form behaviour to ensure that all existing filter inputs are preserved, displayed properly and available for form re-submission to avoid clobbering this field on update action.