### PR TITLE
add reject option for missing task key extracts

### DIFF
--- a/app/models/extractors/question_extractor.rb
+++ b/app/models/extractors/question_extractor.rb
@@ -3,35 +3,37 @@ module Extractors
     class MissingAnnotation < StandardError; end
 
     config_field :task_key, default: 'T0'
-    config_field :if_missing, enum: ['error', 'ignore'], default: 'error'
+    config_field :if_missing, enum: %w[error ignore reject], default: 'error'
 
     def extract_data_for(classification)
-      CountingHash.build do |result|
-        fetch_annotations(classification).each do |annotation|
-          value = annotation.fetch("value")
+      extracted_annotations = classification.annotations.fetch(task_key) do |_missing_key|
+        case if_missing
+        when 'error'
+          raise MissingAnnotation, "No annotations for task #{task_key}"
+        when 'ignore'
+          []
+        when 'reject'
+          return Extractor::NoData # return NoData class here to avoid saving an extract in `runs_extractors` class
+        else
+          raise e # unknown error - ensure this is raised for visibility
+        end
+      end
 
-          case value
-          when Array
+      count_extract_answers(extracted_annotations)
+    end
+
+    private
+
+    def count_extract_answers(annotations)
+      CountingHash.build do |result|
+        annotations.each do |annotation|
+          value = annotation.fetch('value')
+          if value.is_a?(Array)
             value.each { |key| result.increment(key) }
           else
             result.increment(value)
           end
         end
-      end
-    end
-
-    private
-
-    def fetch_annotations(classification)
-      classification.annotations.fetch(task_key)
-    rescue KeyError => ex
-      case if_missing
-      when "error"
-        raise MissingAnnotation, "No annotations for task #{task_key}"
-      when "ignore"
-        []
-      else
-        raise ex
       end
     end
   end

--- a/spec/models/extractors/question_extractor_spec.rb
+++ b/spec/models/extractors/question_extractor_spec.rb
@@ -32,20 +32,23 @@ describe Extractors::QuestionExtractor do
       expect(extractor.process(classification)).to eq({"0" => 1, "1" => 1})
     end
 
-    it 'errors if annotations are missing' do
-      annotations = []
-      classification = Classification.new("annotations" => annotations, "links" => {"workflow" => "1021"})
+    context 'when the task key annotations are missing' do
+      let(:classification) do
+        Classification.new('annotations' => [], 'links' => { 'workflow' => '1021' })
+      end
+      it 'raises an error' do
+        expect { extractor.process(classification) }.to raise_error(described_class::MissingAnnotation)
+      end
 
-      expect { extractor.process(classification) }.to raise_error(described_class::MissingAnnotation)
-    end
+      it 'returns nothing when configured to ignore' do
+        extractor = described_class.new(config: { 'if_missing' => 'ignore' })
+        expect(extractor.process(classification)).to eq({})
+      end
 
-    it 'returns nothing if annotations are missing when configured' do
-      annotations = []
-      classification = Classification.new("annotations" => annotations, "links" => {"workflow" => "1021"})
-
-      extractor = described_class.new(config: {"if_missing" => "ignore"})
-      expect(extractor.process(classification)).to eq({})
+      it 'returns NoData when configured to reject' do
+        extractor = described_class.new(config: { 'if_missing' => 'reject' })
+        expect(extractor.process(classification)).to eq(Extractor::NoData)
+      end
     end
   end
-
 end


### PR DESCRIPTION
This PR updates the `QuestionExtractor` class to add the `reject` behaviour for `if_missing` task key lookups. This reject behaviour will avoid saving extracts with empty payloads when the classification annotation payload doesn't contain the task key.

This behaviour can be used for branching decision trees that create classification when not all worfklow task annotations are in the payload and thus it will avoid saving empty extract data in the db and thus triggering reduction processing which is pointless and may create incorrect reduction results say for a count reducer (which counts missing task_key data as present)

This relies on the way runs_extractors processes `NoData` results, i.e. https://github.com/zooniverse/caesar/blob/f7b1f1814ab327f203717b8c10fad8ebca2ae5a7/app/models/runs_extractors.rb#L36 will avoid saving the extract and has precedent in the HTTP extractor system to avoid saving no results - https://github.com/zooniverse/caesar/blob/68b50a8c4eec11981de6f433e1cb0a559fe6981c/app/models/extractors/http_extraction.rb#L11

Noting that this will not the default option but will be opt in behaviour to preserve the current suite of raise and ignore (save empty extract data) that for extractors in the wild.