### PR TITLE
update panoptes-client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     msgpack (1.5.1)
     multi_json (1.13.1)
     multi_xml (0.6.0)
-    multipart-post (2.1.1)
+    multipart-post (2.2.0)
     netrc (0.11.0)
     newrelic_rpm (8.8.0)
     nio4r (2.5.8)
@@ -189,7 +189,7 @@ GEM
       omniauth (~> 1.2)
     omniauth-zooniverse (0.0.4)
       omniauth-oauth2 (= 1.3.1)
-    panoptes-client (1.1.0)
+    panoptes-client (1.1.1)
       deprecate
       faraday
       faraday-panoptes (~> 0.3.0)


### PR DESCRIPTION
closes #1357 - use the latest panoptes client to avoid skipping the first page of data results.