### PR TITLE
increase cpu and ram limits - avoid OOM

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -73,11 +73,11 @@ spec:
           image: ghcr.io/zooniverse/caesar:__IMAGE_TAG__
           resources:
             requests:
-              memory: "300Mi"
+              memory: "500Mi"
               cpu: "250m"
             limits:
-              memory: "500Mi"
-              cpu: "500m"
+              memory: "1500Mi"
+              cpu: "1000m"
           livenessProbe:
             httpGet:
               path: /
@@ -278,7 +278,7 @@ spec:
               memory: "500Mi"
               cpu: "250m"
             limits:
-              memory: "750Mi"
+              memory: "1500Mi"
               cpu: "1000m"
           args: ["/app/docker/start-sidekiq.sh"]
           env:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -76,7 +76,7 @@ spec:
               memory: "300Mi"
               cpu: "200m"
             limits:
-              memory: "500Mi"
+              memory: "1000Mi"
               cpu: "500m"
           livenessProbe:
             httpGet:
@@ -264,8 +264,8 @@ spec:
               memory: "300Mi"
               cpu: "200m"
             limits:
-              memory: "500Mi"
-              cpu: "500m"
+              memory: "1000Mi"
+              cpu: "1000m"
           args: ["/app/docker/start-sidekiq.sh"]
           env:
             - name: RAILS_ENV


### PR DESCRIPTION
closes #1403 - increase the pod RAM limits to avoid OOM errors and allow CPU to burst to 1vCPU