### PR TITLE
remove nodejs post asset build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ ADD ./ /app
 RUN (cd /app && mkdir -p tmp/pids)
 RUN (cd /app && SECRET_KEY_BASE=1 bundle exec rails assets:precompile)
 
+# remove the node JS installation
+RUN apt-get purge -y --auto-remove nodejs
+
 EXPOSE 80
 
 CMD ["/app/docker/start-puma.sh"]


### PR DESCRIPTION
closes #1084 - remove nodejs post build as it's only needed to build the assets as we don't use the node server runtime