### PR TITLE
Revert "remove nodejs post asset build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,6 @@ ADD ./ /app
 RUN (cd /app && mkdir -p tmp/pids)
 RUN (cd /app && SECRET_KEY_BASE=1 bundle exec rails assets:precompile)
 
-# remove the node JS installation
-RUN apt-get purge -y --auto-remove nodejs
-
 EXPOSE 80
 
 CMD ["/app/docker/start-puma.sh"]


### PR DESCRIPTION
Reverts zooniverse/caesar#1412 - our app still needs the execjs runtime available due to the gemfile including libs like uglifier on boot. This can be solved by a custom gemfile grouping I can't be bothered to fix this now.