### PR TITLE
turn off sidekiq app logging in new relic

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -319,6 +319,8 @@ spec:
               value: Caesar
             - name: NEW_RELIC_MONITOR_MODE
               value: 'true'
+            - name: NEW_RELIC_APPLICATION_LOGGING_ENABLED
+              value: 'false'
             - name: NEW_RELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
@@ -437,6 +439,8 @@ spec:
                   key: AWS_SECRET_ACCESS_KEY
             - name: NEW_RELIC_APP_NAME
               value: Caesar
+            - name: NEW_RELIC_APPLICATION_LOGGING_ENABLED
+              value: 'false'
             - name: NEW_RELIC_MONITOR_MODE
               value: 'true'
             - name: NEW_RELIC_LICENSE_KEY

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -300,6 +300,8 @@ spec:
               value: Caesar (staging)
             - name: NEW_RELIC_MONITOR_MODE
               value: 'true'
+            - name: NEW_RELIC_APPLICATION_LOGGING_ENABLED
+              value: 'false'
             - name: NEW_RELIC_LICENSE_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
avoid ingesting the sidekiq job logs in new relic and keep the ingest data rate lower to come under our free tier budget (1000GB)