### PR TITLE
log caesar app to stdout

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -97,6 +97,8 @@ spec:
           env:
             - name: RAILS_ENV
               value: production
+            - name: RAILS_LOG_TO_STDOUT
+              value: true
             - name: PORT
               value: "81"
             - name: RAILS_SERVE_STATIC_FILES

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -97,6 +97,8 @@ spec:
           env:
             - name: RAILS_ENV
               value: staging
+            - name: RAILS_LOG_TO_STDOUT
+              value: true
             - name: REDIS_URL
               value: redis://caesar-staging-redis:6379
             - name: PORT


### PR DESCRIPTION
currently caesar app is writing to a log file on the temp FS and it get really big, most likely leading to unusual failures if the node runs out of disk space. 

This PR instead changes the caesar app to log to STDOUT instead via the ENV directive setup in staging and production configs. 

Note: this isn't needed for sidekiq pods as sidekiq always logs to stdout, https://github.com/mperham/sidekiq/wiki/Logging#logger