### PR TITLE
ensure the true env value is treated as a string

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -98,7 +98,7 @@ spec:
             - name: RAILS_ENV
               value: production
             - name: RAILS_LOG_TO_STDOUT
-              value: true
+              value: 'true'
             - name: PORT
               value: "81"
             - name: RAILS_SERVE_STATIC_FILES

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -98,7 +98,7 @@ spec:
             - name: RAILS_ENV
               value: staging
             - name: RAILS_LOG_TO_STDOUT
-              value: true
+              value: 'true'
             - name: REDIS_URL
               value: redis://caesar-staging-redis:6379
             - name: PORT


### PR DESCRIPTION
follow up PR to #1444 - ensure the ENV var values are treated as text and not a boolean when parsing the k8s YAML 