### PR TITLE
add order by classification date for repeated classifications filter and adding appropriate test

### DIFF
--- a/app/models/filters/filter_by_repeatedness.rb
+++ b/app/models/filters/filter_by_repeatedness.rb
@@ -6,18 +6,18 @@ module Filters
     validates :repeated_classifications, inclusion: {in: REPEATED_CLASSIFICATIONS}
 
     def apply(extract_groups)
+      ordered_extract_groups = extract_groups.sort_by(&:classification_at)
       case repeated_classifications
       when "keep_all"
         extract_groups
       when "keep_first"
-        keep_first_classification(extract_groups)
+        keep_first_classification(ordered_extract_groups)
       when "keep_last"
-        keep_first_classification(extract_groups.reverse).reverse
+        keep_first_classification(ordered_extract_groups.reverse).reverse
       end
     end
 
     private
-
     def keep_first_classification(extracts)
       subjects ||= Hash.new
 

--- a/spec/models/filters/filter_by_repeatedness_spec.rb
+++ b/spec/models/filters/filter_by_repeatedness_spec.rb
@@ -41,18 +41,17 @@ describe Filters::FilterByRepeatedness do
     describe 'set to keep first' do
       it 'keeps the first classification for a given user' do
         extracts = [
-          Extract.new(id: 1, classification_id: 1, user_id: 1, extractor_key: "a"),
-          Extract.new(id: 2, classification_id: 1, user_id: 1, extractor_key: "b"),
-          Extract.new(id: 3, classification_id: 2, user_id: 2, extractor_key: "a"),
-          Extract.new(id: 4, classification_id: 2, user_id: 2, extractor_key: "b"),
-          Extract.new(id: 5, classification_id: 3, user_id: 1, extractor_key: "a"),
-          Extract.new(id: 6, classification_id: 3, user_id: 1, extractor_key: "b")
+          Extract.new(id: 1, classification_id: 1, user_id: 1, extractor_key: 'a', classification_at:(Time.now - 1.minute)),
+          Extract.new(id: 2, classification_id: 1, user_id: 1, extractor_key: 'b', classification_at:(Time.now - 1.minute)),
+          Extract.new(id: 3, classification_id: 2, user_id: 2, extractor_key: 'a', classification_at:(Time.now - 1.minute)),
+          Extract.new(id: 4, classification_id: 2, user_id: 2, extractor_key: 'b',  classification_at:(Time.now - 1.minute)),
+          Extract.new(id: 5, classification_id: 3, user_id: 1, extractor_key: 'a',  classification_at:(Time.now - 2.minute)),
+          Extract.new(id: 6, classification_id: 3, user_id: 1, extractor_key: 'b', classification_at:(Time.now - 2.minute))
         ]
         extract_groups = ExtractsForClassification.from(extracts)
-
         filter = described_class.new(repeated_classifications: "keep_first")
         result = filter.apply(extract_groups).flat_map(&:extracts)
-        expect(result).to eq(extracts[0..3])
+        expect(result).to match_array(extracts[2..5])
       end
 
       it 'keeps repeated anonymous classifications' do


### PR DESCRIPTION
This is a follow up on https://zooniverse.slack.com/archives/C0DTP3L2K/p1664915116374429

It seems `FilterByRepeatedness` expects extracts to already be of a certain order when going through the filter. Searching on queries created, it does not look like we are sorting by anything. (Possibly we were relying on incremental ids relating to classification timeline? thats a guess though)

In the case of `FilterByRepeatedness`, we can order by an extracts `classification_at` time to only keep a user's first classification or last classification (depending on reducer's `filter_config`). We do this in `FilterByRepeatedness` to "isolate" the change since extracts that go through any Filter are coming from the same extracts query. 

Q: Is there a chance `classification_at` will ever be null? 
A: No. Per schema https://github.com/zooniverse/caesar/blob/e9c4293b9928be54827b5c99454ee3961296e9a1/db/schema.rb#L73 we do not allow this. Extracts will come from classifications which will have a `classification_at` timestamp. In the case of ML extracts. `ImportMLExtractWorker` also sets `classification_at` as the time of ML extract upload https://github.com/zooniverse/caesar/blob/e9c4293b9928be54827b5c99454ee3961296e9a1/app/workers/import_ml_data_worker.rb#L66. 
