### PR TITLE
Where syntax on exists queries

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -42,7 +42,7 @@ class ProjectsController < ApplicationController
 
     panoptes_project = Effects.panoptes.project(project_id) || { id: project_id, display_name: 'New Project' }
 
-    if Project.exists?(project_id)
+    if Project.where(id: project_id).exists?
       flash[:alert] = "Project already exists"
       redirect_to Project.find(project_id) and return
     end

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -50,7 +50,7 @@ class WorkflowsController < ApplicationController
       return
     end
 
-    if Workflow.exists?(workflow_id)
+    if Workflow.where(id: workflow_id).exists?
       flash[:alert] = "Workflow already exists"
       redirect_to Workflow.find(workflow_id) and return
     end


### PR DESCRIPTION
avoid using id params directly in exists query instead use the the where syntax for proper query escaping