### PR TITLE
Add db statement timeouts

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,9 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("DATABASE_POOL_SIZE") { 4 }.to_i %>
+  variables:
+    # default 30s for the DB query exectution - override this via env vars
+    statement_timeout: <%= ENV.fetch('PG_STATEMENT_TIMEOUT', 30000).to_i %>
 development:
   <<: *default
   database: caesar_development

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -284,6 +284,8 @@ spec:
               cpu: "1000m"
           args: ["/app/docker/start-sidekiq.sh"]
           env:
+            - name: PG_STATEMENT_TIMEOUT
+              value: '60000'
             - name: RAILS_ENV
               value: production
             - name: RAILS_SERVE_STATIC_FILES
@@ -406,6 +408,8 @@ spec:
               cpu: "1000m"
           args: ["/app/docker/start-sidekiq.sh"]
           env:
+            - name: PG_STATEMENT_TIMEOUT
+              value: '60000'
             - name: RAILS_ENV
               value: production
             - name: RAILS_SERVE_STATIC_FILES

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -270,6 +270,8 @@ spec:
               cpu: "1000m"
           args: ["/app/docker/start-sidekiq.sh"]
           env:
+            - name: PG_STATEMENT_TIMEOUT
+              value: '60000'
             - name: RAILS_ENV
               value: staging
             - name: REDIS_URL


### PR DESCRIPTION
Avoid long running queries blocking db work** instead time these out at 60s and set a default API timeout at 30s. These values are configurable via env vars and the default value in `config/database.yml`

** this appears to be the issue with PH Tess workers when concurrently trying to save the same user skill records, there is lock contention in the db. 