### PR TITLE
remove db statement timeouts from migration jobs

### DIFF
--- a/kubernetes/db-migrate-production.tmpl
+++ b/kubernetes/db-migrate-production.tmpl
@@ -12,6 +12,8 @@ spec:
         image: ghcr.io/zooniverse/caesar:__IMAGE_TAG__
         command: ["bundle",  "exec", "rails", "db:migrate"]
         env:
+        - name: PG_STATEMENT_TIMEOUT
+          value: '0'
         - name: RAILS_ENV
           value: production
         - name: PORT

--- a/kubernetes/db-migrate-staging.tmpl
+++ b/kubernetes/db-migrate-staging.tmpl
@@ -12,6 +12,8 @@ spec:
         image: ghcr.io/zooniverse/caesar:__IMAGE_TAG__
         command: ["bundle",  "exec", "rails", "db:migrate"]
         env:
+        - name: PG_STATEMENT_TIMEOUT
+          value: '0'
         - name: RAILS_ENV
           value: staging
         - name: REDIS_URL


### PR DESCRIPTION
we want these to run for perhaps a very long time so set the statment timeout to 0, https://www.postgresql.org/docs/11/runtime-config-client.html

> Abort any statement that takes more than the specified number of milliseconds, starting from the time the command arrives at the server from the client. If log_min_error_statement is set to ERROR or lower, the statement that timed out will also be logged. A value of zero (the default) turns this off.
