### PR TITLE
Increase sidekiq timeout to 120s

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -285,7 +285,7 @@ spec:
           args: ["/app/docker/start-sidekiq.sh"]
           env:
             - name: PG_STATEMENT_TIMEOUT
-              value: '60000'
+              value: '120000'
             - name: RAILS_ENV
               value: production
             - name: RAILS_SERVE_STATIC_FILES
@@ -409,7 +409,7 @@ spec:
           args: ["/app/docker/start-sidekiq.sh"]
           env:
             - name: PG_STATEMENT_TIMEOUT
-              value: '60000'
+              value: '120000'
             - name: RAILS_ENV
               value: production
             - name: RAILS_SERVE_STATIC_FILES

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -271,7 +271,7 @@ spec:
           args: ["/app/docker/start-sidekiq.sh"]
           env:
             - name: PG_STATEMENT_TIMEOUT
-              value: '60000'
+              value: '120000'
             - name: RAILS_ENV
               value: staging
             - name: REDIS_URL


### PR DESCRIPTION
To keep consistency with aggregations (see https://github.com/zooniverse/aggregation-for-caesar/pull/312), the sidekiq timeout is increased to 120s to ensure long-running jobs are able to finish.