### PR TITLE
Extractor creation/editing minimum workflow version fix

### DIFF
--- a/app/models/extractor.rb
+++ b/app/models/extractor.rb
@@ -1,5 +1,6 @@
 class Extractor < ApplicationRecord
   include Configurable
+  validates :minimum_workflow_version, numericality: true, allow_nil: true
 
   class ExtractionFailed < StandardError; end
 

--- a/app/views/extractors/_form.html.erb
+++ b/app/views/extractors/_form.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   <% end %>
 
-  <%= f.input :minimum_workflow_version %>
+  <%= f.input :minimum_workflow_version, as: :float%>
 
   <%= f.submit class: 'btn btn-primary' %>
   <%= link_to 'Back', workflow_path(@workflow, anchor: 'extractors'), class: 'btn btn-default' %>

--- a/app/views/workflows/_extractors.html.erb
+++ b/app/views/workflows/_extractors.html.erb
@@ -43,7 +43,7 @@
         <td><%= extractor.key %></td>
         <td><%= extractor.class.to_s.demodulize %></td>
         <td class="params-column"><%= render_hash extractor.config, "No Configuration" %></td>
-        <td><%= extractor.minimum_workflow_version || "any" %></td>
+        <td><%= extractor.minimum_workflow_version || "" %></td>
         <td style="text-align: center;">
           <%= link_to [:edit, @workflow, extractor.becomes(Extractor)] do %>
             <i class="glyphicon glyphicon-cog text-warning"></i>

--- a/spec/models/extractor_spec.rb
+++ b/spec/models/extractor_spec.rb
@@ -44,6 +44,23 @@ describe Extractor do
     )
   end
 
+  describe 'minimum_workflow_version' do
+    it 'disallows letters for min_workflow_version' do
+      extractor = build :extractor, minimum_workflow_version: 'any', workflow: workflow
+      expect(extractor).to_not be_valid
+    end
+
+    it 'allows numerics for min_workflow_version' do
+      extractor = build :extractor, minimum_workflow_version: '1.8', workflow: workflow
+      expect(extractor).to be_valid
+    end
+
+    it 'allows nil for min_workflow_version' do
+      extractor = build :extractor, workflow: workflow
+      expect(extractor).to be_valid
+    end
+  end
+
   describe '#process' do
     it 'processes normally when nothing is changed' do
       extractor = build :extractor, key: 'r'

--- a/spec/models/extractor_spec.rb
+++ b/spec/models/extractor_spec.rb
@@ -50,8 +50,13 @@ describe Extractor do
       expect(extractor).to_not be_valid
     end
 
-    it 'allows numerics for min_workflow_version' do
+    it 'allows string of numbers for min_workflow_version' do
       extractor = build :extractor, minimum_workflow_version: '1.8', workflow: workflow
+      expect(extractor).to be_valid
+    end
+
+    it 'allows numerics for min_workflow_version' do
+      extractor = build :extractor, minimum_workflow_version: 3.14, workflow: workflow
       expect(extractor).to be_valid
     end
 


### PR DESCRIPTION
Related to issue: https://github.com/zooniverse/caesar/issues/1188

### Changes: 
- On Extractor/s list view display Min Workflow Ver as "" if nil 
![Screen Shot 2023-01-04 at 1 37 13 PM](https://user-images.githubusercontent.com/30220346/210635515-1a535ce8-151e-4cce-bc9c-3d6d56d17aa4.png)
- Only allow numerics (video of me trying to type in letters for workflow version)
https://user-images.githubusercontent.com/30220346/210635830-f80155be-bd04-4de4-8a79-ad84787f5df7.mov
- Add validation on extractors model to allow nil or numerics (numeric strings are fine too)

### Weird Issue (FIrefox and possible IE) 
- form input on Firefox allows letters  to be typed (but will save these with min_workflow_version of nil). Validation is not displayed because the extractor is saved (with nil min_workflow_version, but not whatever typed letters were). 
https://user-images.githubusercontent.com/30220346/210636925-ffc4c38a-c072-4f11-b4f9-db1afeec243c.mov

^ I dont have a solution for this, but IMO not a deal breaker to get this merged.

