### PR TITLE
False is valid, but not present

### DIFF
--- a/app/models/exporters/csv_exporter.rb
+++ b/app/models/exporters/csv_exporter.rb
@@ -49,7 +49,8 @@ module Exporters
     private
 
     def format_item(item)
-      return '' unless item.present?
+      # `false` is a valid value here but it's not #present?
+      return '' unless item.present? || item.class == FalseClass
 
       case item
       when Integer, Float, String, TrueClass, FalseClass, DateTime, ActiveSupport::TimeWithZone


### PR DESCRIPTION
`false` is a valid value for data within a reduction, e.g. `level_up` in an external user reduction. But when false is present as a value, it still isn't #present?, so it needs to be separately excluded from the short circuit return. I'm guessing this line is intended to truncate blank strings, and since this functionality isn't tested, I'm going with the simplest fix.