### PR TITLE
Update panoptes-client dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'sidekiq-logstash'
 gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-ui'
-gem 'panoptes-client', '~> 1.1'
+gem 'panoptes-client', '~> 1.2'
 gem 'lograge'
 gem 'logstash-event'
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,10 +193,10 @@ GEM
       omniauth (~> 1.2)
     omniauth-zooniverse (0.0.4)
       omniauth-oauth2 (= 1.3.1)
-    panoptes-client (1.1.1)
+    panoptes-client (1.2.1)
       deprecate
       faraday
-      faraday-panoptes (~> 0.3.0)
+      faraday-panoptes (~> 0.3)
       jwt (~> 1.5.0)
     parallel (1.19.1)
     parser (2.7.1.2)
@@ -398,7 +398,7 @@ DEPENDENCIES
   newrelic_rpm
   omniauth
   omniauth-zooniverse
-  panoptes-client (~> 1.1)
+  panoptes-client (~> 1.2)
   pg (~> 1.3)
   pry-byebug
   pry-rails


### PR DESCRIPTION
Updates the panoptes-client.rb dependency to 1.2.1. This fixes workflow promotion, and includes the 1.2 bump that relaxed the Faraday gem version restriction. 