### PR TITLE
prevent halted workflows from processing classifications

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -9,6 +9,8 @@ class WorkflowsController < ApplicationController
 
   def show
     authorize workflow
+    @paused_confirmation = 'Temporarily stops processing. When unpaused, workflow will pick up from where it left off. Use for temporary interruptions while editing configurations and/or fixing problems'
+    @halt_confirmation = 'Halts processing and intake of classifications, equivalent to case where workflow does not exist on Caesar. When resumed, workflow will start processing classifications from that point forward, but all classifications submitted when halted are ignored. Use for long-term interruptions when Caesar should ignore incoming data.'
     @summary = WorkflowSummary.new(workflow)
     respond_with @workflow
   end

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -88,7 +88,7 @@ class WorkflowsController < ApplicationController
 
       if workflow.active?
         flash[:notice] = 'Resuming workflow' if was_paused || was_halted
-        UnpauseWorkflowWorker.perform_async(workflow.id) if was_paused && !was_halted
+        UnpauseWorkflowWorker.perform_async(workflow.id) if was_paused
       end
 
       if !was_paused && workflow.paused?

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -86,9 +86,9 @@ class WorkflowsController < ApplicationController
 
       workflow.update(workflow_params)
 
-      if (was_paused || was_halted) && workflow.active?
-        UnpauseWorkflowWorker.perform_async workflow.id
-        flash[:notice] = 'Resuming workflow'
+      if workflow.active?
+        flash[:notice] = 'Resuming workflow' if was_paused || was_halted
+        UnpauseWorkflowWorker.perform_async(workflow.id) if was_paused && !was_halted
       end
 
       if !was_paused && workflow.paused?

--- a/app/models/stream_events/classification_event.rb
+++ b/app/models/stream_events/classification_event.rb
@@ -32,7 +32,7 @@ module StreamEvents
 
     def enabled?
       Rails.cache.fetch("workflows/#{workflow_id}/enabled?", expires_in: 5.minutes) do
-        workflow.present?
+        workflow.present? && !workflow.halted?
       end
     end
 

--- a/app/views/workflows/_settings.html.erb
+++ b/app/views/workflows/_settings.html.erb
@@ -28,7 +28,9 @@
   <p class="pull-right">&nbsp;</p>
   <%= simple_form_for(@workflow, url: [@workflow]) do |f| %>
     <%= f.hidden_field :status, :value => 'halted' %>
-    <%= f.button :button, class: 'btn btn-default pull-right' do %>
+    <%= f.button :button, class: 'btn btn-default pull-right',
+    title: @halt_confirmation,
+    data: { confirm: @halt_confirmation } do %>
       <span class="glyphicon glyphicon-stop"></span> Halt Workflow
     <% end %>
   <% end %>
@@ -38,7 +40,9 @@
   <p class="pull-right">&nbsp;</p>
   <%= simple_form_for(@workflow, url: [@workflow]) do |f| %>
     <%= f.hidden_field :status, :value => 'paused' %>
-    <%= f.button :button, class: 'btn btn-default pull-right' do %>
+    <%= f.button :button, class: 'btn btn-default pull-right',
+        title: @paused_confirmation,
+        data: { confirm: @paused_confirmation} do %>
       <span class="glyphicon glyphicon-pause"></span> Pause Workflow
     <% end %>
   <% end %>

--- a/spec/models/stream_events/classification_event_spec.rb
+++ b/spec/models/stream_events/classification_event_spec.rb
@@ -50,6 +50,13 @@ describe StreamEvents::ClassificationEvent do
         described_class.new(stream, hash).process
         expect(queue).not_to have_received(:add)
       end
+
+      it 'does not upsert a classification when the workflow is halted' do
+        workflow.halted!
+        expect(Classification).not_to receive(:upsert)
+
+        described_class.new(stream, hash).process
+      end
     end
 
     context 'when workflow has custom queue' do


### PR DESCRIPTION
Solves for this [issue](https://github.com/zooniverse/caesar/issues/1613). 
Prevent halted workflows from processing classifications upon resume