### PR TITLE
limit graphql to non breaking version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,10 @@ gem 'httparty'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 if next?
   gem "rails", '6.0.6.1'
+  gem 'graphql', "1.12"
 else
   gem 'rails', '~> 5.2'
+  gem 'graphql'
 end
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 1.3'
@@ -55,7 +57,6 @@ gem 'rest-client', '> 2.0'
 gem 'jsonpath'
 gem 'simple_form'
 gem 'pundit', "~> 2.2.0"
-gem 'graphql'
 gem 'graphiql-rails'
 gem 'stoplight'
 gem 'ranked-model'

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -165,7 +165,7 @@ GEM
       activesupport (>= 5.0)
     graphiql-rails (1.10.4)
       railties
-    graphql (1.9.9)
+    graphql (1.12.0)
     hashdiff (1.0.1)
     hashie (5.0.0)
     http-accept (1.7.0)
@@ -467,7 +467,7 @@ DEPENDENCIES
   flipper-active_record
   flipper-ui
   graphiql-rails
-  graphql
+  graphql (= 1.12)
   httparty
   jquery-rails
   jsonpath


### PR DESCRIPTION
Pin graphql to 1.12 (pending proper graphql upgrades: https://github.com/zooniverse/caesar/pull/1623). Fixes the failed run [here](https://github.com/zooniverse/caesar/actions/runs/14598873571/job/40951693406?pr=1624)
Require ostruct in application.rb for graphql 1.12