### PR TITLE
Fix panoptes-client paginate call to use positional arguments

### DIFF
--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -42,7 +42,7 @@ class Credential < ApplicationRecord
   end
 
   def fetch_accessible_projects
-    client.panoptes.paginate("/projects", current_user_roles: ['owner', 'collaborator'])
+    client.panoptes.paginate("/projects", {current_user_roles: ['owner', 'collaborator']})
   end
 
   def accessible_project?(id)

--- a/app/workers/backfill_workflow_worker.rb
+++ b/app/workers/backfill_workflow_worker.rb
@@ -5,7 +5,7 @@ class BackfillWorkflowWorker
   def perform(workflow_id, duration = 24.hours)
     workflow = Workflow.find(workflow_id)
 
-    panoptes_api.paginate("/subjects", workflow_id: workflow.id) do |_, page|
+    panoptes_api.paginate("/subjects", {workflow_id: workflow.id}) do |_, page|
       page["subjects"].each do |attrs|
         subject = Subject.update_cache(attrs)
         delay = rand(duration.to_i).seconds


### PR DESCRIPTION
Solves for this error:  wrong number of arguments (given 1, expected 2) (ArgumentError) 
[See here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0)