### PR TITLE
resolve rails secret error in Kinesis controller

### DIFF
--- a/app/controllers/kinesis_controller.rb
+++ b/app/controllers/kinesis_controller.rb
@@ -22,8 +22,8 @@ class KinesisController < ApplicationController
   end
 
   def authenticate(given_username, given_password)
-    desired_username = Rails.application.secrets.kinesis[:username]
-    desired_password = Rails.application.secrets.kinesis[:password]
+    desired_username = Rails.application.credentials.dig(:kinesis, :username)
+    desired_password = Rails.application.credentials.dig(:kinesis, :password)
 
     if desired_username.present? || desired_password.present?
       given_username == desired_username && given_password == desired_password

--- a/spec/requests/kinesis_spec.rb
+++ b/spec/requests/kinesis_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 RSpec.describe "Kinesis stream", sidekiq: :inline do
   before do
+    allow(Rails.application.credentials).to receive(:dig).with(:kinesis, :username).and_return('testuser')
+    allow(Rails.application.credentials).to receive(:dig).with(:kinesis, :password).and_return('testpass')
+
     panoptes = instance_double(
       Panoptes::Client,
       retire_subject: true,
@@ -13,8 +16,8 @@ RSpec.describe "Kinesis stream", sidekiq: :inline do
     allow(Effects).to receive(:panoptes).and_return(panoptes)
   end
 
-  def http_login(username = Rails.application.secrets.kinesis[:username],
-                 password = Rails.application.secrets.kinesis[:password])
+  def http_login(username = Rails.application.credentials.dig(:kinesis, :username),
+                 password = Rails.application.credentials.dig(:kinesis, :password))
     @env ||= {}
     @env["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
     @env


### PR DESCRIPTION
- Resolve depricated secrets causing this error
```
 Kinesis stream should require HTTP Basic authentication
     Failure/Error: expect(response.status).to eq(403)

       expected: 403
            got: 500

       (compared using ==)
     # ./spec/requests/kinesis_spec.rb:52:in `block (2 levels) in <main>'
     
```
 See [here](https://discuss.rubyonrails.org/t/got-deprecation-warning-secrets-is-deprecated-while-i-do-not-use-secrets-at-all/83955)
- Current specs of dual boot are failing and would be solved with own pr's