### PR TITLE
use strict parameter comparison and add depricated fixture_path change

### DIFF
--- a/app/controllers/subject_reductions_controller.rb
+++ b/app/controllers/subject_reductions_controller.rb
@@ -16,7 +16,7 @@ class SubjectReductionsController < ApplicationController
 
     Subject.maybe_create_subject(subject.id, reducible)
 
-    if reduction.data != reduction_params[:data]
+    if reduction.data != reduction_params[:data].to_h
       reduction.update! reduction_params
       CheckSubjectRulesWorker.perform_async(reducible.id, reducible_type, subject.id) if workflow.configured?
     end

--- a/app/controllers/user_reductions_controller.rb
+++ b/app/controllers/user_reductions_controller.rb
@@ -14,7 +14,7 @@ class UserReductionsController < ApplicationController
                                                 subgroup: subgroup)
     authorize reduction
 
-    if reduction.data != reduction_params[:data]
+    if reduction.data != reduction_params[:data].to_h
       reduction.update! reduction_params
       CheckUserRulesWorker.perform_async(reducible.id, reducible_type, user_id) if workflow.configured?
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,7 +28,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
- Solves the below error caused by removal of deprecated comparison between ActionController::Parameters and Hash change in rails 7.2. See [here](https://guides.rubyonrails.org/7_2_release_notes.html#action-pack-removals)
```
1) UserReductionsController as admin #update does not check rules if nothing changed
     Failure/Error: expect(CheckUserRulesWorker).not_to have_received(:perform_async)

       (CheckUserRulesWorker (class)).perform_async(no args)
           expected: 0 times with any arguments
           received: 1 time
     # ./spec/controllers/user_reductions_controller_spec.rb:120:in `block (4 levels) in <main>'

  2) SubjectReductionsController#update does not trigger rules if nothing changed
     Failure/Error: expect(CheckSubjectRulesWorker).not_to have_received(:perform_async)

       (CheckSubjectRulesWorker (class)).perform_async(no args)
           expected: 0 times with any arguments
           received: 1 time
     # ./spec/controllers/subject_reductions_controller_spec.rb:106:in `block (3 levels) in <main>'
```
- Fix for warning:  Rails 7.1 has deprecated the singular fixture_path in favour of an array 