### PR TITLE
use Pundit::Authorization and use env vars for kinesis vars

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include ActionController::HttpAuthentication::Basic
   include ActionController::HttpAuthentication::Basic::ControllerMethods
-  include Pundit
+  include Pundit::Authorization
 
   protect_from_forgery with: :reset_session
 

--- a/app/controllers/kinesis_controller.rb
+++ b/app/controllers/kinesis_controller.rb
@@ -22,8 +22,8 @@ class KinesisController < ApplicationController
   end
 
   def authenticate(given_username, given_password)
-    desired_username = Rails.application.credentials.dig(:kinesis, :username)
-    desired_password = Rails.application.credentials.dig(:kinesis, :password)
+    desired_username = ENV['KINESIS_STREAM_USERNAME']
+    desired_password = ENV['KINESIS_STREAM_PASSWORD']
 
     if desired_username.present? || desired_password.present?
       given_username == desired_username && given_password == desired_password

--- a/app/operations/application_operation.rb
+++ b/app/operations/application_operation.rb
@@ -1,5 +1,5 @@
 class ApplicationOperation
-  include Pundit
+  include Pundit::Authorization
 
   # Our GraphQL API uses Javascript style camelCase, this class exists to convert that into snake_case.
   # There's some discussion of adding this converter directly into graphql-ruby, so before the resolve

--- a/spec/requests/kinesis_spec.rb
+++ b/spec/requests/kinesis_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe "Kinesis stream", sidekiq: :inline do
   before do
-    allow(Rails.application.credentials).to receive(:dig).with(:kinesis, :username).and_return('testuser')
-    allow(Rails.application.credentials).to receive(:dig).with(:kinesis, :password).and_return('testpass')
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('KINESIS_STREAM_USERNAME').and_return('testuser')
+    allow(ENV).to receive(:[]).with('KINESIS_STREAM_PASSWORD').and_return('testpass')
 
     panoptes = instance_double(
       Panoptes::Client,
@@ -16,8 +17,8 @@ RSpec.describe "Kinesis stream", sidekiq: :inline do
     allow(Effects).to receive(:panoptes).and_return(panoptes)
   end
 
-  def http_login(username = Rails.application.credentials.dig(:kinesis, :username),
-                 password = Rails.application.credentials.dig(:kinesis, :password))
+  def http_login(username = ENV['KINESIS_STREAM_USERNAME'],
+                 password = ENV['KINESIS_STREAM_PASSWORD'])
     @env ||= {}
     @env["HTTP_AUTHORIZATION"] = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
     @env


### PR DESCRIPTION
- Fix kinesis errors, rely on env vars
```
403 Client Error: Forbidden for url: https://caesar-staging.zooniverse.org/kinesis: HTTPError
Traceback (most recent call last):
  File "/var/task/caesar_forwarder.py", line 19, in lambda_handler
    r.raise_for_status()
  File "/var/task/requests/models.py", line 862, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
HTTPError: 403 Client Error: Forbidden for url: https://caesar-staging.zooniverse.org/kinesis
```

- Fix deprication warning
`include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead`