### PR TITLE
use positonal arguments for enum

### DIFF
--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -33,7 +33,7 @@ class DataRequest < ApplicationRecord
     field :status, !Status
   end
 
-  enum status: {
+  enum :status, {
     empty: 0,
     pending: 1,
     processing: 2,
@@ -43,7 +43,7 @@ class DataRequest < ApplicationRecord
     canceled: 12
   }
 
-  enum requested_data: {
+  enum :requested_data, {
     extracts: 0,
     subject_reductions: 1,
     user_reductions: 2

--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -33,21 +33,9 @@ class DataRequest < ApplicationRecord
     field :status, !Status
   end
 
-  enum :status, {
-    empty: 0,
-    pending: 1,
-    processing: 2,
-    failed: 3,
-    complete: 4,
-    canceling: 11,
-    canceled: 12
-  }
+  enum :status, empty: 0, pending: 1, processing: 2, failed: 3, complete: 4, canceling: 11, canceled: 12
 
-  enum :requested_data, {
-    extracts: 0,
-    subject_reductions: 1,
-    user_reductions: 2
-  }
+  enum :requested_data, extracts: 0, subject_reductions: 1, user_reductions: 2
 
   validates :status, presence: true
   validates :requested_data, presence: true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,7 +14,7 @@ class Project < ApplicationRecord
   has_many :user_actions
   has_many :data_requests, as: :exportable
 
-  enum :status, { halted: 0, active: 1 }
+  enum :status, halted: 0, active: 1
 
   attr_accessor :rerun
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,7 +14,7 @@ class Project < ApplicationRecord
   has_many :user_actions
   has_many :data_requests, as: :exportable
 
-  enum status: { halted: 0, active: 1 }
+  enum :status, { halted: 0, active: 1 }
 
   attr_accessor :rerun
 

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -3,12 +3,12 @@ class Reducer < ApplicationRecord
   include BelongsToReducibleCached
   class UnknownTypeError < StandardError; end
 
-  enum topic: {
+  enum :topic, {
     reduce_by_subject: 0,
     reduce_by_user: 1
   }
 
-  enum reduction_mode: {
+  enum :reduction_mode, {
     default_reduction: 0,
     running_reduction: 1
   }

--- a/app/models/reducer.rb
+++ b/app/models/reducer.rb
@@ -3,15 +3,9 @@ class Reducer < ApplicationRecord
   include BelongsToReducibleCached
   class UnknownTypeError < StandardError; end
 
-  enum :topic, {
-    reduce_by_subject: 0,
-    reduce_by_user: 1
-  }
+  enum :topic, reduce_by_subject: 0, reduce_by_user: 1
 
-  enum :reduction_mode, {
-    default_reduction: 0,
-    running_reduction: 1
-  }
+  enum :reduction_mode, default_reduction: 0, running_reduction: 1
 
   def self.of_type(type)
     case type.to_s

--- a/app/models/subject_action.rb
+++ b/app/models/subject_action.rb
@@ -20,7 +20,7 @@ class SubjectAction < ApplicationRecord
     field :completedAt, Types::TimeType, property: :completed_at
   end
 
-  enum :status, [:pending, :completed, :failed]
+  enum :status, %i[pending completed failed]
 
   belongs_to :workflow, counter_cache: true
   belongs_to :subject

--- a/app/models/subject_action.rb
+++ b/app/models/subject_action.rb
@@ -20,7 +20,7 @@ class SubjectAction < ApplicationRecord
     field :completedAt, Types::TimeType, property: :completed_at
   end
 
-  enum status: [:pending, :completed, :failed]
+  enum :status, [:pending, :completed, :failed]
 
   belongs_to :workflow, counter_cache: true
   belongs_to :subject

--- a/app/models/subject_rule.rb
+++ b/app/models/subject_rule.rb
@@ -7,10 +7,7 @@ class SubjectRule < ApplicationRecord
 
   validate :valid_condition?
 
-  enum :topic, {
-    evaluate_by_subject: 0,
-    evaluate_by_user: 1
-  }
+  enum :topic, evaluate_by_subject: 0, evaluate_by_user: 1
 
   def condition
     Conditions::FromConfig.build(self[:condition]) unless self[:condition].blank?

--- a/app/models/subject_rule.rb
+++ b/app/models/subject_rule.rb
@@ -7,7 +7,7 @@ class SubjectRule < ApplicationRecord
 
   validate :valid_condition?
 
-  enum topic: {
+  enum :topic, {
     evaluate_by_subject: 0,
     evaluate_by_user: 1
   }

--- a/app/models/subject_rule_effect.rb
+++ b/app/models/subject_rule_effect.rb
@@ -1,7 +1,7 @@
 class SubjectRuleEffect < ApplicationRecord
   belongs_to :subject_rule
 
-  enum action: %i[retire_subject add_subject_to_set add_subject_to_collection external external_with_basic_auth]
+  enum :action, %i[retire_subject add_subject_to_set add_subject_to_collection external external_with_basic_auth]
 
   validates :action, presence: true, inclusion: {in: SubjectRuleEffect.actions.keys}
   validate :valid_effect?

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -20,7 +20,7 @@ class UserAction < ApplicationRecord
     field :completedAt, Types::TimeType, property: :completed_at
   end
 
-  enum status: [:pending, :completed, :failed]
+  enum :status, [:pending, :completed, :failed]
   belongs_to :workflow, counter_cache: true
 
   def perform

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -20,7 +20,7 @@ class UserAction < ApplicationRecord
     field :completedAt, Types::TimeType, property: :completed_at
   end
 
-  enum :status, [:pending, :completed, :failed]
+  enum :status, %i[pending completed failed]
   belongs_to :workflow, counter_cache: true
 
   def perform

--- a/app/models/user_rule_effect.rb
+++ b/app/models/user_rule_effect.rb
@@ -1,7 +1,7 @@
 class UserRuleEffect < ApplicationRecord
   belongs_to :user_rule
 
-  enum action: [:promote_user]
+  enum :action, [:promote_user]
 
   validates :action, presence: true, inclusion: {in: UserRuleEffect.actions.keys}
   validate :valid_effect?

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -103,8 +103,8 @@ class Workflow < ApplicationRecord
   has_many :user_actions
   has_many :data_requests, as: :exportable
 
-  enum rules_applied: %i[all_matching_rules first_matching_rule no_rules]
-  enum status: { halted: 0, active: 1, paused: 2 }
+  enum :rules_applied, %i[all_matching_rules first_matching_rule no_rules]
+  enum :status, { halted: 0, active: 1, paused: 2 }
 
   attr_accessor :rerun
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -104,7 +104,7 @@ class Workflow < ApplicationRecord
   has_many :data_requests, as: :exportable
 
   enum :rules_applied, %i[all_matching_rules first_matching_rule no_rules]
-  enum :status, { halted: 0, active: 1, paused: 2 }
+  enum :status, halted: 0, active: 1, paused: 2
 
   attr_accessor :rerun
 


### PR DESCRIPTION
Fixes the below error. See [here](https://github.com/rails/rails/pull/50987)
```
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:
```