### PR TITLE
Use updated GHCR image for staging nginx container

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -183,7 +183,7 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "cp -R /app/public/* /static-assets"]
         - name: caesar-staging-nginx
-          image: zooniverse/nginx
+          image: ghcr.io/zooniverse/nginx
           resources:
             requests:
               memory: "25Mi"


### PR DESCRIPTION
Points the sidecar nginx container to GHCR. The docker-nginx repo has been updated and the latest tag now is now nginx version 1.29, so this PR also updates the nginx version (from 1.20).

Only the staging deployment is affected. Panoptes has been already been migrated and both staging and prod are good.