### PR TITLE
Update name of nginx repo

### DIFF
--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -183,7 +183,7 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "cp -R /app/public/* /static-assets"]
         - name: caesar-staging-nginx
-          image: ghcr.io/zooniverse/nginx
+          image: ghcr.io/zooniverse/docker-nginx
           resources:
             requests:
               memory: "25Mi"


### PR DESCRIPTION
Ope.

The GHCR package is now located at `/docker-nginx` (the name of the repo) instead of `/nginx` as on Dockerhub.