### PR TITLE
Use GHCR for production nginx container

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -188,7 +188,7 @@ spec:
               exec:
                 command: ["/bin/bash", "-c", "cp -R /app/public/* /static-assets"]
         - name: caesar-production-nginx
-          image: zooniverse/nginx
+          image: ghcr.io/zooniverse/docker-nginx
           ports:
             - containerPort: 80
           resources:


### PR DESCRIPTION
Staging looks good, so this updates the production deploy to use the updated version 1.29 nginx image from GHCR.

Will check the site (static assets served as expected) as well as validate the nginx config and version in the container.