### PR TITLE
Move away from archived gem sass-rails to dartsass-sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'pg', '~> 1.3'
 # Use Puma as the app server
 gem 'puma', '~> 5.6'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 6.0'
+gem 'dartsass-sprockets'
 gem 'bootstrap-sass', '~> 3.4.1'
 gem 'jquery-rails'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,12 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.3.4)
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.5.1)
     deferred_associations (0.6.5)
       activerecord
@@ -169,6 +175,9 @@ GEM
     fiber-storage (1.0.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.34.0)
+      bigdecimal
+      rake (~> 13.3)
     graphiql-rails (1.10.4)
       railties
     graphql (2.5.14)
@@ -396,16 +405,13 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.5)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
+    sass-embedded (1.97.3)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
     securerandom (0.4.1)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
@@ -491,6 +497,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4.1)
   byebug
+  dartsass-sprockets
   deferred_associations
   factory_bot_rails
   ffi (< 1.17.0)
@@ -519,7 +526,6 @@ DEPENDENCIES
   rest-client (> 2.0)
   rspec-rails
   rubocop
-  sass-rails (~> 6.0)
   sentry-raven
   sidekiq
   sidekiq-congestion (~> 0.1.0)

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -121,6 +121,12 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.3.4)
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.5.1)
     deferred_associations (0.6.5)
       activerecord
@@ -168,6 +174,9 @@ GEM
     ffi (1.16.3)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.34.0)
+      bigdecimal
+      rake (~> 13.3)
     graphiql-rails (1.10.4)
       railties
     graphql (1.12.25)
@@ -392,16 +401,13 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.5)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
+    sass-embedded (1.97.3)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
     securerandom (0.4.1)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
@@ -487,6 +493,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap-sass (~> 3.4.1)
   byebug
+  dartsass-sprockets
   deferred_associations
   factory_bot_rails
   ffi (< 1.17.0)
@@ -515,7 +522,6 @@ DEPENDENCIES
   rest-client (> 2.0)
   rspec-rails
   rubocop
-  sass-rails (~> 6.0)
   sentry-raven
   sidekiq
   sidekiq-congestion (~> 0.1.0)


### PR DESCRIPTION
https://github.com/tablecheck/dartsass-sprockets Dartsass-sprockets can be used as a drop in replacement for legacy sass-rails

This PR should fix broken asset:precompile step that gets broken when trying to update sass-rails to v6 https://github.com/zooniverse/caesar/pull/1666. 

Bigger fix , especially if we move to Rails 8, is to move away from Sprockets and utilize Propshaft with Dartsass-rails. Unfortunately, Caesar uses bootstrap-sass gem which still relies on old sprockets based compilers (i.e. bootstrap-sass and dartsass-rails does not play nice with each other).  So we would need to move away from bootstrap-sass and (if we decide to keep utilizing bootstrap) then use bootstrap gem. 

The change from bootstrap-sass to bootstrap gem is not trivial and suuuuccckkkkss because we'd need to move from  Bootstrap 3 (used in bootstrap-sass) to Bootstrap 5 (used in bootstrap) and update all our sass variable names and other changes.  Saying this because I tried to do this and then broke the styling of caesar and decided it was not worth spending more time on right now. 

Supplementary reading on why this upcoming change while at some point will be necessary is also not fun: https://medium.com/@mj.thakkar97/from-segfaults-to-sass-salvation-my-journey-migrating-rails-6-to-8-with-dart-sass-propshaft-ffeedf82ecbb 