### PR TITLE
bump panoptes-client to ~> 1.3 and gitignore docker-compose.override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 # ingore rvm gemset files
 .ruby-gemset
 
+# Local docker-compose overrides (port mappings, volume mounts)
+docker-compose.override.yml
+

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'sidekiq', '~> 6'
 gem 'sidekiq-congestion', '~> 0.1.0'
 gem 'sidekiq-unique-jobs', '~> 7.1'
+gem 'panoptes-client', '~> 1.3'
 gem 'sidekiq-logstash'
-gem 'panoptes-client', '~> 1.2'
 gem 'lograge'
 gem 'logstash-event'
 gem "sentry-raven"


### PR DESCRIPTION
Bump `panoptes-client` from `~> 1.2` to `~> 1.3` to pick up the JWT v2 upgrade from zooniverse/panoptes-client.rb#49.

We're working toward adding OpenID Connect (OIDC) support to the Zooniverse platform via `doorkeeper-openid_connect` on Panoptes. That gem requires `jwt >= 2.5`, which conflicts with the old `jwt ~> 1.5.0` pin in `panoptes-client`. This version bump pulls in the updated gem so Caesar stays compatible with the upgraded dependency chain.

Also adds `docker-compose.override.yml` to `.gitignore` so developers can customize ports and volume mounts locally.

Depends on:
- zooniverse/panoptes-client.rb#49 merged and released as panoptes-client 1.3.0

Same change as zooniverse/Panoptes#4596.
